### PR TITLE
Add developer tooling automation and quickstart examples

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+# Install uv for dependency management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && ln -s /root/.local/bin/uv /usr/local/bin/uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Orcheo",
+  "dockerFile": "Dockerfile",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "forwardPorts": [8000, 8080],
+  "postCreateCommand": "uv sync --all-groups",
+  "remoteEnv": {
+    "UV_NO_SYNC": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.formatting.provider": "none",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": "explicit",
+          "source.fixAll": "explicit"
+        }
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Tip: Prefix with `uv run` when invoking tools directly, e.g. `uv run pytest -k n
 ## Coding Style & Naming Conventions
 - Python 3.12, type hints required (mypy: `disallow_untyped_defs = true`).
 - Formatting/linting via Ruff; line length 88; Google-style docstrings.
-- Import rules: no relative imports (TID252); use absolute package paths (`from orcheo...`).
+- Import rules: no relative imports (TID252); always use absolute package paths (`from orcheo...`).
 - Naming: modules/files `snake_case.py`; classes `PascalCase`; functions/vars `snake_case`.
 - Keep functions focused; prefer small units with clear docstrings and types.
 

--- a/README.md
+++ b/README.md
@@ -24,23 +24,29 @@ SQLite for local development.
    uv sync --all-groups
    ```
 
-2. **Configure environment variables**
+2. **Seed environment variables**
 
    ```bash
-   cp .env.example .env
+   uv run orcheo-seed-env
    ```
+
+   Pass `-- --force` to overwrite an existing `.env` file.
 
 3. **Run the API server**
 
    ```bash
-   make dev-server
+   uv run orcheo-dev-server
    ```
 
 4. **Verify the setup**
 
    ```bash
-   uv run pytest
+   uv run orcheo-test
    ```
+
+Opening the repository inside VS Code automatically offers to start the included
+dev container with uv and Node.js preinstalled. The new quickstart flows in
+`examples/quickstart/` demonstrate the visual designer and SDK user journeys.
 
 See [`docs/deployment.md`](docs/deployment.md) for Docker Compose and managed
 PostgreSQL deployment recipes.

--- a/docs/developer_tooling.md
+++ b/docs/developer_tooling.md
@@ -1,0 +1,53 @@
+# Developer Tooling Quickstart
+
+This guide captures the baseline tooling shipped with Milestone 1 so that new
+contributors can bootstrap the repository in minutes.
+
+## Dev container
+
+The repository now includes a [VS Code Dev Container](../.devcontainer) profile
+that ships with Python 3.12, uv, and the Node.js runtime required for the React
+canvas. Open the folder in VS Code and select **Reopen in Container**. The
+container will automatically run `uv sync --all-groups` to install Python
+packages and configure recommended extensions.
+
+## uv scripts
+
+The `pyproject.toml` exposes a handful of scripts that wrap common tasks. After
+installing dependencies, run them via `uv run <script>`:
+
+- `uv run orcheo-seed-env` – copy `.env.example` to `.env` and create state
+  directories.
+- `uv run orcheo-dev-server` – launch the FastAPI development server with auto reload.
+- `uv run orcheo-lint` – execute Ruff (lint + format check) and mypy.
+- `uv run orcheo-test` – run the pytest suite with coverage reporting.
+- `uv run orcheo-format` – apply Ruff formatting and import sorting.
+- `uv run orcheo-canvas-lint` – lint the React canvas application.
+
+These commands mirror the existing `make` targets but remove the need for GNU
+Make on contributor machines.
+
+## Seed environment script
+
+`uv run orcheo-seed-env` invokes `orcheo.tooling.env.seed_env_file`, which copies the
+example environment file into place and creates local state directories used by
+SQLite and the credential vault. Pass `--force` to overwrite an existing `.env`:
+
+```bash
+uv run orcheo-seed-env -- --force
+```
+
+An optional `--root` argument allows scripting across workspaces when the
+repository lives outside the current working directory.
+
+## Sample flows
+
+Two quickstart flows now live under `examples/quickstart` to demonstrate both
+onboarding paths:
+
+- `canvas_welcome.json` – graph configuration suited for the visual designer.
+- `sdk_quickstart.py` – Python script that builds the same graph and executes it
+  locally using the SDK primitives.
+
+Use these examples to validate new tooling, test dependencies, and demo the core
+user journeys end-to-end.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
   - [x] Wire Postgres persistence checks into CI once infrastructure is ready.
 - [x] Scaffold repositories for FastAPI backend, Python SDK package, and React canvas app, including CI, linting, and coverage automation.
 - [x] Define workflow data models (graphs, versions, runs, credential metadata) with encryption hooks and audit logging.
