### PR TITLE
Milestone 1 Task 1: configure workflow persistence

### DIFF
--- a/docs/milestone1_task1.md
+++ b/docs/milestone1_task1.md
@@ -1,0 +1,57 @@
+# Milestone 1 – Task 1: Architecture & Persistence Decisions
+
+## Objective
+
+Finalize the LangGraph-centric architecture, persistence layer, and hosting model
+that will power both the code-first SDK and the future canvas experience.
+
+## Summary of Decisions
+
+### LangGraph-Centric Runtime
+
+- **Single orchestration core** – All workflow execution flows through LangGraph to
+  guarantee parity between SDK-authored and canvas-authored graphs.
+- **State envelope** – We standardize on the existing `State` dataclass that extends
+  `MessagesState`, ensuring AI and deterministic nodes share the same shape and can
+  broadcast updates over WebSockets without bespoke adapters.
+- **Graph builder contract** – The `build_graph` helper now remains the canonical
+  entry-point for turning persisted JSON definitions into runnable LangGraph
+  instances. This establishes a stable interface for both authoring modes.
+
+### Persistence Layer
+
+- **Primary backend: SQLite** – For local development and lightweight
+  single-tenant deployments we use `langgraph-checkpoint-sqlite` backed by an
+  application-managed `aiosqlite` connection. This keeps onboarding friction low
+  while providing deterministic recovery for streaming runs.
+- **Production backend: Postgres** – We introduced a pluggable persistence helper
+  that can create either SQLite or Postgres checkpoint savers. Postgres is the
+  recommended production target thanks to connection pooling support via
+  `psycopg_pool` and better concurrency guarantees.
+- **Configuration driven** – Persistence is now controlled through environment
+  variables (`ORCHEO_CHECKPOINT_BACKEND`, `ORCHEO_SQLITE_PATH`,
+  `ORCHEO_POSTGRES_DSN`). This allows operators to toggle storage backends without
+  code changes and creates a clear path for managed hosting.
+
+### Hosting Model
+
+- **FastAPI application** – The backend remains a FastAPI service exposing REST and
+  WebSocket endpoints. Server host/port are configurable via
+  `ORCHEO_HOST`/`ORCHEO_PORT` to support containerized deployment or direct local
+  execution.
+- **Stateless API, stateful runtime** – Application instances stay stateless while
+  workflow execution state is stored in the configured checkpoint backend. This
+  separation makes it easy to scale API pods while delegating durability to the
+  persistence layer.
+- **SDK & Canvas parity** – Both modes invoke the same HTTP/WebSocket APIs which
+  rely on the unified persistence helper. This ensures future canvas iterations
+  inherit the exact runtime semantics used by SDK authors.
+
+## Follow-Ups
+
+- Document deployment recipes for Docker Compose and cloud hosting.
+- Extend configuration helpers to cover credential vault settings when that system
+  lands later in Milestone 1.
+- Wire Postgres-backed persistence into CI to validate connection pooling under
+  load tests once available infrastructure is provisioned.
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,9 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ## Milestone Details
 ### Milestone 1 – Platform Foundation
 - [x] Finalize LangGraph-centric architecture decisions, persistence layer, and hosting model supporting both canvas and SDK. See [Milestone 1 Task 1](./milestone1_task1.md) for the detailed outcomes.
+  - [ ] Capture deployment recipes for local and hosted environments.
+  - [ ] Extend configuration to cover vault-managed credential settings.
+  - [ ] Wire Postgres persistence checks into CI once infrastructure is ready.
 - [ ] Scaffold repositories for FastAPI backend, Python SDK package, and React canvas app, including CI, linting, and coverage automation.
 - [ ] Define workflow data models (graphs, versions, runs, credential metadata) with encryption hooks and audit logging.
 - [ ] Establish developer tooling: local dev containers, `uv` scripts, seed environment variables, and sample flows covering both user paths.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ## Milestone Details
 ### Milestone 1 – Platform Foundation
