### PR TITLE
Add MongoDBNode

### DIFF
--- a/examples/mongodb.py
+++ b/examples/mongodb.py
@@ -1,0 +1,61 @@
+"""MongoDB node example."""
+
+import asyncio
+import time
+from dotenv import load_dotenv
+from langgraph.graph import END, START, StateGraph
+from aic_flow.graph.state import State
+from aic_flow.nodes.mongodb import MongoDBNode
+
+
+async def main():
+    """Main function to demonstrate persistent MongoDB session."""
+    load_dotenv()
+
+    # Create the MongoDB node (session will be created on first use)
+    mongodb_node = MongoDBNode(
+        name="mongodb_node",
+        database="AIC",
+        collection="rss_feeds",
+        operation="find",
+        query={"read": False},
+    )
+
+    # Build the graph
+    graph = StateGraph(State)
+    graph.add_node("mongodb_node", mongodb_node)
+    graph.add_edge(START, "mongodb_node")
+    graph.add_edge("mongodb_node", END)
+    compiled_graph = graph.compile()
+
+    # First execution - will create the session
+    print("First execution (creates session):")
+    start_time = time.time()
+    result = await compiled_graph.ainvoke({})
+    end_time = time.time()
+    print(f"Execution time: {end_time - start_time:.2f}s")
+    print(result)
+    print()
+
+    # Second execution - reuses the same session
+    print("Second execution (reuses session):")
+    start_time = time.time()
+    result = await compiled_graph.ainvoke({})
+    end_time = time.time()
+    print(f"Execution time: {end_time - start_time:.2f}s")
+    print(result)
+    print()
+
+    # Third execution - still reusing the session
+    print("Third execution (still reusing session):")
+    start_time = time.time()
+    result = await compiled_graph.ainvoke({})
+    end_time = time.time()
+    print(f"Execution time: {end_time - start_time:.2f}s")
+    print(result)
+
+    print("\nSession will automatically close when process exits.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
   "python-telegram-bot>=22.0",
   "langchain-mcp-adapters>=0.1.1",
   "feedparser>=6.0.11",
-  "fastmcp>=2.10.5"
+  "fastmcp>=2.10.5",
+  "mcp[cli]>=1.12.0",
+  "pymongo>=4.13.2"
 ]
 description = "Add your description here"
 name = "aic-flow"

