### PR TITLE
Revert persistence changes and expand roadmap backlog

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,9 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ## Milestone Details
 ### Milestone 1 – Platform Foundation
 - [x] Finalize LangGraph-centric architecture decisions, persistence layer, and hosting model supporting both canvas and SDK. See [Milestone 1 Task 1](./milestone1_task1.md) for the detailed outcomes.
+  - [ ] Capture deployment recipes for local and hosted environments.
+  - [ ] Extend configuration to cover vault-managed credential settings.
+  - [ ] Wire Postgres persistence checks into CI once infrastructure is ready.
 - [ ] Scaffold repositories for FastAPI backend, Python SDK package, and React canvas app, including CI, linting, and coverage automation.
 - [ ] Define workflow data models (graphs, versions, runs, credential metadata) with encryption hooks and audit logging.
 - [ ] Establish developer tooling: local dev containers, `uv` scripts, seed environment variables, and sample flows covering both user paths.


### PR DESCRIPTION
## Summary
- revert the workflow persistence refactor to keep the existing SQLite setup for now
- add Milestone 1 subtasks capturing deployment recipes, vault configuration, and Postgres CI follow-ups

## Testing
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9296b30888327a0e2334a59f18806