-- [ ] Finalize LangGraph-centric architecture decisions, persistence layer, and hosting model supporting both canvas and SDK.
+- [x] Finalize LangGraph-centric architecture decisions, persistence layer, and hosting model supporting both canvas and SDK. See [Milestone 1 Task 1](./milestone1_task1.md) for the detailed outcomes.
 - [ ] Scaffold repositories for FastAPI backend, Python SDK package, and React canvas app, including CI, linting, and coverage automation.
 - [ ] Define workflow data models (graphs, versions, runs, credential metadata) with encryption hooks and audit logging.
 - [ ] Establish developer tooling: local dev containers, `uv` scripts, seed environment variables, and sample flows covering both user paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "feedparser>=6.0.11",
   "fastmcp>=2.10.5",
   "mcp[cli]>=1.12.0",
-  "pymongo>=4.13.2"
+  "pymongo>=4.13.2",
+  "dynaconf>=3.2.4"
 ]
 description = "Add your description here"
 name = "orcheo"

--- a/src/orcheo/config.py
+++ b/src/orcheo/config.py
@@ -1,0 +1,77 @@
+"""Runtime configuration helpers for Orcheo."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Literal
+
+
+CheckpointBackend = Literal["sqlite", "postgres"]
+
+
+@dataclass(frozen=True, slots=True)
+class PersistenceSettings:
+    """Settings that describe how workflow checkpoints are stored."""
+
+    backend: CheckpointBackend = "sqlite"
+    sqlite_path: str = "checkpoints.sqlite"
+    postgres_dsn: str | None = None
+
+    @classmethod
+    def from_env(cls) -> "PersistenceSettings":
+        """Build persistence settings using environment variables."""
+
+        backend = os.getenv("ORCHEO_CHECKPOINT_BACKEND", "sqlite").lower()
+        if backend not in {"sqlite", "postgres"}:
+            msg = "ORCHEO_CHECKPOINT_BACKEND must be either 'sqlite' or 'postgres'."
+            raise ValueError(msg)
+
+        sqlite_path = os.getenv("ORCHEO_SQLITE_PATH", "checkpoints.sqlite")
+        postgres_dsn = os.getenv("ORCHEO_POSTGRES_DSN")
+
+        if backend == "postgres" and not postgres_dsn:
+            msg = "ORCHEO_POSTGRES_DSN must be set when using the postgres backend."
+            raise ValueError(msg)
+
+        return cls(
+            backend=backend,  # type: ignore[arg-type]
+            sqlite_path=sqlite_path,
+            postgres_dsn=postgres_dsn,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Settings:
+    """Aggregated application settings."""
+
+    persistence: PersistenceSettings
+    host: str = "0.0.0.0"
+    port: int = 8000
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Build settings by reading from the environment."""
+
+        persistence = PersistenceSettings.from_env()
+        host = os.getenv("ORCHEO_HOST", "0.0.0.0")
+        port = int(os.getenv("ORCHEO_PORT", "8000"))
+
+        return cls(persistence=persistence, host=host, port=port)
+
+
+@lru_cache(maxsize=1)
+def _load_settings() -> Settings:
+    """Load settings once and cache the result."""
+
+    return Settings.from_env()
+
+
+def get_settings(*, refresh: bool = False) -> Settings:
+    """Return the cached settings, reloading them if requested."""
+
+    if refresh:
+        _load_settings.cache_clear()
+    return _load_settings()
+

--- a/src/orcheo/config.py
+++ b/src/orcheo/config.py
@@ -1,10 +1,8 @@
 """Runtime configuration helpers for Orcheo."""
 
 from __future__ import annotations
-
 from functools import lru_cache
 from typing import Literal, cast
-
 from dynaconf import Dynaconf
 
 