-- [ ] Establish developer tooling: local dev containers, `uv` scripts, seed environment variables, and sample flows covering both user paths.
+- [x] Establish developer tooling: local dev containers, `uv` scripts, seed environment variables, and sample flows covering both user paths.
 - [ ] Publish the `orcheo` core package to PyPI and automate release versioning so downstream packages (backend, SDK) can depend on public artifacts.
 - [ ] Add smoke tests for the FastAPI deployment wrapper (import validation, app factory health) and expand CI coverage checks across workspace packages.
 

--- a/examples/quickstart/canvas_welcome.json
+++ b/examples/quickstart/canvas_welcome.json
@@ -1,0 +1,17 @@
+{
+  "name": "Welcome Bot",
+  "description": "Visual path example that greets a new teammate via PythonCode.",
+  "nodes": [
+    {"name": "START", "type": "START"},
+    {
+      "name": "greet_user",
+      "type": "PythonCode",
+      "code": "return {'message': f\"Welcome {state['name']} to Orcheo!\"}"
+    },
+    {"name": "END", "type": "END"}
+  ],
+  "edges": [["START", "greet_user"], ["greet_user", "END"]],
+  "inputs": {
+    "name": "Ada"
+  }
+}

--- a/examples/quickstart/sdk_quickstart.py
+++ b/examples/quickstart/sdk_quickstart.py
@@ -1,0 +1,36 @@
+"""Quickstart example for the SDK-driven workflow path."""
+
+from __future__ import annotations
+import asyncio
+from typing import Any
+from orcheo.graph.builder import build_graph
+
+
+def build_quickstart_graph() -> dict[str, Any]:
+    """Return the graph configuration shared with the canvas example."""
+
+    return {
+        "nodes": [
+            {"name": "START", "type": "START"},
+            {
+                "name": "greet_user",
+                "type": "PythonCode",
+                "code": "return {'message': f\"Welcome {state['name']} to Orcheo!\"}",
+            },
+            {"name": "END", "type": "END"},
+        ],
+        "edges": [["START", "greet_user"], ["greet_user", "END"]],
+    }
+
+
+async def run() -> None:
+    """Execute the quickstart graph locally."""
+
+    graph = build_graph(build_quickstart_graph())
+    app = graph.compile()
+    result = await app.ainvoke({"name": "Ada", "messages": []})
+    print(result["outputs"]["message"])  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,14 @@ requires-python = ">=3.12"
 url = "https://github.com/AI-Colleagues/orcheo"
 version = "0.0.1"
 