--- a/src/aic_flow/nodes/mongodb.py
+++ b/src/aic_flow/nodes/mongodb.py
@@ -1,0 +1,163 @@
+"""MongoDB node."""
+
+import os
+from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
+from pymongo import MongoClient
+from pymongo.command_cursor import CommandCursor
+from pymongo.cursor import Cursor
+from pymongo.results import (
+    BulkWriteResult,
+    DeleteResult,
+    InsertManyResult,
+    InsertOneResult,
+    UpdateResult,
+)
+from aic_flow.graph.state import State
+from aic_flow.nodes.base import TaskNode
+from aic_flow.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="MongoDBNode",
+        description="MongoDB node",
+        category="mongodb",
+    )
+)
+class MongoDBNode(TaskNode):
+    """MongoDB node.
+
+    To use this node, you need to set the following environment variables:
+    - MDB_CONNECTION_STRING: Required.
+    """
+
+    database: str
+    """The database to use."""
+    collection: str
+    """The collection to use."""
+    operation: Literal[
+        "find",
+        "find_one",
+        "find_raw_batches",
+        "insert_one",
+        "insert_many",
+        "update_one",
+        "update_many",
+        "replace_one",
+        "delete_one",
+        "delete_many",
+        "aggregate",
+        "aggregate_raw_batches",
+        "count_documents",
+        "estimated_document_count",
+        "distinct",
+        "find_one_and_delete",
+        "find_one_and_replace",
+        "find_one_and_update",
+        "bulk_write",
+        "create_index",
+        "create_indexes",
+        "drop_index",
+        "drop_indexes",
+        "list_indexes",
+        "index_information",
+        "create_search_index",
+        "create_search_indexes",
+        "drop_search_index",
+        "update_search_index",
+        "list_search_indexes",
+        "drop",
+        "rename",
+        "options",
+        "watch",
+    ]
+    query: dict = {}
+    """The query to pass to the operation."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the MongoDB client."""
+        super().__init__(**kwargs)
+        self._client: MongoClient = MongoClient(os.getenv("MDB_CONNECTION_STRING"))
+        self._collection = self._client[self.database][self.collection]
+
+    def _convert_result_to_dict(self, result: Any) -> dict | list[dict]:
+        """Convert MongoDB operation result to dict or list[dict] format."""
+        converted_result: dict | list[dict]
+
+        match result:
+            case Cursor() | CommandCursor():
+                converted_result = [dict(doc) for doc in result]
+
+            case None | int() | float() | str() | bool():
+                converted_result = {"result": result}
+
+            case list():
+                converted_result = [
+                    {"value": item} if not isinstance(item, dict) else dict(item)
+                    for item in result
+                ]
+
+            case InsertOneResult():
+                converted_result = {
+                    "operation": "insert_one",
+                    "inserted_id": str(result.inserted_id),
+                    "acknowledged": result.acknowledged,
+                }
+
+            case InsertManyResult():
+                converted_result = {
+                    "operation": "insert_many",
+                    "inserted_ids": [str(id_) for id_ in result.inserted_ids],
+                    "acknowledged": result.acknowledged,
+                }
+
+            case UpdateResult():
+                converted_result = {
+                    "operation": "update",
+                    "matched_count": result.matched_count,
+                    "modified_count": result.modified_count,
+                    "upserted_id": str(result.upserted_id)
+                    if result.upserted_id
+                    else None,
+                    "acknowledged": result.acknowledged,
+                }
+
+            case DeleteResult():
+                converted_result = {
+                    "operation": "delete",
+                    "deleted_count": result.deleted_count,
+                    "acknowledged": result.acknowledged,
+                }
+
+            case BulkWriteResult():
+                converted_result = {
+                    "operation": "bulk_write",
+                    "inserted_count": result.inserted_count,
+                    "matched_count": result.matched_count,
+                    "modified_count": result.modified_count,
+                    "deleted_count": result.deleted_count,
+                    "upserted_count": result.upserted_count,
+                    "upserted_ids": {
+                        str(k): str(v) for k, v in (result.upserted_ids or {}).items()
+                    },
+                    "acknowledged": result.acknowledged,
+                }
+
+            case _ if hasattr(result, "__dict__"):
+                converted_result = dict(result.__dict__)
+
+            case _:
+                converted_result = {"result": str(result)}
+
+        return converted_result
+
+    async def run(self, state: State, config: RunnableConfig) -> dict:
+        """Run the MongoDB node with persistent session."""
+        operation = getattr(self._collection, self.operation)
+        result = operation(self.query)
+        return {"data": self._convert_result_to_dict(result)}
+
+    def __del__(self) -> None:
+        """Automatic cleanup when object is garbage collected."""
+        self._client.close()