@@ -21,7 +19,6 @@ _DEFAULTS: dict[str, object] = {
 
 def _build_loader() -> Dynaconf:
     """Create a Dynaconf loader wired to environment variables only."""
-
     return Dynaconf(
         envvar_prefix="ORCHEO",
         settings_files=[],  # No config files, env vars only
@@ -30,13 +27,8 @@ def _build_loader() -> Dynaconf:
     )
 
 
-# Initialize Dynaconf with environment variable prefix
-settings_loader = _build_loader()
-
-
 def _normalize_settings(source: Dynaconf) -> Dynaconf:
     """Validate and fill defaults on the raw Dynaconf settings."""
-
     backend_raw = source.get("CHECKPOINT_BACKEND", _DEFAULTS["CHECKPOINT_BACKEND"])
     backend = str(backend_raw or _DEFAULTS["CHECKPOINT_BACKEND"]).lower()
     if backend not in {"sqlite", "postgres"}:
@@ -79,15 +71,11 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
 @lru_cache(maxsize=1)
 def _load_settings() -> Dynaconf:
     """Load settings once and cache the normalized Dynaconf instance."""
-
-    return _normalize_settings(settings_loader)
+    return _normalize_settings(_build_loader())
 
 
 def get_settings(*, refresh: bool = False) -> Dynaconf:
     """Return the cached Dynaconf settings, reloading them if requested."""
-
     if refresh:
-        global settings_loader
-        settings_loader = _build_loader()
         _load_settings.cache_clear()
     return _load_settings()

--- a/src/orcheo/config.py
+++ b/src/orcheo/config.py
@@ -30,7 +30,10 @@ def _build_loader() -> Dynaconf:
 def _normalize_settings(source: Dynaconf) -> Dynaconf:
     """Validate and fill defaults on the raw Dynaconf settings."""
     backend_raw = source.get("CHECKPOINT_BACKEND", _DEFAULTS["CHECKPOINT_BACKEND"])
-    backend = str(backend_raw or _DEFAULTS["CHECKPOINT_BACKEND"]).lower()
+    if backend_raw is None:
+        backend = str(_DEFAULTS["CHECKPOINT_BACKEND"]).lower()
+    else:
+        backend = str(backend_raw).lower()
     if backend not in {"sqlite", "postgres"}:
         msg = "ORCHEO_CHECKPOINT_BACKEND must be either 'sqlite' or 'postgres'."
         raise ValueError(msg)

--- a/src/orcheo/main.py
+++ b/src/orcheo/main.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 
 load_dotenv()
 
-settings = get_settings()
-
 app = FastAPI()
 
 # Enable CORS
@@ -49,6 +47,7 @@ async def execute_workflow(
         logger.info(f"Initial inputs: {inputs}")
 
         # Create graph from config
+        settings = get_settings()
         async with create_checkpointer(settings) as checkpointer:
             graph = build_graph(graph_config)
             compiled_graph = graph.compile(checkpointer=checkpointer)

--- a/src/orcheo/main.py
+++ b/src/orcheo/main.py
@@ -4,12 +4,14 @@ import asyncio
 import logging
 import uuid
 from typing import Any
-import aiosqlite
+
 from dotenv import load_dotenv
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+from orcheo.config import get_settings
 from orcheo.graph.builder import build_graph
+from orcheo.persistence import create_checkpointer
 
 
 # Configure logging
@@ -19,6 +21,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 load_dotenv()
+
+settings = get_settings()
 
 app = FastAPI()
 
@@ -47,8 +51,7 @@ async def execute_workflow(
         logger.info(f"Initial inputs: {inputs}")
 
         # Create graph from config
-        async with aiosqlite.connect("checkpoints.sqlite") as conn:
-            checkpointer = AsyncSqliteSaver(conn)
+        async with create_checkpointer(settings) as checkpointer:
             graph = build_graph(graph_config)
             compiled_graph = graph.compile(checkpointer=checkpointer)
 

--- a/src/orcheo/main.py
+++ b/src/orcheo/main.py
@@ -4,11 +4,9 @@ import asyncio
 import logging
 import uuid
 from typing import Any
-
 from dotenv import load_dotenv
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
-
 from orcheo.config import get_settings
 from orcheo.graph.builder import build_graph
 from orcheo.persistence import create_checkpointer

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -1,0 +1,51 @@
+"""Persistence helpers that create LangGraph checkpoint savers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+import aiosqlite
+
+from orcheo.config import Settings
+
+try:  # pragma: no cover - import guarded for optional dependency
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from psycopg_pool import AsyncConnectionPool
+except Exception:  # pragma: no cover - fallback when dependency missing
+    AsyncPostgresSaver = None  # type: ignore[assignment]
+    AsyncConnectionPool = None  # type: ignore[assignment]
+
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+
+@asynccontextmanager
+async def create_checkpointer(settings: Settings) -> AsyncIterator[Any]:
+    """Create a LangGraph checkpointer based on the configured backend."""
+
+    persistence = settings.persistence
+
+    if persistence.backend == "sqlite":
+        conn = await aiosqlite.connect(persistence.sqlite_path)
+        try:
+            yield AsyncSqliteSaver(conn)
+        finally:
+            await conn.close()
+        return
+
+    if persistence.backend == "postgres":
+        if AsyncPostgresSaver is None or AsyncConnectionPool is None:  # pragma: no cover
+            msg = "Postgres backend requires psycopg_pool and langgraph postgres extras."
+            raise RuntimeError(msg)
+
+        pool = AsyncConnectionPool(persistence.postgres_dsn)
+        try:
+            async with pool.connection() as conn:  # type: ignore[assignment]
+                yield AsyncPostgresSaver(conn)
+        finally:
+            await pool.close()
+        return
+
+    msg = "Unsupported checkpoint backend configured."
+    raise ValueError(msg)
+

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -1,28 +1,31 @@
 """Persistence helpers that create LangGraph checkpoint savers."""
 
 from __future__ import annotations
-
+import importlib
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator
-
+from typing import Any, cast
 import aiosqlite
-
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from orcheo.config import Settings
 
-try:  # pragma: no cover - import guarded for optional dependency
-    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-    from psycopg_pool import AsyncConnectionPool
-except Exception:  # pragma: no cover - fallback when dependency missing
-    AsyncPostgresSaver = None  # type: ignore[assignment]
-    AsyncConnectionPool = None  # type: ignore[assignment]
 
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+AsyncPostgresSaver: Any | None
+AsyncConnectionPool: Any | None
+
+try:  # pragma: no cover - optional dependency
+    AsyncPostgresSaver = importlib.import_module(
+        "langgraph.checkpoint.postgres.aio"
+    ).AsyncPostgresSaver
+    AsyncConnectionPool = importlib.import_module("psycopg_pool").AsyncConnectionPool
+except Exception:  # pragma: no cover - fallback when dependency missing
+    AsyncPostgresSaver = None
+    AsyncConnectionPool = None
 
 
 @asynccontextmanager
 async def create_checkpointer(settings: Settings) -> AsyncIterator[Any]:
     """Create a LangGraph checkpointer based on the configured backend."""
-
     persistence = settings.persistence
 
     if persistence.backend == "sqlite":
@@ -34,18 +37,26 @@ async def create_checkpointer(settings: Settings) -> AsyncIterator[Any]:
         return
 
     if persistence.backend == "postgres":
-        if AsyncPostgresSaver is None or AsyncConnectionPool is None:  # pragma: no cover
-            msg = "Postgres backend requires psycopg_pool and langgraph postgres extras."
+        if (
+            AsyncPostgresSaver is None or AsyncConnectionPool is None
+        ):  # pragma: no cover
+            msg = (
+                "Postgres backend requires psycopg_pool and langgraph postgres extras."
+            )
             raise RuntimeError(msg)
 
-        pool = AsyncConnectionPool(persistence.postgres_dsn)
+        dsn = persistence.postgres_dsn
+        if dsn is None:  # pragma: no cover - defensive, validated earlier
+            msg = "Postgres backend requires ORCHEO_POSTGRES_DSN to be set."
+            raise RuntimeError(msg)
+
+        pool = AsyncConnectionPool(dsn)
         try:
             async with pool.connection() as conn:  # type: ignore[assignment]
-                yield AsyncPostgresSaver(conn)
+                yield AsyncPostgresSaver(cast(Any, conn))
         finally:
             await pool.close()
         return
 
     msg = "Unsupported checkpoint backend configured."
     raise ValueError(msg)
-

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -52,8 +52,9 @@ async def create_checkpointer(settings: Dynaconf) -> AsyncIterator[Any]:
             raise RuntimeError(msg)
 
         pool = AsyncConnectionPool(dsn)
+        await pool.open()
         try:
-            async with pool.connection() as conn:  # type: ignore[assignment]
+            async with pool.connection() as conn:  # type: ignore[attr-defined] - psycopg_pool connection type not recognized
                 yield AsyncPostgresSaver(cast(Any, conn))
         finally:
             await pool.close()

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -6,8 +6,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, cast
 import aiosqlite
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from dynaconf import Dynaconf
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from orcheo.config import CheckpointBackend
 
 

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -54,7 +54,7 @@ async def create_checkpointer(settings: Dynaconf) -> AsyncIterator[Any]:
         pool = AsyncConnectionPool(dsn)
         await pool.open()
         try:
-            async with pool.connection() as conn:  # type: ignore[attr-defined] - psycopg_pool connection type not recognized
+            async with pool.connection() as conn:  # type: ignore[attr-defined]
                 yield AsyncPostgresSaver(cast(Any, conn))
         finally:
             await pool.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 """Tests for configuration helpers."""
 
 import pytest
-
 from orcheo import config
 
 
@@ -50,4 +49,3 @@ def test_get_settings_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ORCHEO_SQLITE_PATH", "updated.db")
     refreshed = config.get_settings(refresh=True)
     assert refreshed.persistence.sqlite_path == "updated.db"
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for configuration helpers."""
 
 import pytest
+from dynaconf import Dynaconf
 from orcheo import config
 
 
@@ -37,6 +38,17 @@ def test_postgres_backend_requires_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(ValueError):
         config.get_settings(refresh=True)
+
+
+def test_normalize_backend_none() -> None:
+    """Explicit `None` backend values should fall back to defaults."""
+
+    source = Dynaconf(settings_files=[], load_dotenv=False, environments=False)
+    source.set("CHECKPOINT_BACKEND", None)
+
+    normalized = config._normalize_settings(source)
+
+    assert normalized.checkpoint_backend == "sqlite"
 
 
 def test_get_settings_refresh(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,10 @@ def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ORCHEO_HOST", raising=False)
     monkeypatch.delenv("ORCHEO_PORT", raising=False)
 
+    # Clear dynaconf cache to ensure clean state
+    config.settings_loader.reload()
+    config._load_settings.cache_clear()
+
     settings = config.Settings.from_env()
 
     assert settings.persistence.backend == "sqlite"
@@ -24,6 +28,7 @@ def test_settings_invalid_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     """Invalid persistence backend values raise a helpful error."""
 
     monkeypatch.setenv("ORCHEO_CHECKPOINT_BACKEND", "invalid")
+    config.settings_loader.reload()
 
     with pytest.raises(ValueError):
         config.Settings.from_env()
@@ -34,6 +39,7 @@ def test_postgres_backend_requires_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("ORCHEO_CHECKPOINT_BACKEND", "postgres")
     monkeypatch.delenv("ORCHEO_POSTGRES_DSN", raising=False)
+    config.settings_loader.reload()
 
     with pytest.raises(ValueError):
         config.Settings.from_env()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+"""Tests for configuration helpers."""
+
+import pytest
+
+from orcheo import config
+
+
+def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default settings fall back to SQLite and localhost server."""
+
+    monkeypatch.delenv("ORCHEO_CHECKPOINT_BACKEND", raising=False)
+    monkeypatch.delenv("ORCHEO_SQLITE_PATH", raising=False)
+    monkeypatch.delenv("ORCHEO_HOST", raising=False)
+    monkeypatch.delenv("ORCHEO_PORT", raising=False)
+
+    settings = config.Settings.from_env()
+
+    assert settings.persistence.backend == "sqlite"
+    assert settings.persistence.sqlite_path == "checkpoints.sqlite"
+    assert settings.host == "0.0.0.0"
+    assert settings.port == 8000
+
+
+def test_settings_invalid_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid persistence backend values raise a helpful error."""
+
+    monkeypatch.setenv("ORCHEO_CHECKPOINT_BACKEND", "invalid")
+
+    with pytest.raises(ValueError):
+        config.Settings.from_env()
+
+
+def test_postgres_backend_requires_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Using Postgres without a DSN should fail fast."""
+
+    monkeypatch.setenv("ORCHEO_CHECKPOINT_BACKEND", "postgres")
+    monkeypatch.delenv("ORCHEO_POSTGRES_DSN", raising=False)
+
+    with pytest.raises(ValueError):
+        config.Settings.from_env()
+
+
+def test_get_settings_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_settings refresh flag should reload cached values."""
+
+    monkeypatch.setenv("ORCHEO_SQLITE_PATH", "initial.db")
+    settings = config.get_settings(refresh=True)
+    assert settings.persistence.sqlite_path == "initial.db"
+
+    monkeypatch.setenv("ORCHEO_SQLITE_PATH", "updated.db")
+    refreshed = config.get_settings(refresh=True)
+    assert refreshed.persistence.sqlite_path == "updated.db"
+

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -66,7 +66,9 @@ async def test_create_checkpointer_postgres(monkeypatch: pytest.MonkeyPatch) -> 
 async def test_create_checkpointer_invalid_backend() -> None:
     """An unsupported backend should raise an error."""
 
-    bad_settings = Dynaconf(envvar_prefix="ORCHEO", environments=False, load_dotenv=False, settings_files=[])
+    bad_settings = Dynaconf(
+        envvar_prefix="ORCHEO", environments=False, load_dotenv=False, settings_files=[]
+    )
     bad_settings.set("CHECKPOINT_BACKEND", cast(str, "invalid"))
     bad_settings.set("SQLITE_PATH", "irrelevant")
     bad_settings.set("POSTGRES_DSN", None)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -41,6 +41,7 @@ async def test_create_checkpointer_postgres(monkeypatch: pytest.MonkeyPatch) -> 
     settings = config.get_settings(refresh=True)
 
     fake_pool = MagicMock()
+    fake_pool.open = AsyncMock()
     fake_conn_cm = AsyncMock()
     fake_conn_cm.__aenter__.return_value = "pg_connection"
     fake_conn_cm.__aexit__.return_value = None
@@ -59,6 +60,7 @@ async def test_create_checkpointer_postgres(monkeypatch: pytest.MonkeyPatch) -> 
 
     fake_pool.connection.assert_called_once()
     fake_conn_cm.__aenter__.assert_awaited_once()
+    fake_pool.open.assert_awaited_once()
     fake_pool.close.assert_awaited_once()
 
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,62 @@
+"""Tests for the persistence helper utilities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orcheo.config import Settings
+from orcheo.persistence import create_checkpointer
+
+
+@pytest.mark.asyncio
+async def test_create_checkpointer_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SQLite backend should yield a saver created from the configured path."""
+
+    fake_conn = MagicMock()
+    fake_conn.close = AsyncMock()
+
+    monkeypatch.setattr(
+        "orcheo.persistence.aiosqlite.connect", AsyncMock(return_value=fake_conn)
+    )
+
+    saver_mock = MagicMock(side_effect=lambda conn: ("sqlite_saver", conn))
+    monkeypatch.setattr("orcheo.persistence.AsyncSqliteSaver", saver_mock)
+
+    settings = Settings.from_env()
+
+    async with create_checkpointer(settings) as checkpointer:
+        assert checkpointer == ("sqlite_saver", fake_conn)
+
+    saver_mock.assert_called_once_with(fake_conn)
+    fake_conn.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_checkpointer_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Postgres backend should open a pooled connection and close it afterwards."""
+
+    monkeypatch.setenv("ORCHEO_CHECKPOINT_BACKEND", "postgres")
+    monkeypatch.setenv("ORCHEO_POSTGRES_DSN", "postgresql://example")
+
+    settings = Settings.from_env()
+
+    fake_pool = MagicMock()
+    fake_conn_cm = AsyncMock()
+    fake_conn_cm.__aenter__.return_value = "pg_connection"
+    fake_conn_cm.__aexit__.return_value = None
+    fake_pool.connection.return_value = fake_conn_cm
+    fake_pool.close = AsyncMock()
+
+    monkeypatch.setattr(
+        "orcheo.persistence.AsyncConnectionPool", MagicMock(return_value=fake_pool)
+    )
+
+    saver_mock = MagicMock(side_effect=lambda conn: ("pg_saver", conn))
+    monkeypatch.setattr("orcheo.persistence.AsyncPostgresSaver", saver_mock)
+
+    async with create_checkpointer(settings) as checkpointer:
+        assert checkpointer == ("pg_saver", "pg_connection")
+
+    fake_pool.connection.assert_called_once()
+    fake_conn_cm.__aenter__.assert_awaited_once()
+    fake_pool.close.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -8,101 +8,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "orcheo"
-version = "0.0.1"
-source = { editable = "." }
-dependencies = [
-    { name = "aiosqlite" },
-    { name = "fastapi" },
-    { name = "fastmcp" },
-    { name = "feedparser" },
-    { name = "langchain" },
-    { name = "langchain-community" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-openai" },
-    { name = "langgraph" },
-    { name = "langgraph-checkpoint-postgres" },
-    { name = "langgraph-checkpoint-sqlite" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pymongo" },
-    { name = "python-dotenv" },
-    { name = "python-telegram-bot" },
-    { name = "selenium" },
-    { name = "uvicorn" },
-    { name = "websockets" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "bump2version" },
-    { name = "diff-cover" },
-    { name = "isort" },
-    { name = "mypy" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "smokeshow" },
-    { name = "types-requests" },
-]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.21.0" },
-    { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "fastmcp", specifier = ">=2.10.5" },
-    { name = "feedparser", specifier = ">=6.0.11" },
-    { name = "langchain", specifier = ">=0.1.0" },
-    { name = "langchain-community", specifier = ">=0.0.10" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.1.1" },
-    { name = "langchain-openai", specifier = ">=0.0.5" },
-    { name = "langgraph", specifier = ">=0.0.10" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
-    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.7" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
-    { name = "openai", specifier = ">=1.0.0" },
-    { name = "pydantic", specifier = ">=2.4.2" },
-    { name = "pymongo", specifier = ">=4.13.2" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-telegram-bot", specifier = ">=22.0" },
-    { name = "selenium", specifier = ">=4.32.0" },
-    { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "websockets", specifier = ">=12.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "bump2version" },
-    { name = "diff-cover", specifier = ">=9.2.4" },
-    { name = "isort" },
-    { name = "mypy", specifier = ">=1.11.2" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio", specifier = ">=0.23.8" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "ruff", specifier = ">=0.11.3" },
-    { name = "smokeshow", specifier = ">=0.5.0" },
-    { name = "types-requests" },
-]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-jupyter" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28.1" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -617,6 +522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408 },
+]
+
+[[package]]
+name = "dynaconf"
+version = "3.2.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/eb/e9d1249ff56b11e63fd8c7d0fcc1f94704e21693c16862bf0ebfb07bd61a/dynaconf-3.2.11.tar.gz", hash = "sha256:4cfc6a730c533bf1a1d0bf266ae202133a22236bb3227d23eff4b8542d4034a5", size = 234694 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/64/580c74003a356c5662e7b1da43ecd7cbda6e8f970c87b30c5a654c8ccb53/dynaconf-3.2.11-py2.py3-none-any.whl", hash = "sha256:660de90879d4da236f79195692a7d197957224d7acf922bcc6899187dc7b4a27", size = 236536 },
 ]
 
 [[package]]
@@ -1850,6 +1764,103 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381 },
+]
+
+[[package]]
+name = "orcheo"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "dynaconf" },
+    { name = "fastapi" },
+    { name = "fastmcp" },
+    { name = "feedparser" },
+    { name = "langchain" },
+    { name = "langchain-community" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pymongo" },
+    { name = "python-dotenv" },
+    { name = "python-telegram-bot" },
+    { name = "selenium" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "bump2version" },
+    { name = "diff-cover" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "smokeshow" },
+    { name = "types-requests" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-jupyter" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "dynaconf", specifier = ">=3.2.4" },
+    { name = "fastapi", specifier = ">=0.104.0" },
+    { name = "fastmcp", specifier = ">=2.10.5" },
+    { name = "feedparser", specifier = ">=6.0.11" },
+    { name = "langchain", specifier = ">=0.1.0" },
+    { name = "langchain-community", specifier = ">=0.0.10" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1.1" },
+    { name = "langchain-openai", specifier = ">=0.0.5" },
+    { name = "langgraph", specifier = ">=0.0.10" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.7" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
+    { name = "openai", specifier = ">=1.0.0" },
+    { name = "pydantic", specifier = ">=2.4.2" },
+    { name = "pymongo", specifier = ">=4.13.2" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-telegram-bot", specifier = ">=22.0" },
+    { name = "selenium", specifier = ">=4.32.0" },
+    { name = "uvicorn", specifier = ">=0.24.0" },
+    { name = "websockets", specifier = ">=12.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bump2version" },
+    { name = "diff-cover", specifier = ">=9.2.4" },
+    { name = "isort" },
+    { name = "mypy", specifier = ">=1.11.2" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio", specifier = ">=0.23.8" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "ruff", specifier = ">=0.11.3" },
+    { name = "smokeshow", specifier = ">=0.5.0" },
+    { name = "types-requests" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-jupyter" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add configuration helpers to load checkpoint and hosting settings from the environment
- introduce a persistence factory that provisions SQLite or Postgres LangGraph checkpointers and update the FastAPI server to use it
- document the milestone 1 architecture decisions and mark task 1 complete in the roadmap

## Testing
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9296b30888327a0e2334a59f18806