+[project.scripts]
+orcheo-dev-server = "orcheo.tooling.commands:dev_server"
+orcheo-lint = "orcheo.tooling.commands:lint"
+orcheo-format = "orcheo.tooling.commands:format_code"
+orcheo-test = "orcheo.tooling.commands:test"
+orcheo-canvas-lint = "orcheo.tooling.commands:canvas_lint"
+orcheo-seed-env = "orcheo.tooling.env:main"
+
 [tool.coverage.report]
 exclude_lines = [
   "pragma: no cover",
@@ -124,3 +132,4 @@ convention = "google"
 
 [tool.uv.workspace]
 members = ["apps/backend", "packages/sdk", "."]
+

--- a/src/orcheo/tooling/__init__.py
+++ b/src/orcheo/tooling/__init__.py
@@ -1,0 +1,14 @@
+"""Developer tooling utilities for Orcheo."""
+
+from orcheo.tooling.commands import canvas_lint, dev_server, format_code, lint, test
+from orcheo.tooling.env import seed_env_file
+
+
+__all__ = [
+    "seed_env_file",
+    "dev_server",
+    "lint",
+    "format_code",
+    "test",
+    "canvas_lint",
+]

--- a/src/orcheo/tooling/commands.py
+++ b/src/orcheo/tooling/commands.py
@@ -1,0 +1,58 @@
+"""Convenience commands exposed as uv-friendly entry points."""
+
+from __future__ import annotations
+import subprocess
+from collections.abc import Sequence
+
+
+def _run(command: Sequence[str]) -> None:
+    """Run a shell command and exit if it fails."""
+    completed = subprocess.run(command, check=False)
+    if completed.returncode != 0:  # pragma: no cover - propagated via SystemExit
+        raise SystemExit(completed.returncode)
+
+
+def dev_server() -> None:
+    """Start the FastAPI development server."""
+    _run(
+        [
+            "uvicorn",
+            "--app-dir",
+            "apps/backend/src",
+            "orcheo_backend.app:app",
+            "--reload",
+            "--port",
+            "8000",
+        ]
+    )
+
+
+def lint() -> None:
+    """Run linting and type checks."""
+    _run(["ruff", "check", "src/orcheo", "packages/sdk/src", "apps/backend/src"])
+    _run(
+        [
+            "mypy",
+            "src/orcheo",
+            "packages/sdk/src",
+            "apps/backend/src",
+        ]
+    )
+    _run(["ruff", "format", ".", "--check"])
+
+
+def format_code() -> None:
+    """Format Python code and organize imports."""
+    _run(["ruff", "format", "."])
+    _run(["ruff", "check", ".", "--select", "I001", "--fix"])
+    _run(["ruff", "check", ".", "--select", "F401", "--fix"])
+
+
+def test() -> None:
+    """Run the pytest suite with coverage reporting."""
+    _run(["pytest", "--cov", "--cov-report", "term-missing", "tests/"])
+
+
+def canvas_lint() -> None:
+    """Lint the React canvas application."""
+    _run(["npm", "--prefix", "apps/canvas", "run", "lint"])

--- a/src/orcheo/tooling/env.py
+++ b/src/orcheo/tooling/env.py
@@ -1,0 +1,117 @@
+"""Utilities for preparing local development environments."""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+from typing import Final
+
+
+ENV_FILENAME: Final[str] = ".env"
+ENV_EXAMPLE_FILENAME: Final[str] = ".env.example"
+
+
+class SeedEnvError(RuntimeError):
+    """Raised when the environment seed process cannot be completed."""
+
+
+def seed_env_file(
+    project_root: Path | None = None,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Create a local ``.env`` file from ``.env.example``.
+
+    Args:
+        project_root: Repository root containing the environment files. When ``None``
+            the current working directory is used.
+        overwrite: Whether to overwrite an existing ``.env`` file.
+
+    Returns:
+        Path to the seeded ``.env`` file.
+
+    Raises:
+        FileNotFoundError: If ``.env.example`` is missing.
+        SeedEnvError: If the copy fails unexpectedly.
+    """
+    root = project_root or Path.cwd()
+    example_path = root / ENV_EXAMPLE_FILENAME
+    if not example_path.exists():
+        raise FileNotFoundError(f"Missing {ENV_EXAMPLE_FILENAME} in {root}")
+
+    target_path = root / ENV_FILENAME
+    if target_path.exists() and not overwrite:
+        return target_path
+
+    try:
+        target_path.write_text(example_path.read_text())
+    except OSError as exc:  # pragma: no cover - defensive guard
+        raise SeedEnvError("Unable to copy environment template") from exc
+
+    _create_state_directories(example_path, root)
+    return target_path
+
+
+def _create_state_directories(example_path: Path, root: Path) -> None:
+    """Create directories referenced by seeded environment variables."""
+    for value in _extract_path_values(example_path):
+        resolved_path = (root / value).expanduser()
+        target_directory = (
+            resolved_path
+            if resolved_path.suffix == "" or resolved_path.is_dir()
+            else resolved_path.parent
+        )
+        if not target_directory.exists():
+            target_directory.mkdir(parents=True, exist_ok=True)
+
+
+def _extract_path_values(example_path: Path) -> set[Path]:
+    """Return path-like environment values from ``.env.example``."""
+    values: set[Path] = set()
+    for raw_line in example_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", maxsplit=1)
+        if "PATH" not in key and not key.endswith("_DIR"):
+            continue
+        value = raw_value.strip().strip('"')
+        if not value or value.startswith("$"):
+            continue
+        # Only create directories for relative paths inside the repo
+        path_value = Path(value)
+        if not path_value.is_absolute():
+            values.add(path_value)
+    return values
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Seed a local .env file and create state directories."
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing .env file if present.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Optional repository root. Defaults to the current working directory.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``seed-env`` script."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    seed_env_file(project_root=args.root, overwrite=args.force)
+    print("Seeded .env file successfully.")  # noqa: T201 - user-facing output
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_tooling_commands.py
+++ b/tests/test_tooling_commands.py
@@ -1,0 +1,58 @@
+from collections.abc import Sequence
+from subprocess import CompletedProcess
+
+import pytest
+
+from orcheo.tooling import commands
+
+
+@pytest.fixture()
+def successful_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _run(command: Sequence[str], check: bool = False) -> CompletedProcess[str]:
+        return CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(commands.subprocess, "run", _run)
+
+
+def test_dev_server_invokes_uvicorn(successful_run: None) -> None:
+    commands.dev_server()
+
+
+def test_lint_invokes_all_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[Sequence[str]] = []
+
+    def _run(command: Sequence[str], check: bool = False) -> CompletedProcess[str]:
+        calls.append(command)
+        return CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(commands.subprocess, "run", _run)
+
+    commands.lint()
+
+    assert calls == [
+        ["ruff", "check", "src/orcheo", "packages/sdk/src", "apps/backend/src"],
+        ["mypy", "src/orcheo", "packages/sdk/src", "apps/backend/src"],
+        ["ruff", "format", ".", "--check"],
+    ]
+
+
+def test_format_invokes_formatters(successful_run: None) -> None:
+    commands.format_code()
+
+
+def test_test_invokes_pytest(successful_run: None) -> None:
+    commands.test()
+
+
+def test_canvas_lint_invokes_npm(successful_run: None) -> None:
+    commands.canvas_lint()
+
+
+def test_run_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _run(command: Sequence[str], check: bool = False) -> CompletedProcess[str]:
+        return CompletedProcess(args=command, returncode=1)
+
+    monkeypatch.setattr(commands.subprocess, "run", _run)
+
+    with pytest.raises(SystemExit):
+        commands.dev_server()

--- a/tests/test_tooling_env.py
+++ b/tests/test_tooling_env.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+
+from orcheo.tooling.env import _extract_path_values, main, seed_env_file
+
+
+def write_env_example(tmp_path: Path, content: str) -> Path:
+    example_path = tmp_path / ".env.example"
+    example_path.write_text(content)
+    return example_path
+
+
+def test_seed_env_creates_file_and_directories(tmp_path: Path) -> None:
+    write_env_example(
+        tmp_path,
+        "ORCHEO_SQLITE_PATH=.orcheo/orcheo.sqlite3\nORCHEO_VAULT_LOCAL_PATH=.orcheo/vault.sqlite\n",
+    )
+
+    env_path = seed_env_file(project_root=tmp_path)
+
+    assert env_path.exists()
+    assert (tmp_path / ".orcheo").is_dir()
+
+
+def test_seed_env_creates_directory_path(tmp_path: Path) -> None:
+    write_env_example(
+        tmp_path,
+        "ORCHEO_VAULT_DIR=.orcheo/vault\n",
+    )
+
+    seed_env_file(project_root=tmp_path, overwrite=True)
+
+    assert (tmp_path / ".orcheo" / "vault").is_dir()
+
+
+def test_seed_env_skips_when_file_exists(tmp_path: Path) -> None:
+    write_env_example(tmp_path, "ORCHEO_SQLITE_PATH=.orcheo/orcheo.sqlite3\n")
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXISTING=1\n")
+
+    result = seed_env_file(project_root=tmp_path)
+
+    assert result.read_text() == "EXISTING=1\n"
+
+
+def test_seed_env_overwrites_when_forced(tmp_path: Path) -> None:
+    example = write_env_example(tmp_path, "ORCHEO_SQLITE_PATH=.orcheo/orcheo.sqlite3\n")
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXISTING=1\n")
+
+    result = seed_env_file(project_root=tmp_path, overwrite=True)
+
+    assert result.read_text() == example.read_text()
+
+
+def test_seed_env_raises_when_example_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        seed_env_file(project_root=tmp_path)
+
+
+def test_extract_path_values_filters_non_paths(tmp_path: Path) -> None:
+    example = write_env_example(
+        tmp_path,
+        """
+# comment line
+ORCHEO_HOST=0.0.0.0
+ORCHEO_SQLITE_PATH=.orcheo/orcheo.sqlite3
+ORCHEO_VAULT_DIR=.orcheo/vault
+ORCHEO_ABS_PATH=/var/lib/orcheo
+SECRET_PATH=$RUNTIME_SECRET
+MALFORMED_LINE
+""".strip(),
+    )
+
+    values = _extract_path_values(example)
+
+    assert values == {Path(".orcheo/orcheo.sqlite3"), Path(".orcheo/vault")}
+
+
+def test_main_seeds_environment(tmp_path: Path) -> None:
+    write_env_example(tmp_path, "ORCHEO_SQLITE_PATH=.orcheo/orcheo.sqlite3\n")
+
+    result = main(["--root", str(tmp_path), "--force"])
+
+    assert result == 0
+    assert (tmp_path / ".env").exists()


### PR DESCRIPTION
## Summary
- add a devcontainer profile and developer tooling guide that documents the new uv-based commands
- introduce a tooling module with uv entry points for linting, testing, formatting, and environment seeding, updating the README workflow
- publish quickstart canvas and SDK samples plus pytest coverage for the new tooling utilities while checking off the roadmap task
- ensure the tooling package exposes its uv commands through absolute imports instead of relative paths
- clarify the repository AGENTS guidance to explicitly require absolute import paths

## Testing
- `make lint` *(fails: pyenv missing Python 3.12.6/ruff)*
- `make test` *(fails: pyenv missing Python 3.12.6/pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68e175ea4e908327a4b1846093d7911e