--- a/tests/nodes/test_mongodb.py
+++ b/tests/nodes/test_mongodb.py
@@ -1,0 +1,441 @@
+"""Test MongoDB node result conversion."""
+
+import asyncio
+from unittest.mock import MagicMock, Mock, patch
+from pymongo.results import (
+    BulkWriteResult,
+    DeleteResult,
+    InsertManyResult,
+    InsertOneResult,
+    UpdateResult,
+)
+from aic_flow.graph.state import State
+from aic_flow.nodes.mongodb import MongoDBNode
+
+
+class TestMongoDBResultConversion:
+    """Test MongoDB result conversion to dict/list[dict] format."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Mock MongoDB components to avoid requiring real connection
+        self.mock_collection = MagicMock()
+        self.mock_database = MagicMock()
+        self.mock_database.__getitem__.return_value = self.mock_collection
+        self.mock_client = MagicMock()
+        self.mock_client.__getitem__.return_value = self.mock_database
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_cursor_to_list_dict(self, mock_mongo_client):
+        """Test conversion of cursor results to list[dict]."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        # Create a MongoDB node
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find",
+            query={},
+        )
+
+        # Mock cursor result using the specific type check
+        from pymongo.cursor import Cursor
+
+        mock_cursor = Mock(spec=Cursor)
+        mock_cursor.__iter__ = Mock(
+            return_value=iter(
+                [{"_id": "1", "name": "doc1"}, {"_id": "2", "name": "doc2"}]
+            )
+        )
+
+        result = node._convert_result_to_dict(mock_cursor)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == {"_id": "1", "name": "doc1"}
+        assert result[1] == {"_id": "2", "name": "doc2"}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_command_cursor_to_list_dict(self, mock_mongo_client):
+        """Test conversion of command cursor results to list[dict]."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        # Create a MongoDB node
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="aggregate",
+            query={},
+        )
+
+        # Mock command cursor result
+        from pymongo.command_cursor import CommandCursor
+
+        mock_cursor = Mock(spec=CommandCursor)
+        mock_cursor.__iter__ = Mock(
+            return_value=iter([{"_id": "1", "count": 5}, {"_id": "2", "count": 3}])
+        )
+
+        result = node._convert_result_to_dict(mock_cursor)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == {"_id": "1", "count": 5}
+        assert result[1] == {"_id": "2", "count": 3}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_insert_result_to_dict(self, mock_mongo_client):
+        """Test conversion of insert result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="insert_one",
+            query={},
+        )
+
+        # Mock insert result
+        mock_result = Mock(spec=InsertOneResult)
+        mock_result.inserted_id = "507f1f77bcf86cd799439011"
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["operation"] == "insert_one"
+        assert result["inserted_id"] == "507f1f77bcf86cd799439011"
+        assert result["acknowledged"] is True
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_insert_many_result_to_dict(self, mock_mongo_client):
+        """Test conversion of insert many result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="insert_many",
+            query={},
+        )
+
+        # Mock insert many result
+        mock_result = Mock(spec=InsertManyResult)
+        mock_result.inserted_ids = [
+            "507f1f77bcf86cd799439011",
+            "507f1f77bcf86cd799439012",
+        ]
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["operation"] == "insert_many"
+        assert result["inserted_ids"] == [
+            "507f1f77bcf86cd799439011",
+            "507f1f77bcf86cd799439012",
+        ]
+        assert result["acknowledged"] is True
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_update_result_to_dict(self, mock_mongo_client):
+        """Test conversion of update result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="update_one",
+            query={},
+        )
+
+        # Mock update result
+        mock_result = Mock(spec=UpdateResult)
+        mock_result.matched_count = 1
+        mock_result.modified_count = 1
+        mock_result.upserted_id = None
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["operation"] == "update"
+        assert result["matched_count"] == 1
+        assert result["modified_count"] == 1
+        assert result["upserted_id"] is None
+        assert result["acknowledged"] is True
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_delete_result_to_dict(self, mock_mongo_client):
+        """Test conversion of delete result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="delete_one",
+            query={},
+        )
+
+        # Mock delete result
+        mock_result = Mock(spec=DeleteResult)
+        mock_result.deleted_count = 1
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["operation"] == "delete"
+        assert result["deleted_count"] == 1
+        assert result["acknowledged"] is True
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_bulk_write_result_to_dict(self, mock_mongo_client):
+        """Test conversion of bulk write result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="bulk_write",
+            query={},
+        )
+
+        # Mock bulk write result
+        mock_result = Mock(spec=BulkWriteResult)
+        mock_result.inserted_count = 2
+        mock_result.matched_count = 3
+        mock_result.modified_count = 3
+        mock_result.deleted_count = 1
+        mock_result.upserted_count = 1
+        mock_result.upserted_ids = {0: "507f1f77bcf86cd799439011"}
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["operation"] == "bulk_write"
+        assert result["inserted_count"] == 2
+        assert result["matched_count"] == 3
+        assert result["modified_count"] == 3
+        assert result["deleted_count"] == 1
+        assert result["upserted_count"] == 1
+        assert result["upserted_ids"] == {"0": "507f1f77bcf86cd799439011"}
+        assert result["acknowledged"] is True
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_bulk_write_result_no_upserted_ids(self, mock_mongo_client):
+        """Test conversion of bulk write result with no upserted_ids."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="bulk_write",
+            query={},
+        )
+
+        # Mock bulk write result with None upserted_ids
+        mock_result = Mock(spec=BulkWriteResult)
+        mock_result.inserted_count = 2
+        mock_result.matched_count = 3
+        mock_result.modified_count = 3
+        mock_result.deleted_count = 1
+        mock_result.upserted_count = 0
+        mock_result.upserted_ids = None
+        mock_result.acknowledged = True
+
+        result = node._convert_result_to_dict(mock_result)
+        assert isinstance(result, dict)
+        assert result["upserted_ids"] == {}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_primitive_to_dict(self, mock_mongo_client):
+        """Test conversion of primitive values to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="count_documents",
+            query={},
+        )
+
+        # Test integer
+        result = node._convert_result_to_dict(42)
+        assert result == {"result": 42}
+
+        # Test string
+        result = node._convert_result_to_dict("test_string")
+        assert result == {"result": "test_string"}
+
+        # Test boolean
+        result = node._convert_result_to_dict(True)
+        assert result == {"result": True}
+
+        # Test float
+        result = node._convert_result_to_dict(3.14)
+        assert result == {"result": 3.14}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_none_to_dict(self, mock_mongo_client):
+        """Test conversion of None result to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find_one",
+            query={},
+        )
+
+        result = node._convert_result_to_dict(None)
+        assert result == {"result": None}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_list_to_list_dict(self, mock_mongo_client):
+        """Test conversion of list results to list[dict]."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="distinct",
+            query={},
+        )
+
+        # Test list of strings
+        result = node._convert_result_to_dict(["value1", "value2", "value3"])
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0] == {"value": "value1"}
+        assert result[1] == {"value": "value2"}
+        assert result[2] == {"value": "value3"}
+
+        # Test list of dicts
+        result = node._convert_result_to_dict([{"key1": "val1"}, {"key2": "val2"}])
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == {"key1": "val1"}
+        assert result[1] == {"key2": "val2"}
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_object_with_dict_to_dict(self, mock_mongo_client):
+        """Test conversion of objects with __dict__ to dict."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find",
+            query={},
+        )
+
+        # Create an object with __dict__
+        class CustomObject:
+            def __init__(self):
+                self.attr1 = "value1"
+                self.attr2 = 42
+
+        custom_obj = CustomObject()
+        result = node._convert_result_to_dict(custom_obj)
+        assert isinstance(result, dict)
+        assert result["attr1"] == "value1"
+        assert result["attr2"] == 42
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_convert_unknown_object_to_dict(self, mock_mongo_client):
+        """Test conversion of unknown objects to dict using string representation."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find",
+            query={},
+        )
+
+        # Test with a complex object without __dict__
+        class ComplexObject:
+            __slots__ = ()
+
+            def __str__(self):
+                return "complex_object_representation"
+
+        complex_obj = ComplexObject()
+        result = node._convert_result_to_dict(complex_obj)
+        assert isinstance(result, dict)
+        assert result["result"] == "complex_object_representation"
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_run_method(self, mock_mongo_client):
+        """Test the run method of MongoDB node."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        # Mock the collection operation
+        self.mock_collection.find.return_value = [{"_id": "1", "name": "doc1"}]
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find",
+            query={"status": "active"},
+        )
+
+        # Create a mock state and config
+        state = State(messages=[], outputs={})
+        config = {}
+
+        # Run the node
+        result = asyncio.run(node.run(state, config))
+
+        # Verify the result
+        assert isinstance(result, dict)
+        assert "data" in result
+        assert isinstance(result["data"], list)
+        assert len(result["data"]) == 1
+        assert result["data"][0] == {"_id": "1", "name": "doc1"}
+
+        # Verify the operation was called with the correct query
+        self.mock_collection.find.assert_called_once_with({"status": "active"})
+
+    @patch("aic_flow.nodes.mongodb.MongoClient")
+    def test_del_method(self, mock_mongo_client):
+        """Test the __del__ method closes the client."""
+        # Mock MongoDB client
+        mock_mongo_client.return_value = self.mock_client
+
+        node = MongoDBNode(
+            name="test_node",
+            database="test_db",
+            collection="test_coll",
+            operation="find",
+            query={},
+        )
+
+        # Manually call __del__ to test cleanup
+        node.__del__()
+
+        # Verify the client close method was called
+        self.mock_client.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -23,8 +23,10 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "mcp", extra = ["cli"] },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pymongo" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "selenium" },
@@ -67,8 +69,10 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.0.10" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.7" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.4.2" },
+    { name = "pymongo", specifier = ">=4.13.2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
     { name = "selenium", specifier = ">=4.32.0" },
@@ -1405,7 +1409,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.11.0"
+version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1420,9 +1424,15 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/f5/9506eb5578d5bbe9819ee8ba3198d0ad0e2fbe3bab8b257e4131ceb7dfb6/mcp-1.11.0.tar.gz", hash = "sha256:49a213df56bb9472ff83b3132a4825f5c8f5b120a90246f08b0dac6bedac44c8", size = 406907 }
+sdist = { url = "https://files.pythonhosted.org/packages/45/94/caa0f4754e2437f7033068989f13fee784856f95870c786b0b5c2c0f511e/mcp-1.12.0.tar.gz", hash = "sha256:853f6b17a3f31ea6e2f278c2ec7d3b38457bc80c7c2c675260dd7f04a6fd0e70", size = 424678 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/9c/c9ca79f9c512e4113a5d07043013110bb3369fc7770040c61378c7fbcf70/mcp-1.11.0-py3-none-any.whl", hash = "sha256:58deac37f7483e4b338524b98bc949b7c2b7c33d978f5fafab5bde041c5e2595", size = 155880 },
+    { url = "https://files.pythonhosted.org/packages/ed/da/c7eaab6a58f1034de115b7902141ad8f81b4f3bbf7dc0cc267594947a4d7/mcp-1.12.0-py3-none-any.whl", hash = "sha256:19a498b2bf273283e463b4dd1ed83f791fbba5c25bfa16b8b34cfd5571673e7f", size = 158470 },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -2242,6 +2252,44 @@ wheels = [
 ]
 
 [[package]]
+name = "pymongo"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/5a/d664298bf54762f0c89b8aa2c276868070e06afb853b4a8837de5741e5f9/pymongo-4.13.2.tar.gz", hash = "sha256:0f64c6469c2362962e6ce97258ae1391abba1566a953a492562d2924b44815c2", size = 2167844 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e0/0e187750e23eed4227282fcf568fdb61f2b53bbcf8cbe3a71dde2a860d12/pymongo-4.13.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ec89516622dfc8b0fdff499612c0bd235aa45eeb176c9e311bcc0af44bf952b6", size = 912004 },
+    { url = "https://files.pythonhosted.org/packages/57/c2/9b79795382daaf41e5f7379bffdef1880d68160adea352b796d6948cb5be/pymongo-4.13.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f30eab4d4326df54fee54f31f93e532dc2918962f733ee8e115b33e6fe151d92", size = 911698 },
+    { url = "https://files.pythonhosted.org/packages/6f/e4/f04dc9ed5d1d9dbc539dc2d8758dd359c5373b0e06fcf25418b2c366737c/pymongo-4.13.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cce9428d12ba396ea245fc4c51f20228cead01119fcc959e1c80791ea45f820", size = 1690357 },
+    { url = "https://files.pythonhosted.org/packages/bb/de/41478a7d527d38f1b98b084f4a78bbb805439a6ebd8689fbbee0a3dfacba/pymongo-4.13.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac9241b727a69c39117c12ac1e52d817ea472260dadc66262c3fdca0bab0709b", size = 1754593 },
+    { url = "https://files.pythonhosted.org/packages/df/d9/8fa2eb110291e154f4312779b1a5b815090b8b05a59ecb4f4a32427db1df/pymongo-4.13.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3efc4c515b371a9fa1d198b6e03340985bfe1a55ae2d2b599a714934e7bc61ab", size = 1723637 },
+    { url = "https://files.pythonhosted.org/packages/27/7b/9863fa60a4a51ea09f5e3cd6ceb231af804e723671230f2daf3bd1b59c2b/pymongo-4.13.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f57a664aa74610eb7a52fa93f2cf794a1491f4f76098343485dd7da5b3bcff06", size = 1693613 },
+    { url = "https://files.pythonhosted.org/packages/9b/89/a42efa07820a59089836f409a63c96e7a74e33313e50dc39c554db99ac42/pymongo-4.13.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3dcb0b8cdd499636017a53f63ef64cf9b6bd3fd9355796c5a1d228e4be4a4c94", size = 1652745 },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/2c77d1acda61d281edd3e3f00d5017d3fac0c29042c769efd3b8018cb469/pymongo-4.13.2-cp312-cp312-win32.whl", hash = "sha256:bf43ae07804d7762b509f68e5ec73450bb8824e960b03b861143ce588b41f467", size = 883232 },
+    { url = "https://files.pythonhosted.org/packages/d2/4f/727f59156e3798850c3c2901f106804053cb0e057ed1bd9883f5fa5aa8fa/pymongo-4.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:812a473d584bcb02ab819d379cd5e752995026a2bb0d7713e78462b6650d3f3a", size = 903304 },
+    { url = "https://files.pythonhosted.org/packages/e0/95/b44b8e24b161afe7b244f6d43c09a7a1f93308cad04198de1c14c67b24ce/pymongo-4.13.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6044ca0eb74d97f7d3415264de86a50a401b7b0b136d30705f022f9163c3124", size = 966232 },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/d4d59799a52033acb187f7bd1f09bc75bebb9fd12cef4ba2964d235ad3f9/pymongo-4.13.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd326bcb92d28d28a3e7ef0121602bad78691b6d4d1f44b018a4616122f1ba8b", size = 965935 },
+    { url = "https://files.pythonhosted.org/packages/07/a8/67502899d89b317ea9952e4769bc193ca15efee561b24b38a86c59edde6f/pymongo-4.13.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfb0c21bdd58e58625c9cd8de13e859630c29c9537944ec0a14574fdf88c2ac4", size = 1954070 },
+    { url = "https://files.pythonhosted.org/packages/da/3b/0dac5d81d1af1b96b3200da7ccc52fc261a35efb7d2ac493252eb40a2b11/pymongo-4.13.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9c7d345d57f17b1361008aea78a37e8c139631a46aeb185dd2749850883c7ba", size = 2031424 },
+    { url = "https://files.pythonhosted.org/packages/31/ed/7a5af49a153224ca7e31e9915703e612ad9c45808cc39540e9dd1a2a7537/pymongo-4.13.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8860445a8da1b1545406fab189dc20319aff5ce28e65442b2b4a8f4228a88478", size = 1995339 },
+    { url = "https://files.pythonhosted.org/packages/f1/e9/9c72eceae8439c4f1bdebc4e6b290bf035e3f050a80eeb74abb5e12ef8e2/pymongo-4.13.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01c184b612f67d5a4c8f864ae7c40b6cc33c0e9bb05e39d08666f8831d120504", size = 1956066 },
+    { url = "https://files.pythonhosted.org/packages/ac/79/9b019c47923395d5fced03856996465fb9340854b0f5a2ddf16d47e2437c/pymongo-4.13.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ea8c62d5f3c6529407c12471385d9a05f9fb890ce68d64976340c85cd661b", size = 1905642 },
+    { url = "https://files.pythonhosted.org/packages/93/2f/ebf56c7fa9298fa2f9716e7b66cf62b29e7fc6e11774f3b87f55d214d466/pymongo-4.13.2-cp313-cp313-win32.whl", hash = "sha256:d13556e91c4a8cb07393b8c8be81e66a11ebc8335a40fa4af02f4d8d3b40c8a1", size = 930184 },
+    { url = "https://files.pythonhosted.org/packages/76/2f/49c35464cbd5d116d950ff5d24b4b20491aaae115d35d40b945c33b29250/pymongo-4.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:cfc69d7bc4d4d5872fd1e6de25e6a16e2372c7d5556b75c3b8e2204dce73e3fb", size = 955111 },
+    { url = "https://files.pythonhosted.org/packages/57/56/b17c8b5329b1842b7847cf0fa224ef0a272bf2e5126360f4da8065c855a1/pymongo-4.13.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a457d2ac34c05e9e8a6bb724115b093300bf270f0655fb897df8d8604b2e3700", size = 1022735 },
+    { url = "https://files.pythonhosted.org/packages/83/e6/66fec65a7919bf5f35be02e131b4dc4bf3152b5e8d78cd04b6d266a44514/pymongo-4.13.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:02f131a6e61559613b1171b53fbe21fed64e71b0cb4858c47fc9bc7c8e0e501c", size = 1022740 },
+    { url = "https://files.pythonhosted.org/packages/17/92/cda7383df0d5e71dc007f172c1ecae6313d64ea05d82bbba06df7f6b3e49/pymongo-4.13.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c942d1c6334e894271489080404b1a2e3b8bd5de399f2a0c14a77d966be5bc9", size = 2282430 },
+    { url = "https://files.pythonhosted.org/packages/84/da/285e05eb1d617b30dc7a7a98ebeb264353a8903e0e816a4eec6487c81f18/pymongo-4.13.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:850168d115680ab66a0931a6aa9dd98ed6aa5e9c3b9a6c12128049b9a5721bc5", size = 2369470 },
+    { url = "https://files.pythonhosted.org/packages/89/c0/c0d5eae236de9ca293497dc58fc1e4872382223c28ec223f76afc701392c/pymongo-4.13.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af7dfff90647ee77c53410f7fe8ca4fe343f8b768f40d2d0f71a5602f7b5a541", size = 2328857 },
+    { url = "https://files.pythonhosted.org/packages/2b/5a/d8639fba60def128ce9848b99c56c54c8a4d0cd60342054cd576f0bfdf26/pymongo-4.13.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8057f9bc9c94a8fd54ee4f5e5106e445a8f406aff2df74746f21c8791ee2403", size = 2280053 },
+    { url = "https://files.pythonhosted.org/packages/a1/69/d56f0897cc4932a336820c5d2470ffed50be04c624b07d1ad6ea75aaa975/pymongo-4.13.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51040e1ba78d6671f8c65b29e2864483451e789ce93b1536de9cc4456ede87fa", size = 2219378 },
+    { url = "https://files.pythonhosted.org/packages/04/1e/427e7f99801ee318b6331062d682d3816d7e1d6b6013077636bd75d49c87/pymongo-4.13.2-cp313-cp313t-win32.whl", hash = "sha256:7ab86b98a18c8689514a9f8d0ec7d9ad23a949369b31c9a06ce4a45dcbffcc5e", size = 979460 },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/00301a6df26f0f8d5c5955192892241e803742e7c3da8c2c222efabc0df6/pymongo-4.13.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c38168263ed94a250fc5cf9c6d33adea8ab11c9178994da1c3481c2a49d235f8", size = 1011057 },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2876,7 +2924,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.15.2"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2884,9 +2932,9 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
 ]
 
 [[package]]


### PR DESCRIPTION
The original plan was to implement the node based on MongoDB's official MCP server. However, there are a few problems found during this process:
1. MongoDB's MCP server doesn't support FastMCP
2. The MCP server's initial connection is very slow, taking ~34 seconds while Python client takes only 4s
3. Persisting the server client during the node's lifecycle is much more complex than the Python version, making it not a "shortcut implementation" anymore