### PR TITLE
Add FastAPI workflow API and repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![CI](https://github.com/ShaojieJiang/orcheo/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/ShaojieJiang/orcheo/actions/workflows/ci.yml?query=branch%3Amain)
 [![Coverage](https://coverage-badge.samuelcolvin.workers.dev/ShaojieJiang/orcheo.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/ShaojieJiang/orcheo)
-[![PyPI](https://img.shields.io/pypi/v/orcheo.svg)](https://pypi.python.org/pypi/orcheo)
+[![PyPI - Core](https://img.shields.io/pypi/v/orcheo.svg?label=core)](https://pypi.org/project/orcheo/)
+[![PyPI - Backend](https://img.shields.io/pypi/v/orcheo-backend.svg?label=backend)](https://pypi.org/project/orcheo-backend/)
+[![PyPI - SDK](https://img.shields.io/pypi/v/orcheo-sdk.svg?label=sdk)](https://pypi.org/project/orcheo-sdk/)
 
 Orcheo is a tool for creating and running workflows.
 

--- a/apps/backend/src/orcheo_backend/__init__.py
+++ b/apps/backend/src/orcheo_backend/__init__.py
@@ -1,13 +1,20 @@
 """Backend entrypoint package for the Orcheo FastAPI service."""
 
 from fastapi import FastAPI
-from orcheo_backend.app import app, create_app, execute_workflow, workflow_websocket
+from orcheo_backend.app import (
+    app,
+    create_app,
+    execute_workflow,
+    get_repository,
+    workflow_websocket,
+)
 
 
 __all__ = [
     "app",
     "create_app",
     "execute_workflow",
+    "get_repository",
     "workflow_websocket",
     "get_app",
 ]

--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -391,7 +391,7 @@ async def mark_run_failed(
         )
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
-    except ValueError as exc:
+    except ValueError as exc:  # pragma: no cover
         _raise_conflict(str(exc), exc)
 
 

--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -391,7 +391,7 @@ async def mark_run_failed(
         )
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
-    except ValueError as exc:  # pragma: no cover
+    except ValueError as exc:
         _raise_conflict(str(exc), exc)
 
 

--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -61,6 +61,14 @@ def _raise_not_found(detail: str, exc: Exception) -> NoReturn:
     ) from exc
 
 
+def _raise_conflict(detail: str, exc: Exception) -> NoReturn:
+    """Raise a standardized 409 HTTP error for conflicting run transitions."""
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=detail,
+    ) from exc
+
+
 async def execute_workflow(
     workflow_id: str,
     graph_config: dict[str, Any],
@@ -345,6 +353,8 @@ async def mark_run_started(
         return await repository.mark_run_started(run_id, actor=request.actor)
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
+    except ValueError as exc:
+        _raise_conflict(str(exc), exc)
 
 
 @_http_router.post("/runs/{run_id}/succeed", response_model=WorkflowRun)
@@ -362,6 +372,8 @@ async def mark_run_succeeded(
         )
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
+    except ValueError as exc:
+        _raise_conflict(str(exc), exc)
 
 
 @_http_router.post("/runs/{run_id}/fail", response_model=WorkflowRun)
@@ -379,6 +391,8 @@ async def mark_run_failed(
         )
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
+    except ValueError as exc:
+        _raise_conflict(str(exc), exc)
 
 
 @_http_router.post("/runs/{run_id}/cancel", response_model=WorkflowRun)
@@ -396,6 +410,8 @@ async def mark_run_cancelled(
         )
     except WorkflowRunNotFoundError as exc:
         _raise_not_found("Workflow run not found", exc)
+    except ValueError as exc:
+        _raise_conflict(str(exc), exc)
 
 
 def create_app(

--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -1,0 +1,362 @@
+"""In-memory repositories powering the FastAPI service."""
+
+from __future__ import annotations
+import asyncio
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from difflib import unified_diff
+from typing import Any
+from uuid import UUID
+from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
+
+
+class RepositoryError(RuntimeError):
+    """Base class for repository specific errors."""
+
+
+class WorkflowNotFoundError(RepositoryError):
+    """Raised when a workflow cannot be located."""
+
+
+class WorkflowVersionNotFoundError(RepositoryError):
+    """Raised when attempting to access an unknown workflow version."""
+
+
+class WorkflowRunNotFoundError(RepositoryError):
+    """Raised when attempting to access an unknown workflow run."""
+
+
+@dataclass(slots=True)
+class VersionDiff:
+    """Represents a unified diff between two workflow graphs."""
+
+    base_version: int
+    target_version: int
+    diff: list[str]
+
+
+class InMemoryWorkflowRepository:
+    """Simple async-safe in-memory repository for workflows and runs."""
+
+    def __init__(self) -> None:
+        """Initialize the storage containers used by the repository."""
+        self._lock = asyncio.Lock()
+        self._workflows: dict[UUID, Workflow] = {}
+        self._workflow_versions: dict[UUID, list[UUID]] = {}
+        self._versions: dict[UUID, WorkflowVersion] = {}
+        self._runs: dict[UUID, WorkflowRun] = {}
+        self._version_runs: dict[UUID, list[UUID]] = {}
+
+    async def list_workflows(self) -> list[Workflow]:
+        """Return all workflows stored within the repository."""
+        async with self._lock:
+            return [
+                workflow.model_copy(deep=True) for workflow in self._workflows.values()
+            ]
+
+    async def create_workflow(
+        self,
+        *,
+        name: str,
+        slug: str | None,
+        description: str | None,
+        tags: Iterable[str] | None,
+        actor: str,
+    ) -> Workflow:
+        """Persist a new workflow and return the created instance."""
+        async with self._lock:
+            workflow = Workflow(
+                name=name,
+                slug=slug or "",
+                description=description,
+                tags=list(tags or []),
+            )
+            workflow.record_event(actor=actor, action="workflow_created")
+            self._workflows[workflow.id] = workflow
+            self._workflow_versions.setdefault(workflow.id, [])
+            return workflow.model_copy(deep=True)
+
+    async def get_workflow(self, workflow_id: UUID) -> Workflow:
+        """Retrieve a workflow by its identifier."""
+        async with self._lock:
+            workflow = self._workflows.get(workflow_id)
+            if workflow is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+            return workflow.model_copy(deep=True)
+
+    async def update_workflow(
+        self,
+        workflow_id: UUID,
+        *,
+        name: str | None,
+        description: str | None,
+        tags: Iterable[str] | None,
+        is_archived: bool | None,
+        actor: str,
+    ) -> Workflow:
+        """Update workflow metadata and record an audit event."""
+        async with self._lock:
+            workflow = self._workflows.get(workflow_id)
+            if workflow is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+
+            metadata: dict[str, Any] = {}
+
+            if name is not None and name != workflow.name:
+                metadata["name"] = {"from": workflow.name, "to": name}
+                workflow.name = name
+
+            if description is not None and description != workflow.description:
+                metadata["description"] = {
+                    "from": workflow.description,
+                    "to": description,
+                }
+                workflow.description = description
+
+            if tags is not None:
+                normalized_tags = list(tags)
+                if normalized_tags != workflow.tags:
+                    metadata["tags"] = {"from": workflow.tags, "to": normalized_tags}
+                    workflow.tags = normalized_tags
+
+            if is_archived is not None and is_archived != workflow.is_archived:
+                metadata["is_archived"] = {
+                    "from": workflow.is_archived,
+                    "to": is_archived,
+                }
+                workflow.is_archived = is_archived
+
+            workflow.record_event(
+                actor=actor,
+                action="workflow_updated",
+                metadata=metadata,
+            )
+            return workflow.model_copy(deep=True)
+
+    async def archive_workflow(self, workflow_id: UUID, *, actor: str) -> Workflow:
+        """Archive a workflow by delegating to the update helper."""
+        return await self.update_workflow(
+            workflow_id,
+            name=None,
+            description=None,
+            tags=None,
+            is_archived=True,
+            actor=actor,
+        )
+
+    async def create_version(
+        self,
+        workflow_id: UUID,
+        *,
+        graph: dict[str, Any],
+        metadata: dict[str, Any],
+        notes: str | None,
+        created_by: str,
+    ) -> WorkflowVersion:
+        """Create and store a new workflow version."""
+        async with self._lock:
+            workflow = self._workflows.get(workflow_id)
+            if workflow is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+
+            version_ids = self._workflow_versions.setdefault(workflow_id, [])
+            next_version_number = len(version_ids) + 1
+            version = WorkflowVersion(
+                workflow_id=workflow_id,
+                version=next_version_number,
+                graph=json.loads(json.dumps(graph)),
+                metadata=dict(metadata),
+                created_by=created_by,
+                notes=notes,
+            )
+            version.record_event(actor=created_by, action="version_created")
+            self._versions[version.id] = version
+            version_ids.append(version.id)
+            self._version_runs.setdefault(version.id, [])
+            return version.model_copy(deep=True)
+
+    async def list_versions(self, workflow_id: UUID) -> list[WorkflowVersion]:
+        """Return the versions belonging to the given workflow."""
+        async with self._lock:
+            version_ids = self._workflow_versions.get(workflow_id)
+            if version_ids is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+            return [
+                self._versions[version_id].model_copy(deep=True)
+                for version_id in version_ids
+            ]
+
+    async def get_version_by_number(
+        self, workflow_id: UUID, version_number: int
+    ) -> WorkflowVersion:
+        """Fetch a workflow version by its human readable number."""
+        async with self._lock:
+            version_ids = self._workflow_versions.get(workflow_id)
+            if version_ids is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+            for version_id in version_ids:
+                version = self._versions[version_id]
+                if version.version == version_number:
+                    return version.model_copy(deep=True)
+            raise WorkflowVersionNotFoundError(f"v{version_number}")
+
+    async def get_version(self, version_id: UUID) -> WorkflowVersion:
+        """Retrieve a workflow version by its identifier."""
+        async with self._lock:
+            version = self._versions.get(version_id)
+            if version is None:
+                raise WorkflowVersionNotFoundError(str(version_id))
+            return version.model_copy(deep=True)
+
+    async def diff_versions(
+        self, workflow_id: UUID, base_version: int, target_version: int
+    ) -> VersionDiff:
+        """Compute a unified diff between two workflow versions."""
+        base = await self.get_version_by_number(workflow_id, base_version)
+        target = await self.get_version_by_number(workflow_id, target_version)
+
+        base_serialized = json.dumps(base.graph, indent=2, sort_keys=True).splitlines()
+        target_serialized = json.dumps(
+            target.graph,
+            indent=2,
+            sort_keys=True,
+        ).splitlines()
+
+        diff = list(
+            unified_diff(
+                base_serialized,
+                target_serialized,
+                fromfile=f"v{base_version}",
+                tofile=f"v{target_version}",
+                lineterm="",
+            )
+        )
+        return VersionDiff(
+            base_version=base_version,
+            target_version=target_version,
+            diff=diff,
+        )
+
+    async def create_run(
+        self,
+        workflow_id: UUID,
+        *,
+        workflow_version_id: UUID,
+        triggered_by: str,
+        input_payload: dict[str, Any],
+    ) -> WorkflowRun:
+        """Create a workflow run tied to a version."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+
+            version = self._versions.get(workflow_version_id)
+            if version is None:
+                raise WorkflowVersionNotFoundError(str(workflow_version_id))
+            if version.workflow_id != workflow_id:
+                raise WorkflowVersionNotFoundError(str(workflow_version_id))
+
+            run = WorkflowRun(
+                workflow_version_id=workflow_version_id,
+                triggered_by=triggered_by,
+                input_payload=dict(input_payload),
+            )
+            run.record_event(actor=triggered_by, action="run_created")
+            self._runs[run.id] = run
+            self._version_runs.setdefault(workflow_version_id, []).append(run.id)
+            return run.model_copy(deep=True)
+
+    async def list_runs_for_workflow(self, workflow_id: UUID) -> list[WorkflowRun]:
+        """Return all runs associated with the provided workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            version_ids = self._workflow_versions.get(workflow_id, [])
+            run_ids = [
+                run_id
+                for version_id in version_ids
+                for run_id in self._version_runs.get(version_id, [])
+            ]
+            return [self._runs[run_id].model_copy(deep=True) for run_id in run_ids]
+
+    async def get_run(self, run_id: UUID) -> WorkflowRun:
+        """Fetch a run by its identifier."""
+        async with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                raise WorkflowRunNotFoundError(str(run_id))
+            return run.model_copy(deep=True)
+
+    async def _update_run(
+        self, run_id: UUID, updater: Callable[[WorkflowRun], None]
+    ) -> WorkflowRun:
+        """Apply a mutation to a run under lock and return a copy."""
+        async with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                raise WorkflowRunNotFoundError(str(run_id))
+            updater(run)
+            return run.model_copy(deep=True)
+
+    async def mark_run_started(self, run_id: UUID, *, actor: str) -> WorkflowRun:
+        """Mark the specified run as started."""
+        return await self._update_run(run_id, lambda run: run.mark_started(actor=actor))
+
+    async def mark_run_succeeded(
+        self,
+        run_id: UUID,
+        *,
+        actor: str,
+        output: dict[str, Any] | None,
+    ) -> WorkflowRun:
+        """Mark the specified run as succeeded with optional output."""
+        return await self._update_run(
+            run_id,
+            lambda run: run.mark_succeeded(actor=actor, output=output),
+        )
+
+    async def mark_run_failed(
+        self,
+        run_id: UUID,
+        *,
+        actor: str,
+        error: str,
+    ) -> WorkflowRun:
+        """Transition the run to a failed state."""
+        return await self._update_run(
+            run_id,
+            lambda run: run.mark_failed(actor=actor, error=error),
+        )
+
+    async def mark_run_cancelled(
+        self,
+        run_id: UUID,
+        *,
+        actor: str,
+        reason: str | None,
+    ) -> WorkflowRun:
+        """Cancel a run, optionally including a reason."""
+        return await self._update_run(
+            run_id,
+            lambda run: run.mark_cancelled(actor=actor, reason=reason),
+        )
+
+    async def reset(self) -> None:
+        """Clear all stored workflows, versions, and runs."""
+        async with self._lock:
+            self._workflows.clear()
+            self._workflow_versions.clear()
+            self._versions.clear()
+            self._runs.clear()
+            self._version_runs.clear()
+
+
+__all__ = [
+    "InMemoryWorkflowRepository",
+    "RepositoryError",
+    "VersionDiff",
+    "WorkflowNotFoundError",
+    "WorkflowRunNotFoundError",
+    "WorkflowVersionNotFoundError",
+]

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -1,0 +1,75 @@
+"""Pydantic request schemas for the FastAPI service."""
+
+from __future__ import annotations
+from typing import Any
+from uuid import UUID
+from pydantic import BaseModel, Field
+
+
+class WorkflowCreateRequest(BaseModel):
+    """Payload for creating a new workflow."""
+
+    name: str
+    slug: str | None = None
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    actor: str = Field(default="system")
+
+
+class WorkflowUpdateRequest(BaseModel):
+    """Payload for updating an existing workflow."""
+
+    name: str | None = None
+    description: str | None = None
+    tags: list[str] | None = None
+    is_archived: bool | None = None
+    actor: str = Field(default="system")
+
+
+class WorkflowVersionCreateRequest(BaseModel):
+    """Payload for creating a workflow version."""
+
+    graph: dict[str, Any]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    notes: str | None = None
+    created_by: str
+
+
+class WorkflowRunCreateRequest(BaseModel):
+    """Payload for creating a new workflow execution run."""
+
+    workflow_version_id: UUID
+    triggered_by: str
+    input_payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunActionRequest(BaseModel):
+    """Base payload for run lifecycle transitions."""
+
+    actor: str
+
+
+class RunSucceedRequest(RunActionRequest):
+    """Payload for marking a run as succeeded."""
+
+    output: dict[str, Any] | None = None
+
+
+class RunFailRequest(RunActionRequest):
+    """Payload for marking a run as failed."""
+
+    error: str
+
+
+class RunCancelRequest(RunActionRequest):
+    """Payload for cancelling a run."""
+
+    reason: str | None = None
+
+
+class WorkflowVersionDiffResponse(BaseModel):
+    """Response payload for workflow version diffs."""
+
+    base_version: int
+    target_version: int
+    diff: list[str]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ### Milestone 2 – Backend Orchestration & Triggers
 - [x] Implement Python SDK with typed node authoring, local execution parity, and deployment hooks that sync with the server.
-- [ ] Build FastAPI services for workflow CRUD, execution lifecycle, version diffing, and WebSocket streaming telemetry.
+- [x] Build FastAPI services for workflow CRUD, execution lifecycle, version diffing, and WebSocket streaming telemetry.
 - [ ] Deliver trigger layer covering webhook validation (verbs, filtering, rate limits), cron scheduler (timezone aware, overlap guards), manual/batch runs, and retry policies.
 - [ ] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
 - [ ] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.

--- a/tests/backend/test_repository.py
+++ b/tests/backend/test_repository.py
@@ -1,0 +1,369 @@
+"""Unit tests for the in-memory workflow repository implementation."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from orcheo_backend.app.repository import (
+    InMemoryWorkflowRepository,
+    RepositoryError,
+    VersionDiff,
+    WorkflowNotFoundError,
+    WorkflowRunNotFoundError,
+    WorkflowVersionNotFoundError,
+)
+
+
+@pytest.fixture()
+def repository() -> InMemoryWorkflowRepository:
+    """Return a fresh repository instance for each test."""
+
+    return InMemoryWorkflowRepository()
+
+
+@pytest.mark.asyncio()
+async def test_create_and_list_workflows(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Workflows can be created and listed with deep copies returned."""
+
+    created = await repository.create_workflow(
+        name="Test Flow",
+        slug=None,
+        description="Example workflow",
+        tags=["alpha"],
+        actor="tester",
+    )
+
+    workflows = await repository.list_workflows()
+    assert len(workflows) == 1
+    assert workflows[0].id == created.id
+    assert workflows[0].slug == "test-flow"
+
+    # Returned instances must be detached copies.
+    workflows[0].name = "mutated"
+    fresh = await repository.get_workflow(created.id)
+    assert fresh.name == "Test Flow"
+
+
+@pytest.mark.asyncio()
+async def test_update_and_archive_workflow(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Updating a workflow touches each branch of metadata normalization."""
+
+    created = await repository.create_workflow(
+        name="Original",
+        slug="custom-slug",
+        description="Desc",
+        tags=["a"],
+        actor="author",
+    )
+
+    updated = await repository.update_workflow(
+        created.id,
+        name="Renamed",
+        description="New desc",
+        tags=["b"],
+        is_archived=None,
+        actor="editor",
+    )
+    assert updated.name == "Renamed"
+    assert updated.description == "New desc"
+    assert updated.tags == ["b"]
+    assert updated.is_archived is False
+
+    archived = await repository.archive_workflow(created.id, actor="editor")
+    assert archived.is_archived is True
+
+    unchanged = await repository.update_workflow(
+        created.id,
+        name=None,
+        description=None,
+        tags=["b"],
+        is_archived=True,
+        actor="editor",
+    )
+    assert unchanged.tags == ["b"]
+    assert unchanged.is_archived is True
+    # The most recent audit event should not include redundant metadata.
+    assert unchanged.audit_log[-1].metadata == {}
+
+
+@pytest.mark.asyncio()
+async def test_update_missing_workflow(repository: InMemoryWorkflowRepository) -> None:
+    """Updating a missing workflow raises an explicit error."""
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.update_workflow(
+            uuid4(),
+            name=None,
+            description=None,
+            tags=None,
+            is_archived=None,
+            actor="tester",
+        )
+
+
+@pytest.mark.asyncio()
+async def test_version_management(repository: InMemoryWorkflowRepository) -> None:
+    """Version CRUD supports numbering, listing, and retrieval."""
+
+    workflow = await repository.create_workflow(
+        name="Versioned",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="author",
+    )
+
+    first = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["a"], "edges": []},
+        metadata={"first": True},
+        notes=None,
+        created_by="author",
+    )
+    second = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["a", "b"], "edges": []},
+        metadata={"first": False},
+        notes="update",
+        created_by="author",
+    )
+
+    versions = await repository.list_versions(workflow.id)
+    assert [version.version for version in versions] == [1, 2]
+
+    looked_up = await repository.get_version_by_number(workflow.id, 2)
+    assert looked_up.id == second.id
+
+    fetched = await repository.get_version(second.id)
+    assert fetched.id == second.id
+
+    with pytest.raises(WorkflowVersionNotFoundError):
+        await repository.get_version_by_number(workflow.id, 3)
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.get_version_by_number(uuid4(), 1)
+
+    with pytest.raises(WorkflowVersionNotFoundError):
+        await repository.get_version(uuid4())
+
+    diff = await repository.diff_versions(workflow.id, 1, 2)
+    assert isinstance(diff, VersionDiff)
+    assert diff.base_version == 1
+    assert diff.target_version == 2
+    assert any('+    "b"' in line for line in diff.diff)
+
+
+@pytest.mark.asyncio()
+async def test_create_version_without_workflow(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Creating a version for an unknown workflow fails."""
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.create_version(
+            uuid4(),
+            graph={},
+            metadata={},
+            notes=None,
+            created_by="actor",
+        )
+
+
+@pytest.mark.asyncio()
+async def test_run_lifecycle(repository: InMemoryWorkflowRepository) -> None:
+    """Runs can transition through success, failure, and cancellation."""
+
+    workflow = await repository.create_workflow(
+        name="Runnable",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    version = await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    # Successful run path
+    run = await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="runner",
+        input_payload={"payload": True},
+    )
+    started = await repository.mark_run_started(run.id, actor="runner")
+    assert started.status == "running"
+    succeeded = await repository.mark_run_succeeded(
+        run.id, actor="runner", output={"result": "ok"}
+    )
+    assert succeeded.status == "succeeded"
+    assert succeeded.output_payload == {"result": "ok"}
+
+    # Failed run path
+    failed_run = await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="runner",
+        input_payload={},
+    )
+    failed = await repository.mark_run_failed(
+        failed_run.id, actor="runner", error="boom"
+    )
+    assert failed.status == "failed"
+    assert failed.error == "boom"
+
+    # Cancelled run path
+    cancelled_run = await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="runner",
+        input_payload={},
+    )
+    cancelled = await repository.mark_run_cancelled(
+        cancelled_run.id, actor="runner", reason="stop"
+    )
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "stop"
+
+    runs = await repository.list_runs_for_workflow(workflow.id)
+    assert {run.status for run in runs} == {"succeeded", "failed", "cancelled"}
+
+
+@pytest.mark.asyncio()
+async def test_run_error_paths(repository: InMemoryWorkflowRepository) -> None:
+    """All run error branches raise the correct exceptions."""
+
+    missing_workflow_id = uuid4()
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.create_run(
+            missing_workflow_id,
+            workflow_version_id=uuid4(),
+            triggered_by="actor",
+            input_payload={},
+        )
+
+    workflow = await repository.create_workflow(
+        name="Run Errors",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    version = await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    with pytest.raises(WorkflowVersionNotFoundError):
+        await repository.create_run(
+            workflow.id,
+            workflow_version_id=uuid4(),
+            triggered_by="actor",
+            input_payload={},
+        )
+
+    other_workflow = await repository.create_workflow(
+        name="Other",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    mismatched_version = await repository.create_version(
+        other_workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    with pytest.raises(WorkflowVersionNotFoundError):
+        await repository.create_run(
+            workflow.id,
+            workflow_version_id=mismatched_version.id,
+            triggered_by="actor",
+            input_payload={},
+        )
+
+    with pytest.raises(WorkflowRunNotFoundError):
+        await repository.get_run(uuid4())
+
+    with pytest.raises(WorkflowRunNotFoundError):
+        await repository.mark_run_started(uuid4(), actor="actor")
+
+    with pytest.raises(WorkflowRunNotFoundError):
+        await repository.mark_run_succeeded(uuid4(), actor="actor", output=None)
+
+    with pytest.raises(WorkflowRunNotFoundError):
+        await repository.mark_run_failed(uuid4(), actor="actor", error="err")
+
+    with pytest.raises(WorkflowRunNotFoundError):
+        await repository.mark_run_cancelled(uuid4(), actor="actor", reason=None)
+
+
+@pytest.mark.asyncio()
+async def test_list_entities_error_paths(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Listing versions or runs for unknown workflows surfaces not found errors."""
+
+    missing_id = uuid4()
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.list_versions(missing_id)
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.list_runs_for_workflow(missing_id)
+
+
+@pytest.mark.asyncio()
+async def test_reset_clears_internal_state(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Reset removes all previously stored workflows, versions, and runs."""
+
+    workflow = await repository.create_workflow(
+        name="Reset",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="actor",
+    )
+    version = await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="actor",
+    )
+    await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="actor",
+        input_payload={},
+    )
+
+    await repository.reset()
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.get_workflow(workflow.id)
+
+
+def test_repository_error_hierarchy() -> None:
+    """Ensure repository-specific errors inherit from the common base."""
+
+    assert issubclass(WorkflowNotFoundError, RepositoryError)
+    assert issubclass(WorkflowVersionNotFoundError, RepositoryError)
+    assert issubclass(WorkflowRunNotFoundError, RepositoryError)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import WebSocket
-from orcheo_backend.app import execute_workflow, workflow_websocket
+from orcheo_backend.app import execute_workflow, get_repository, workflow_websocket
 
 
 @pytest.mark.asyncio
@@ -79,3 +79,11 @@ async def test_workflow_websocket():
         mock_websocket,
     )
     mock_websocket.close.assert_called_once()
+
+
+def test_get_repository_returns_singleton() -> None:
+    """The module-level repository accessor returns a singleton instance."""
+
+    first = get_repository()
+    second = get_repository()
+    assert first is second

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,0 +1,171 @@
+"""End-to-end API tests for the Orcheo FastAPI backend."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from orcheo_backend.app import create_app
+from orcheo_backend.app.repository import InMemoryWorkflowRepository
+
+
+@pytest.fixture()
+def api_client() -> Iterator[TestClient]:
+    """Yield a configured API client backed by a fresh repository."""
+
+    repository = InMemoryWorkflowRepository()
+    app = create_app(repository)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_workflow_crud_operations(api_client: TestClient) -> None:
+    """Validate workflow creation, retrieval, update, and archival."""
+
+    create_response = api_client.post(
+        "/api/workflows",
+        json={
+            "name": "Sample Flow",
+            "description": "Initial description",
+            "tags": ["Demo", "Example"],
+            "actor": "tester",
+        },
+    )
+    assert create_response.status_code == 201
+    workflow = create_response.json()
+    workflow_id = workflow["id"]
+    assert workflow["slug"] == "sample-flow"
+
+    get_response = api_client.get(f"/api/workflows/{workflow_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["name"] == "Sample Flow"
+
+    update_response = api_client.put(
+        f"/api/workflows/{workflow_id}",
+        json={"description": "Updated description", "actor": "tester"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["description"] == "Updated description"
+
+    list_response = api_client.get("/api/workflows")
+    assert list_response.status_code == 200
+    assert any(item["id"] == workflow_id for item in list_response.json())
+
+    delete_response = api_client.delete(
+        f"/api/workflows/{workflow_id}",
+        params={"actor": "tester"},
+    )
+    assert delete_response.status_code == 200
+    assert delete_response.json()["is_archived"] is True
+
+
+def test_workflow_versions_and_diff(api_client: TestClient) -> None:
+    """Ensure version creation, retrieval, and diffing all function."""
+
+    workflow_response = api_client.post(
+        "/api/workflows",
+        json={"name": "Diff Flow", "actor": "author"},
+    )
+    workflow = workflow_response.json()
+    workflow_id = workflow["id"]
+
+    version_one = api_client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": ["start"], "edges": []},
+            "metadata": {"notes": "v1"},
+            "created_by": "author",
+        },
+    )
+    assert version_one.status_code == 201
+    version_two = api_client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {
+                "nodes": ["start", "end"],
+                "edges": [{"from": "start", "to": "end"}],
+            },
+            "metadata": {"notes": "v2"},
+            "created_by": "author",
+            "notes": "Adds end node",
+        },
+    )
+    assert version_two.status_code == 201
+
+    list_versions = api_client.get(f"/api/workflows/{workflow_id}/versions")
+    assert list_versions.status_code == 200
+    versions = list_versions.json()
+    assert [version["version"] for version in versions] == [1, 2]
+
+    version_detail = api_client.get(f"/api/workflows/{workflow_id}/versions/2")
+    assert version_detail.status_code == 200
+    assert version_detail.json()["version"] == 2
+
+    diff_response = api_client.get(f"/api/workflows/{workflow_id}/versions/1/diff/2")
+    assert diff_response.status_code == 200
+    diff_payload = diff_response.json()
+    assert diff_payload["base_version"] == 1
+    assert diff_payload["target_version"] == 2
+    diff_lines = diff_payload["diff"]
+    assert any('+    "end"' in line for line in diff_lines)
+
+
+def test_workflow_run_lifecycle(api_client: TestClient) -> None:
+    """Exercise the workflow run state transitions."""
+
+    workflow_response = api_client.post(
+        "/api/workflows",
+        json={"name": "Run Flow", "actor": "runner"},
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    version_response = api_client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": ["start"], "edges": []},
+            "metadata": {},
+            "created_by": "runner",
+        },
+    )
+    version_id = UUID(version_response.json()["id"])
+
+    run_response = api_client.post(
+        f"/api/workflows/{workflow_id}/runs",
+        json={
+            "workflow_version_id": str(version_id),
+            "triggered_by": "runner",
+            "input_payload": {"input": "value"},
+        },
+    )
+    assert run_response.status_code == 201
+    run_payload = run_response.json()
+    run_id = run_payload["id"]
+    assert run_payload["status"] == "pending"
+
+    start_response = api_client.post(
+        f"/api/runs/{run_id}/start",
+        json={"actor": "runner"},
+    )
+    assert start_response.status_code == 200
+    assert start_response.json()["status"] == "running"
+
+    succeed_response = api_client.post(
+        f"/api/runs/{run_id}/succeed",
+        json={"actor": "runner", "output": {"result": "ok"}},
+    )
+    assert succeed_response.status_code == 200
+    succeeded_payload = succeed_response.json()
+    assert succeeded_payload["status"] == "succeeded"
+    assert succeeded_payload["output_payload"]["result"] == "ok"
+
+    list_runs_response = api_client.get(f"/api/workflows/{workflow_id}/runs")
+    assert list_runs_response.status_code == 200
+    run_ids = [run["id"] for run in list_runs_response.json()]
+    assert run_id in run_ids
+
+    run_detail = api_client.get(f"/api/runs/{run_id}")
+    assert run_detail.status_code == 200
+    assert run_detail.json()["status"] == "succeeded"

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -171,6 +171,70 @@ def test_workflow_run_lifecycle(api_client: TestClient) -> None:
     assert run_detail.json()["status"] == "succeeded"
 
 
+def test_workflow_run_invalid_transitions(api_client: TestClient) -> None:
+    """Invalid run transitions return conflict responses with helpful details."""
+
+    workflow = api_client.post(
+        "/api/workflows",
+        json={"name": "Conflict Flow", "actor": "runner"},
+    ).json()
+    workflow_id = workflow["id"]
+
+    version = api_client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={"graph": {}, "metadata": {}, "created_by": "runner"},
+    ).json()
+
+    run = api_client.post(
+        f"/api/workflows/{workflow_id}/runs",
+        json={
+            "workflow_version_id": version["id"],
+            "triggered_by": "runner",
+            "input_payload": {},
+        },
+    ).json()
+    run_id = run["id"]
+
+    succeed_before_start = api_client.post(
+        f"/api/runs/{run_id}/succeed",
+        json={"actor": "runner", "output": {}},
+    )
+    assert succeed_before_start.status_code == 409
+    assert (
+        succeed_before_start.json()["detail"]
+        == "Only running runs can be marked as succeeded."
+    )
+
+    start_response = api_client.post(
+        f"/api/runs/{run_id}/start",
+        json={"actor": "runner"},
+    )
+    assert start_response.status_code == 200
+
+    restart_response = api_client.post(
+        f"/api/runs/{run_id}/start",
+        json={"actor": "runner"},
+    )
+    assert restart_response.status_code == 409
+    assert restart_response.json()["detail"] == "Only pending runs can be started."
+
+    succeed_response = api_client.post(
+        f"/api/runs/{run_id}/succeed",
+        json={"actor": "runner", "output": {"result": "ok"}},
+    )
+    assert succeed_response.status_code == 200
+
+    cancel_after_completion = api_client.post(
+        f"/api/runs/{run_id}/cancel",
+        json={"actor": "runner", "reason": None},
+    )
+    assert cancel_after_completion.status_code == 409
+    assert (
+        cancel_after_completion.json()["detail"]
+        == "Cannot cancel a run that is already completed."
+    )
+
+
 def test_not_found_responses(api_client: TestClient) -> None:
     """The API surfaces standardized 404 errors when entities are missing."""
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -224,6 +224,16 @@ def test_workflow_run_invalid_transitions(api_client: TestClient) -> None:
     )
     assert succeed_response.status_code == 200
 
+    fail_after_completion = api_client.post(
+        f"/api/runs/{run_id}/fail",
+        json={"actor": "runner", "error": "boom"},
+    )
+    assert fail_after_completion.status_code == 409
+    assert (
+        fail_after_completion.json()["detail"]
+        == "Only pending or running runs can be marked as failed."
+    )
+
     cancel_after_completion = api_client.post(
         f"/api/runs/{run_id}/cancel",
         json={"actor": "runner", "reason": None},


### PR DESCRIPTION
## Summary
- add HTTP routes for workflows, versions, and run lifecycle management backed by an in-memory repository
- expose request schemas and repository dependency wiring from the backend package
- cover the new API with FastAPI client tests for CRUD, version diffing, and execution transitions

## Testing
- uv run make lint
- uv run make test

------
https://chatgpt.com/codex/tasks/task_e_68e6bee3ad408327baecd6cb5303f311