### PR TITLE
Add cron trigger scheduling support

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 import asyncio
 import json
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from difflib import unified_diff
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
+from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.webhook import (
+    WebhookRequest,
+    WebhookTriggerConfig,
+    WebhookTriggerState,
+)
 
 
 class RepositoryError(RuntimeError):
@@ -47,6 +54,9 @@ class InMemoryWorkflowRepository:
         self._versions: dict[UUID, WorkflowVersion] = {}
         self._runs: dict[UUID, WorkflowRun] = {}
         self._version_runs: dict[UUID, list[UUID]] = {}
+        self._webhook_states: dict[UUID, WebhookTriggerState] = {}
+        self._cron_states: dict[UUID, CronTriggerState] = {}
+        self._cron_run_index: dict[UUID, UUID] = {}
 
     async def list_workflows(self) -> list[Workflow]:
         """Return all workflows stored within the repository."""
@@ -209,6 +219,20 @@ class InMemoryWorkflowRepository:
                 raise WorkflowVersionNotFoundError(str(version_id))
             return version.model_copy(deep=True)
 
+    async def get_latest_version(self, workflow_id: UUID) -> WorkflowVersion:
+        """Return the most recent workflow version for the workflow."""
+        async with self._lock:
+            version_ids = self._workflow_versions.get(workflow_id)
+            if version_ids is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+            if not version_ids:
+                raise WorkflowVersionNotFoundError("latest")
+            latest_version_id = version_ids[-1]
+            version = self._versions.get(latest_version_id)
+            if version is None:
+                raise WorkflowVersionNotFoundError(str(latest_version_id))
+            return version.model_copy(deep=True)
+
     async def diff_versions(
         self, workflow_id: UUID, base_version: int, target_version: int
     ) -> VersionDiff:
@@ -265,6 +289,8 @@ class InMemoryWorkflowRepository:
             run.record_event(actor=triggered_by, action="run_created")
             self._runs[run.id] = run
             self._version_runs.setdefault(workflow_version_id, []).append(run.id)
+            if triggered_by == "cron":
+                self._cron_run_index[run.id] = workflow_id
             return run.model_copy(deep=True)
 
     async def list_runs_for_workflow(self, workflow_id: UUID) -> list[WorkflowRun]:
@@ -311,10 +337,12 @@ class InMemoryWorkflowRepository:
         output: dict[str, Any] | None,
     ) -> WorkflowRun:
         """Mark the specified run as succeeded with optional output."""
-        return await self._update_run(
+        run = await self._update_run(
             run_id,
             lambda run: run.mark_succeeded(actor=actor, output=output),
         )
+        self._release_cron_run(run_id)
+        return run
 
     async def mark_run_failed(
         self,
@@ -324,10 +352,12 @@ class InMemoryWorkflowRepository:
         error: str,
     ) -> WorkflowRun:
         """Transition the run to a failed state."""
-        return await self._update_run(
+        run = await self._update_run(
             run_id,
             lambda run: run.mark_failed(actor=actor, error=error),
         )
+        self._release_cron_run(run_id)
+        return run
 
     async def mark_run_cancelled(
         self,
@@ -337,10 +367,12 @@ class InMemoryWorkflowRepository:
         reason: str | None,
     ) -> WorkflowRun:
         """Cancel a run, optionally including a reason."""
-        return await self._update_run(
+        run = await self._update_run(
             run_id,
             lambda run: run.mark_cancelled(actor=actor, reason=reason),
         )
+        self._release_cron_run(run_id)
+        return run
 
     async def reset(self) -> None:
         """Clear all stored workflows, versions, and runs."""
@@ -350,6 +382,154 @@ class InMemoryWorkflowRepository:
             self._versions.clear()
             self._runs.clear()
             self._version_runs.clear()
+            self._webhook_states.clear()
+            self._cron_states.clear()
+            self._cron_run_index.clear()
+
+    def _release_cron_run(self, run_id: UUID) -> None:
+        """Release overlap tracking for the provided cron run."""
+        workflow_id = self._cron_run_index.pop(run_id, None)
+        if workflow_id is None:
+            return
+        state = self._cron_states.get(workflow_id)
+        if state is None:
+            return
+        state.release_run(run_id)
+
+    async def configure_webhook_trigger(
+        self, workflow_id: UUID, config: WebhookTriggerConfig
+    ) -> WebhookTriggerConfig:
+        """Persist webhook trigger configuration for a workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+            state.update_config(config)
+            return state.config
+
+    async def get_webhook_trigger_config(
+        self, workflow_id: UUID
+    ) -> WebhookTriggerConfig:
+        """Return the webhook configuration for the workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+            return state.config
+
+    async def handle_webhook_trigger(
+        self,
+        workflow_id: UUID,
+        *,
+        method: str,
+        headers: Mapping[str, str],
+        query_params: Mapping[str, str],
+        payload: Any,
+        source_ip: str | None,
+    ) -> WorkflowRun:
+        """Validate webhook input and enqueue a workflow run."""
+        async with self._lock:
+            workflow = self._workflows.get(workflow_id)
+            if workflow is None:
+                raise WorkflowNotFoundError(str(workflow_id))
+
+            version_ids = self._workflow_versions.get(workflow_id)
+            if not version_ids:
+                raise WorkflowVersionNotFoundError("latest")
+            latest_version_id = version_ids[-1]
+            version = self._versions.get(latest_version_id)
+            if version is None:
+                raise WorkflowVersionNotFoundError(str(latest_version_id))
+
+            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+            request = WebhookRequest(
+                method=method,
+                headers=headers,
+                query_params=query_params,
+                payload=payload,
+                source_ip=source_ip,
+            )
+            state.validate(request)
+
+            normalized_payload = state.serialize_payload(payload)
+            run = WorkflowRun(
+                workflow_version_id=version.id,
+                triggered_by="webhook",
+                input_payload={
+                    "body": normalized_payload,
+                    "headers": request.normalized_headers(),
+                    "query_params": request.normalized_query(),
+                    "source_ip": source_ip,
+                },
+            )
+            run.record_event(actor="webhook", action="run_created")
+            self._runs[run.id] = run
+            self._version_runs.setdefault(version.id, []).append(run.id)
+            self._cron_run_index.pop(run.id, None)
+            return run.model_copy(deep=True)
+
+    async def configure_cron_trigger(
+        self, workflow_id: UUID, config: CronTriggerConfig
+    ) -> CronTriggerConfig:
+        """Persist cron trigger configuration for a workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            state = self._cron_states.setdefault(workflow_id, CronTriggerState())
+            state.update_config(config)
+            return state.config
+
+    async def get_cron_trigger_config(self, workflow_id: UUID) -> CronTriggerConfig:
+        """Return the configured cron trigger definition."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            state = self._cron_states.setdefault(workflow_id, CronTriggerState())
+            return state.config
+
+    async def dispatch_due_cron_runs(
+        self, *, now: datetime | None = None
+    ) -> list[WorkflowRun]:
+        """Evaluate cron schedules and enqueue runs that are due."""
+        reference = now or datetime.now(tz=UTC)
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=UTC)
+
+        async with self._lock:
+            runs: list[WorkflowRun] = []
+            for workflow_id, state in self._cron_states.items():
+                if workflow_id not in self._workflows:
+                    continue
+                due_at = state.peek_due(now=reference)
+                if due_at is None:
+                    continue
+                if not state.can_dispatch():
+                    continue
+
+                version_ids = self._workflow_versions.get(workflow_id)
+                if not version_ids:
+                    continue
+                latest_version_id = version_ids[-1]
+                version = self._versions.get(latest_version_id)
+                if version is None:
+                    continue
+
+                fire_at = state.consume_due()
+                run = WorkflowRun(
+                    workflow_version_id=version.id,
+                    triggered_by="cron",
+                    input_payload={
+                        "scheduled_for": fire_at.isoformat(),
+                        "timezone": state.config.timezone,
+                    },
+                )
+                run.record_event(actor="cron", action="run_created")
+                self._runs[run.id] = run
+                self._version_runs.setdefault(version.id, []).append(run.id)
+                self._cron_run_index[run.id] = workflow_id
+                state.register_run(run.id)
+                runs.append(run.model_copy(deep=True))
+            return runs
 
 
 __all__ = [

--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -465,7 +465,6 @@ class InMemoryWorkflowRepository:
             run.record_event(actor="webhook", action="run_created")
             self._runs[run.id] = run
             self._version_runs.setdefault(version.id, []).append(run.id)
-            self._cron_run_index.pop(run.id, None)
             return run.model_copy(deep=True)
 
     async def configure_cron_trigger(

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -1,6 +1,7 @@
 """Pydantic request schemas for the FastAPI service."""
 
 from __future__ import annotations
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 from pydantic import BaseModel, Field
@@ -73,3 +74,9 @@ class WorkflowVersionDiffResponse(BaseModel):
     base_version: int
     target_version: int
     diff: list[str]
+
+
+class CronDispatchRequest(BaseModel):
+    """Request body for dispatching cron triggers."""
+
+    now: datetime | None = None

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,10 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Implement Python SDK with typed node authoring, local execution parity, and deployment hooks that sync with the server.
 - [x] Build FastAPI services for workflow CRUD, execution lifecycle, version diffing, and WebSocket streaming telemetry.
 - [ ] Deliver trigger layer covering webhook validation (verbs, filtering, rate limits), cron scheduler (timezone aware, overlap guards), manual/batch runs, and retry policies.
+  - [x] Implement webhook trigger configuration with verb filtering, shared secrets, and rate limiting.
+  - [x] Build cron scheduler supporting timezone-aware execution and overlap protection.
+  - [ ] Support manual and batch run dispatch from the trigger layer.
+  - [ ] Introduce configurable retry policies for trigger-driven runs.
 - [ ] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
 - [ ] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "python-dotenv>=1.0.0",
   "websockets>=12.0",
   "openai>=1.0.0",
+  "croniter>=2.0.0",
   "langgraph-checkpoint-sqlite>=2.0.7",
   "aiosqlite>=0.21.0",
   "langgraph-checkpoint-postgres>=2.0.21",

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -1,12 +1,12 @@
 """Trigger configuration and validation utilities."""
 
-from .cron import (
+from orcheo.triggers.cron import (
     CronOverlapError,
     CronTriggerConfig,
     CronTriggerState,
     CronValidationError,
 )
-from .webhook import (
+from orcheo.triggers.webhook import (
     MethodNotAllowedError,
     RateLimitConfig,
     RateLimitExceededError,

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -1,0 +1,32 @@
+"""Trigger configuration and validation utilities."""
+
+from .cron import (
+    CronOverlapError,
+    CronTriggerConfig,
+    CronTriggerState,
+    CronValidationError,
+)
+from .webhook import (
+    MethodNotAllowedError,
+    RateLimitConfig,
+    RateLimitExceededError,
+    WebhookAuthenticationError,
+    WebhookRequest,
+    WebhookTriggerConfig,
+    WebhookValidationError,
+)
+
+
+__all__ = [
+    "CronTriggerConfig",
+    "CronTriggerState",
+    "CronValidationError",
+    "CronOverlapError",
+    "RateLimitConfig",
+    "WebhookRequest",
+    "WebhookTriggerConfig",
+    "WebhookValidationError",
+    "MethodNotAllowedError",
+    "WebhookAuthenticationError",
+    "RateLimitExceededError",
+]

--- a/src/orcheo/triggers/cron.py
+++ b/src/orcheo/triggers/cron.py
@@ -1,0 +1,212 @@
+"""Cron trigger configuration, validation, and scheduling utilities."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+from croniter import CroniterBadCronError, croniter  # type: ignore[import-untyped]
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class CronValidationError(ValueError):
+    """Base error raised when cron configuration cannot be validated."""
+
+
+class CronOverlapError(RuntimeError):
+    """Raised when a cron trigger would create overlapping runs."""
+
+
+@dataclass(slots=True)
+class CronOccurrence:
+    """Single cron occurrence with precomputed schedule bounds."""
+
+    expression: str
+    timezone: ZoneInfo
+    start_at: datetime | None
+    end_at: datetime | None
+
+    def _localize(self, value: datetime) -> datetime:
+        return value.astimezone(self.timezone)
+
+    def _local_naive(self, value: datetime) -> datetime:
+        return self._localize(value).replace(tzinfo=None)
+
+    def next_after(
+        self, reference: datetime, *, inclusive: bool = False
+    ) -> datetime | None:
+        """Return the next occurrence after the provided reference."""
+        local_reference = self._local_naive(reference)
+        start_naive = (
+            self.start_at.astimezone(self.timezone).replace(tzinfo=None)
+            if self.start_at
+            else None
+        )
+        end_naive = (
+            self.end_at.astimezone(self.timezone).replace(tzinfo=None)
+            if self.end_at
+            else None
+        )
+
+        if start_naive and local_reference < start_naive:
+            local_reference = start_naive
+            inclusive = True
+
+        if inclusive and croniter.match(self.expression, local_reference):
+            candidate = local_reference
+        else:
+            iterator = croniter(
+                self.expression,
+                local_reference,
+                ret_type=datetime,
+                day_or=True,
+            )
+            candidate = iterator.get_next(datetime)
+
+        if end_naive and candidate > end_naive:
+            return None
+
+        return candidate.replace(tzinfo=self.timezone)
+
+
+class CronTriggerConfig(BaseModel):
+    """Configuration describing how cron triggers should be scheduled."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expression: str = Field(
+        default="0 * * * *",
+        description=(
+            "Cron expression controlling the schedule (minute hour day month weekday)."
+        ),
+    )
+    timezone: str = Field(
+        default="UTC",
+        description="IANA timezone identifier used to evaluate the cron expression.",
+    )
+    allow_overlapping: bool = Field(
+        default=False,
+        description="Whether multiple cron-triggered runs may overlap in time.",
+    )
+    start_at: datetime | None = Field(
+        default=None,
+        description="Optional earliest datetime (inclusive) the schedule may fire.",
+    )
+    end_at: datetime | None = Field(
+        default=None,
+        description="Optional latest datetime (inclusive) the schedule may fire.",
+    )
+
+    @field_validator("expression")
+    @classmethod
+    def _validate_expression(cls, value: str) -> str:
+        try:
+            croniter(value)
+        except CroniterBadCronError as exc:
+            msg = f"Invalid cron expression: {value}"
+            raise CronValidationError(msg) from exc
+        return value
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except Exception as exc:
+            msg = f"Unknown timezone '{value}'"
+            raise CronValidationError(msg) from exc
+        return value
+
+    @field_validator("start_at", "end_at", mode="before")
+    @classmethod
+    def _ensure_timezone_awareness(cls, value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            msg = "Cron boundaries must be timezone-aware"
+            raise CronValidationError(msg)
+        if value.second != 0 or value.microsecond != 0:
+            msg = "Cron boundaries must align to whole minutes"
+            raise CronValidationError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_window(self) -> CronTriggerConfig:
+        if self.start_at and self.end_at and self.start_at > self.end_at:
+            msg = "start_at must be earlier than end_at"
+            raise CronValidationError(msg)
+        return self
+
+    def timezone_info(self) -> ZoneInfo:
+        """Return the ZoneInfo instance for the configured timezone."""
+        return ZoneInfo(self.timezone)
+
+    def to_occurrence(self) -> CronOccurrence:
+        """Create a schedule helper for computing future occurrences."""
+        return CronOccurrence(
+            expression=self.expression,
+            timezone=self.timezone_info(),
+            start_at=self.start_at,
+            end_at=self.end_at,
+        )
+
+
+class CronTriggerState:
+    """Holds cron trigger configuration and scheduling state."""
+
+    def __init__(self, config: CronTriggerConfig | None = None) -> None:
+        """Initialize the cron trigger state with optional configuration."""
+        self._config = (config or CronTriggerConfig()).model_copy(deep=True)
+        self._occurrence = self._config.to_occurrence()
+        self._next_fire_at: datetime | None = None
+        self._active_runs: set[UUID] = set()
+
+    @property
+    def config(self) -> CronTriggerConfig:
+        """Return a deep copy of the cron trigger configuration."""
+        return self._config.model_copy(deep=True)
+
+    def update_config(self, config: CronTriggerConfig) -> None:
+        """Replace the configuration and reset the scheduling cursor."""
+        self._config = config.model_copy(deep=True)
+        self._occurrence = self._config.to_occurrence()
+        self._next_fire_at = None
+
+    def can_dispatch(self) -> bool:
+        """Return whether a new cron run may be dispatched."""
+        return self._config.allow_overlapping or not self._active_runs
+
+    def register_run(self, run_id: UUID) -> None:
+        """Register a newly created cron run, enforcing overlap rules."""
+        if not self.can_dispatch():
+            msg = "Cron trigger already has an active run"
+            raise CronOverlapError(msg)
+        self._active_runs.add(run_id)
+
+    def release_run(self, run_id: UUID) -> None:
+        """Release an active run from overlap tracking."""
+        self._active_runs.discard(run_id)
+
+    def peek_due(self, *, now: datetime) -> datetime | None:
+        """Return the next due execution time without advancing state."""
+        self._ensure_next(now)
+        if self._next_fire_at and self._next_fire_at <= now.astimezone(UTC):
+            return self._next_fire_at
+        return None
+
+    def consume_due(self) -> datetime:
+        """Advance the schedule and return the datetime that was consumed."""
+        if self._next_fire_at is None:
+            msg = "No scheduled run is ready to consume"
+            raise CronValidationError(msg)
+        fire_at = self._next_fire_at
+        next_time = self._occurrence.next_after(fire_at, inclusive=False)
+        self._next_fire_at = next_time.astimezone(UTC) if next_time else None
+        return fire_at
+
+    def _ensure_next(self, now: datetime) -> None:
+        if self._next_fire_at is not None:
+            return
+        reference = self._config.start_at or now
+        next_time = self._occurrence.next_after(reference, inclusive=True)
+        self._next_fire_at = next_time.astimezone(UTC) if next_time else None

--- a/src/orcheo/triggers/webhook.py
+++ b/src/orcheo/triggers/webhook.py
@@ -1,0 +1,250 @@
+"""Webhook trigger configuration and validation helpers."""
+
+from __future__ import annotations
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class WebhookValidationError(ValueError):
+    """Base error raised when webhook requests fail validation."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        """Store the error message alongside the HTTP status code."""
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class MethodNotAllowedError(WebhookValidationError):
+    """Raised when the inbound request method is not permitted."""
+
+    def __init__(self, method: str, allowed: set[str]) -> None:
+        """Initialize the error with the offending method and allowed set."""
+        allowed_methods = ", ".join(sorted(allowed)) or "none"
+        message = f"Method {method} not allowed. Allowed methods: {allowed_methods}"
+        super().__init__(message, status_code=405)
+
+
+class WebhookAuthenticationError(WebhookValidationError):
+    """Raised when the request fails shared secret validation."""
+
+    def __init__(self) -> None:
+        """Construct the error using a fixed authentication failure message."""
+        super().__init__("Invalid webhook authentication credentials", status_code=401)
+
+
+class RateLimitExceededError(WebhookValidationError):
+    """Raised when requests exceed the configured rate limit."""
+
+    def __init__(self, limit: int, interval_seconds: int) -> None:
+        """Include the configured limit and interval in the error message."""
+        message = (
+            "Webhook rate limit exceeded. "
+            f"Limit: {limit} requests per {interval_seconds} seconds"
+        )
+        super().__init__(message, status_code=429)
+
+
+class RateLimitConfig(BaseModel):
+    """Configuration describing webhook rate limiting behaviour."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    limit: int = Field(
+        default=60,
+        ge=1,
+        description="Maximum number of requests allowed in the configured interval.",
+    )
+    interval_seconds: int = Field(
+        default=60,
+        ge=1,
+        description="Time window in seconds over which the limit is applied.",
+    )
+
+
+class WebhookTriggerConfig(BaseModel):
+    """Configuration defining webhook trigger validation rules."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    allowed_methods: list[str] = Field(
+        default_factory=lambda: ["POST"],
+        description="Set of HTTP methods that are permitted for the webhook.",
+    )
+    required_headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Headers that must be present with specific values.",
+    )
+    required_query_params: dict[str, str] = Field(
+        default_factory=dict,
+        description="Query parameters that must match expected values.",
+    )
+    shared_secret_header: str | None = Field(
+        default=None,
+        alias="secret_header",
+        serialization_alias="secret_header",
+        description="Optional HTTP header used to supply a shared secret.",
+    )
+    shared_secret: str | None = Field(
+        default=None,
+        description="Optional shared secret value used to authenticate requests.",
+    )
+    rate_limit: RateLimitConfig | None = Field(
+        default=None,
+        description="Optional rate limit configuration for inbound requests.",
+    )
+
+    @field_validator("allowed_methods", mode="after")
+    @classmethod
+    def _normalize_methods(cls, value: list[str]) -> list[str]:
+        methods = sorted({method.upper() for method in value})
+        if not methods:
+            raise WebhookValidationError(
+                "At least one HTTP method must be allowed", status_code=400
+            )
+        return methods
+
+    @field_validator("required_headers", mode="after")
+    @classmethod
+    def _normalize_required_headers(cls, value: dict[str, str]) -> dict[str, str]:
+        return {key.lower(): str(val) for key, val in value.items()}
+
+    @field_validator("required_query_params", mode="after")
+    @classmethod
+    def _normalize_required_query(cls, value: dict[str, str]) -> dict[str, str]:
+        return {str(key): str(val) for key, val in value.items()}
+
+    @field_validator("shared_secret_header")
+    @classmethod
+    def _normalize_secret_header(cls, value: str | None) -> str | None:
+        return value if value is None else value.lower()
+
+    @model_validator(mode="after")
+    def _validate_secret_configuration(self) -> WebhookTriggerConfig:
+        if self.shared_secret_header and not self.shared_secret:
+            raise WebhookValidationError(
+                "shared_secret must be provided when shared_secret_header is set",
+                status_code=400,
+            )
+        if self.shared_secret and not self.shared_secret_header:
+            raise WebhookValidationError(
+                "shared_secret_header is required when shared_secret is provided",
+                status_code=400,
+            )
+        return self
+
+
+@dataclass(slots=True)
+class WebhookRequest:
+    """Normalized representation of an inbound webhook request."""
+
+    method: str
+    headers: Mapping[str, str]
+    query_params: Mapping[str, str]
+    payload: Any
+    source_ip: str | None = None
+
+    def normalized_method(self) -> str:
+        """Return the uppercase HTTP method."""
+        return self.method.upper()
+
+    def normalized_headers(self) -> dict[str, str]:
+        """Return headers normalized to lowercase keys."""
+        return {key.lower(): value for key, value in self.headers.items()}
+
+    def normalized_query(self) -> dict[str, str]:
+        """Return a shallow copy of the query parameters."""
+        return dict(self.query_params)
+
+
+class WebhookTriggerState:
+    """Maintain webhook configuration and request validation state."""
+
+    def __init__(self, config: WebhookTriggerConfig | None = None) -> None:
+        """Initialize state with an optional configuration instance."""
+        self._config = (config or WebhookTriggerConfig()).model_copy(deep=True)
+        self._recent_invocations: deque[datetime] = deque()
+
+    @property
+    def config(self) -> WebhookTriggerConfig:
+        """Return a deep copy of the stored webhook configuration."""
+        return self._config.model_copy(deep=True)
+
+    def update_config(self, config: WebhookTriggerConfig) -> None:
+        """Replace the configuration and reset rate limiting state."""
+        self._config = config.model_copy(deep=True)
+        self._recent_invocations.clear()
+
+    def validate(self, request: WebhookRequest) -> None:
+        """Validate the inbound request against the configured rules."""
+        self._validate_method(request)
+        self._validate_required_headers(request)
+        self._validate_required_query_params(request)
+        self._validate_authentication(request)
+        self._enforce_rate_limit()
+
+    def serialize_payload(self, payload: Any) -> Any:
+        """Normalize payloads for storage on workflow runs."""
+        if isinstance(payload, bytes):
+            decoded = payload.decode("utf-8", errors="replace")
+            return {"raw": decoded}
+        return payload
+
+    # Internal helpers -------------------------------------------------
+
+    def _validate_method(self, request: WebhookRequest) -> None:
+        allowed = set(self._config.allowed_methods)
+        method = request.normalized_method()
+        if method not in allowed:
+            raise MethodNotAllowedError(method, allowed)
+
+    def _validate_authentication(self, request: WebhookRequest) -> None:
+        header_name = self._config.shared_secret_header
+        if header_name is None:
+            return
+
+        expected = self._config.shared_secret
+        provided = request.normalized_headers().get(header_name)
+        if expected is None or provided != expected:
+            raise WebhookAuthenticationError()
+
+    def _validate_required_headers(self, request: WebhookRequest) -> None:
+        expected = self._config.required_headers
+        if not expected:
+            return
+
+        headers = request.normalized_headers()
+        for key, value in expected.items():
+            if headers.get(key) != value:
+                message = f"Missing or invalid required header: {key}"
+                raise WebhookValidationError(message, status_code=400)
+
+    def _validate_required_query_params(self, request: WebhookRequest) -> None:
+        expected = self._config.required_query_params
+        if not expected:
+            return
+
+        params = request.normalized_query()
+        for key, value in expected.items():
+            if params.get(key) != value:
+                message = f"Missing or invalid required query parameter: {key}"
+                raise WebhookValidationError(message, status_code=400)
+
+    def _enforce_rate_limit(self) -> None:
+        config = self._config.rate_limit
+        if config is None:
+            return
+
+        now = datetime.now(tz=UTC)
+        window_start = now - timedelta(seconds=config.interval_seconds)
+
+        while self._recent_invocations and self._recent_invocations[0] < window_start:
+            self._recent_invocations.popleft()
+
+        if len(self._recent_invocations) >= config.limit:
+            raise RateLimitExceededError(config.limit, config.interval_seconds)
+
+        self._recent_invocations.append(now)

--- a/tests/backend/test_repository.py
+++ b/tests/backend/test_repository.py
@@ -1,13 +1,10 @@
 """Unit tests for the in-memory workflow repository implementation."""
 
 from __future__ import annotations
-
 from datetime import UTC, datetime
 from uuid import uuid4
-
 import pytest
-
-from orcheo.triggers.cron import CronTriggerConfig
+from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
 from orcheo.triggers.webhook import WebhookTriggerConfig
 from orcheo_backend.app.repository import (
     InMemoryWorkflowRepository,
@@ -139,6 +136,7 @@ async def test_version_management(repository: InMemoryWorkflowRepository) -> Non
 
     versions = await repository.list_versions(workflow.id)
     assert [version.version for version in versions] == [1, 2]
+    assert versions[0].id == first.id
 
     looked_up = await repository.get_version_by_number(workflow.id, 2)
     assert looked_up.id == second.id
@@ -262,7 +260,7 @@ async def test_run_error_paths(repository: InMemoryWorkflowRepository) -> None:
         tags=None,
         actor="owner",
     )
-    version = await repository.create_version(
+    _ = await repository.create_version(
         workflow.id,
         graph={},
         metadata={},
@@ -315,6 +313,40 @@ async def test_run_error_paths(repository: InMemoryWorkflowRepository) -> None:
 
     with pytest.raises(WorkflowRunNotFoundError):
         await repository.mark_run_cancelled(uuid4(), actor="actor", reason=None)
+
+
+@pytest.mark.asyncio()
+async def test_create_run_with_cron_source_tracks_overlap(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Cron-sourced runs register overlap tracking even without stored state."""
+
+    workflow = await repository.create_workflow(
+        name="Cron Indexed",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="cron",
+    )
+    version = await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="cron",
+    )
+
+    run = await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="cron",
+        input_payload={},
+    )
+    assert repository._cron_run_index[run.id] == workflow.id
+
+    await repository.mark_run_started(run.id, actor="cron")
+    await repository.mark_run_succeeded(run.id, actor="cron", output=None)
+    assert run.id not in repository._cron_run_index
 
 
 @pytest.mark.asyncio()
@@ -525,6 +557,19 @@ async def test_cron_trigger_configuration_and_dispatch(
 
 
 @pytest.mark.asyncio()
+async def test_cron_trigger_requires_existing_workflow(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Cron trigger helpers raise when the workflow is unknown."""
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.configure_cron_trigger(uuid4(), CronTriggerConfig())
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.get_cron_trigger_config(uuid4())
+
+
+@pytest.mark.asyncio()
 async def test_cron_trigger_overlap_guard(
     repository: InMemoryWorkflowRepository,
 ) -> None:
@@ -568,6 +613,106 @@ async def test_cron_trigger_overlap_guard(
         now=datetime(2025, 1, 2, 9, 0, tzinfo=UTC)
     )
     assert len(next_runs) == 1
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_due_cron_runs_handles_edge_cases(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Cron dispatcher gracefully skips invalid and incomplete state entries."""
+
+    naive_now = datetime(2025, 1, 1, 11, 0)
+
+    # Entry without a persisted workflow.
+    repository._cron_states[uuid4()] = CronTriggerState()
+
+    # Workflow without versions.
+    workflow_without_versions = await repository.create_workflow(
+        name="No Versions",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    repository._cron_states[workflow_without_versions.id] = CronTriggerState(
+        CronTriggerConfig(expression="0 11 * * *", timezone="UTC")
+    )
+
+    # Workflow with a missing latest version object.
+    workflow_missing_version = await repository.create_workflow(
+        name="Missing Version",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    orphaned_version = await repository.create_version(
+        workflow_missing_version.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+    repository._versions.pop(orphaned_version.id)
+    repository._cron_states[workflow_missing_version.id] = CronTriggerState(
+        CronTriggerConfig(expression="0 11 * * *", timezone="UTC")
+    )
+
+    # Workflow that is not yet due.
+    workflow_not_due = await repository.create_workflow(
+        name="Not Due",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    await repository.create_version(
+        workflow_not_due.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+    repository._cron_states[workflow_not_due.id] = CronTriggerState(
+        CronTriggerConfig(expression="0 12 * * *", timezone="UTC")
+    )
+
+    runs = await repository.dispatch_due_cron_runs(now=naive_now)
+    assert runs == []
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_due_cron_runs_respects_overlap_without_creating_runs(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Cron dispatcher skips scheduling when overlap guard is active."""
+
+    workflow = await repository.create_workflow(
+        name="Guarded Cron",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    await repository.configure_cron_trigger(
+        workflow.id,
+        CronTriggerConfig(expression="0 7 * * *", timezone="UTC"),
+    )
+    state = repository._cron_states[workflow.id]
+    state.register_run(uuid4())
+
+    runs = await repository.dispatch_due_cron_runs(
+        now=datetime(2025, 1, 1, 7, 0, tzinfo=UTC)
+    )
+    assert runs == []
 
 
 @pytest.mark.asyncio()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,13 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import WebSocket
-from orcheo_backend.app import execute_workflow, get_repository, workflow_websocket
+from orcheo_backend.app import (
+    create_app,
+    execute_workflow,
+    get_repository,
+    workflow_websocket,
+)
+from orcheo_backend.app.repository import InMemoryWorkflowRepository
 
 
 @pytest.mark.asyncio
@@ -87,3 +93,13 @@ def test_get_repository_returns_singleton() -> None:
     first = get_repository()
     second = get_repository()
     assert first is second
+
+
+def test_create_app_allows_dependency_override() -> None:
+    """Passing a repository instance wires it into FastAPI dependency overrides."""
+
+    repository = InMemoryWorkflowRepository()
+    app = create_app(repository)
+
+    override = app.dependency_overrides[get_repository]
+    assert override() is repository

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 import pytest
@@ -20,6 +21,30 @@ def api_client() -> Iterator[TestClient]:
     app = create_app(repository)
     with TestClient(app) as client:
         yield client
+
+
+def _create_workflow_with_version(api_client: TestClient) -> tuple[str, str]:
+    """Create a workflow and a single version, returning their identifiers."""
+
+    workflow_response = api_client.post(
+        "/api/workflows",
+        json={"name": "Webhook Flow", "actor": "tester"},
+    )
+    workflow_response.raise_for_status()
+    workflow_id = workflow_response.json()["id"]
+
+    version_response = api_client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": ["start"], "edges": []},
+            "metadata": {},
+            "created_by": "tester",
+        },
+    )
+    version_response.raise_for_status()
+    version_id = version_response.json()["id"]
+
+    return workflow_id, version_id
 
 
 def test_workflow_crud_operations(api_client: TestClient) -> None:
@@ -363,3 +388,272 @@ def test_version_and_run_error_responses(api_client: TestClient) -> None:
             json=payload,
         )
         assert response.status_code == 404
+
+
+def test_webhook_trigger_configuration_roundtrip(api_client: TestClient) -> None:
+    """Validate webhook trigger configuration persistence."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    default_response = api_client.get(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config"
+    )
+    assert default_response.status_code == 200
+    default_payload = default_response.json()
+    assert set(default_payload["allowed_methods"]) == {"POST"}
+
+    update_response = api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config",
+        json={
+            "allowed_methods": ["POST", "GET"],
+            "required_headers": {"x-custom": "value"},
+            "required_query_params": {"env": "prod"},
+            "shared_secret": "super-secret",
+            "secret_header": "x-super-secret",
+            "rate_limit": {"limit": 5, "interval_seconds": 60},
+        },
+    )
+    assert update_response.status_code == 200
+    updated_payload = update_response.json()
+    assert set(updated_payload["allowed_methods"]) == {"POST", "GET"}
+    assert updated_payload["required_headers"] == {"x-custom": "value"}
+    assert updated_payload["required_query_params"] == {"env": "prod"}
+    assert updated_payload["shared_secret"] == "super-secret"
+    assert updated_payload["secret_header"] == "x-super-secret"
+
+    roundtrip_response = api_client.get(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config"
+    )
+    assert roundtrip_response.status_code == 200
+    assert roundtrip_response.json() == updated_payload
+
+
+def test_webhook_trigger_execution_creates_run(api_client: TestClient) -> None:
+    """Ensure webhook invocation creates a pending workflow run."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config",
+        json={
+            "allowed_methods": ["POST"],
+            "required_headers": {"x-custom": "value"},
+            "shared_secret": "token",
+            "secret_header": "x-auth",
+            "rate_limit": {"limit": 5, "interval_seconds": 60},
+        },
+    )
+
+    trigger_response = api_client.post(
+        f"/api/workflows/{workflow_id}/triggers/webhook",
+        json={"message": "hello"},
+        headers={
+            "x-custom": "value",
+            "x-auth": "token",
+        },
+        params={"extra": "context"},
+    )
+    assert trigger_response.status_code == 202
+    run_payload = trigger_response.json()
+    assert run_payload["triggered_by"] == "webhook"
+    assert run_payload["status"] == "pending"
+
+    runs_response = api_client.get(f"/api/workflows/{workflow_id}/runs")
+    assert runs_response.status_code == 200
+    runs = runs_response.json()
+    assert len(runs) == 1
+    stored_run = runs[0]
+    assert stored_run["input_payload"]["body"] == {"message": "hello"}
+    assert stored_run["input_payload"]["headers"]["x-custom"] == "value"
+    assert stored_run["input_payload"]["query_params"] == {"extra": "context"}
+
+
+def test_webhook_trigger_enforces_method_and_rate_limit(
+    api_client: TestClient,
+) -> None:
+    """Ensure webhook trigger enforces method filters and rate limiting."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config",
+        json={
+            "allowed_methods": ["GET"],
+            "rate_limit": {"limit": 1, "interval_seconds": 60},
+        },
+    )
+
+    post_response = api_client.post(
+        f"/api/workflows/{workflow_id}/triggers/webhook",
+    )
+    assert post_response.status_code == 405
+
+    first_get = api_client.get(f"/api/workflows/{workflow_id}/triggers/webhook")
+    assert first_get.status_code == 202
+
+    second_get = api_client.get(f"/api/workflows/{workflow_id}/triggers/webhook")
+    assert second_get.status_code == 429
+
+
+def test_webhook_trigger_config_missing_workflow(api_client: TestClient) -> None:
+    """Webhook config routes return 404 for unknown workflows."""
+
+    missing = str(uuid4())
+    response = api_client.put(
+        f"/api/workflows/{missing}/triggers/webhook/config",
+        json={"allowed_methods": ["POST"]},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workflow not found"
+
+    get_response = api_client.get(f"/api/workflows/{missing}/triggers/webhook/config")
+    assert get_response.status_code == 404
+    assert get_response.json()["detail"] == "Workflow not found"
+
+
+def test_webhook_trigger_invoke_missing_workflow(api_client: TestClient) -> None:
+    """Webhook invocation returns a not found error for unknown workflows."""
+
+    missing = str(uuid4())
+    response = api_client.post(f"/api/workflows/{missing}/triggers/webhook")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workflow not found"
+
+
+def test_webhook_trigger_invoke_requires_version(api_client: TestClient) -> None:
+    """Webhook invocation requires at least one workflow version."""
+
+    workflow_response = api_client.post(
+        "/api/workflows",
+        json={"name": "No Version Flow", "actor": "tester"},
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    response = api_client.post(f"/api/workflows/{workflow_id}/triggers/webhook")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workflow version not found"
+
+
+def test_webhook_trigger_accepts_non_json_body(api_client: TestClient) -> None:
+    """Webhook invocation stores non-JSON payloads as raw bytes."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/webhook/config",
+        json={"allowed_methods": ["POST"]},
+    )
+
+    binary_payload = b"\xff\xfe"
+    trigger_response = api_client.post(
+        f"/api/workflows/{workflow_id}/triggers/webhook",
+        data=binary_payload,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert trigger_response.status_code == 202
+
+    runs_response = api_client.get(f"/api/workflows/{workflow_id}/runs")
+    run_payload = runs_response.json()[0]["input_payload"]
+    assert run_payload["body"] == {"raw": "��"}
+
+
+def test_cron_trigger_configuration_roundtrip(api_client: TestClient) -> None:
+    """Cron trigger configuration can be updated and retrieved."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    default_response = api_client.get(
+        f"/api/workflows/{workflow_id}/triggers/cron/config"
+    )
+    assert default_response.status_code == 200
+    assert default_response.json()["expression"] == "0 * * * *"
+
+    update_response = api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/cron/config",
+        json={
+            "expression": "0 9 * * MON-FRI",
+            "timezone": "America/New_York",
+            "allow_overlapping": False,
+        },
+    )
+    assert update_response.status_code == 200
+    payload = update_response.json()
+    assert payload["expression"] == "0 9 * * MON-FRI"
+    assert payload["timezone"] == "America/New_York"
+    assert payload["allow_overlapping"] is False
+
+    roundtrip = api_client.get(f"/api/workflows/{workflow_id}/triggers/cron/config")
+    assert roundtrip.status_code == 200
+    assert roundtrip.json() == payload
+
+
+def test_cron_trigger_dispatch_and_overlap(api_client: TestClient) -> None:
+    """Cron dispatch endpoint enqueues due runs and enforces overlap guard."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/cron/config",
+        json={
+            "expression": "0 9 * * *",
+            "timezone": "UTC",
+            "allow_overlapping": False,
+        },
+    )
+
+    dispatch_response = api_client.post(
+        "/api/triggers/cron/dispatch",
+        json={"now": datetime(2025, 1, 1, 9, 0, tzinfo=UTC).isoformat()},
+    )
+    assert dispatch_response.status_code == 200
+    runs = dispatch_response.json()
+    assert len(runs) == 1
+    run_id = runs[0]["id"]
+    assert runs[0]["triggered_by"] == "cron"
+
+    blocked = api_client.post(
+        "/api/triggers/cron/dispatch",
+        json={"now": datetime(2025, 1, 1, 10, 0, tzinfo=UTC).isoformat()},
+    )
+    assert blocked.status_code == 200
+    assert blocked.json() == []
+
+    start_response = api_client.post(
+        f"/api/runs/{run_id}/start",
+        json={"actor": "cron"},
+    )
+    assert start_response.status_code == 200
+
+    succeed_response = api_client.post(
+        f"/api/runs/{run_id}/succeed",
+        json={"actor": "cron"},
+    )
+    assert succeed_response.status_code == 200
+
+    next_dispatch = api_client.post(
+        "/api/triggers/cron/dispatch",
+        json={"now": datetime(2025, 1, 2, 9, 0, tzinfo=UTC).isoformat()},
+    )
+    assert next_dispatch.status_code == 200
+    assert len(next_dispatch.json()) == 1
+
+
+def test_cron_trigger_timezone_dispatch(api_client: TestClient) -> None:
+    """Cron dispatch respects configured timezones when evaluating schedules."""
+
+    workflow_id, _ = _create_workflow_with_version(api_client)
+
+    api_client.put(
+        f"/api/workflows/{workflow_id}/triggers/cron/config",
+        json={
+            "expression": "0 9 * * *",
+            "timezone": "America/Los_Angeles",
+        },
+    )
+
+    dispatch_response = api_client.post(
+        "/api/triggers/cron/dispatch",
+        json={"now": datetime(2025, 1, 1, 17, 0, tzinfo=UTC).isoformat()},
+    )
+    assert dispatch_response.status_code == 200
+    assert len(dispatch_response.json()) == 1

--- a/tests/test_triggers_cron.py
+++ b/tests/test_triggers_cron.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 from datetime import UTC, datetime
 from uuid import uuid4
-
 import pytest
 from pydantic import ValidationError
-
 from orcheo.triggers.cron import (
     CronOverlapError,
     CronTriggerConfig,

--- a/tests/test_triggers_cron.py
+++ b/tests/test_triggers_cron.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
 
-from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.cron import (
+    CronOverlapError,
+    CronTriggerConfig,
+    CronTriggerState,
+    CronValidationError,
+)
 
 
 def test_cron_trigger_state_computes_next_occurrence() -> None:
@@ -51,6 +58,100 @@ def test_cron_trigger_overlap_guard() -> None:
 
     state.release_run(run_id)
     assert state.can_dispatch() is True
+
+
+def test_cron_trigger_overlap_guard_raises_when_busy() -> None:
+    """Registering a second run without overlap permissions should fail."""
+
+    config = CronTriggerConfig(expression="0 * * * *", allow_overlapping=False)
+    state = CronTriggerState(config)
+
+    state.register_run(uuid4())
+
+    with pytest.raises(CronOverlapError):
+        state.register_run(uuid4())
+
+
+def test_cron_trigger_consume_without_schedule() -> None:
+    """Consuming without priming the schedule should raise an error."""
+
+    state = CronTriggerState()
+
+    with pytest.raises(CronValidationError):
+        state.consume_due()
+
+
+def test_cron_occurrence_respects_start_and_end_window() -> None:
+    """Occurrences should snap to the configured window bounds."""
+
+    start = datetime(2025, 1, 1, 9, 0, tzinfo=UTC)
+    config = CronTriggerConfig(
+        expression="0 9 * * *",
+        timezone="UTC",
+        start_at=start,
+        end_at=start,
+    )
+
+    occurrence = config.to_occurrence()
+
+    before_window = datetime(2025, 1, 1, 8, 0, tzinfo=UTC)
+    next_due = occurrence.next_after(before_window, inclusive=False)
+    assert next_due == start
+
+    assert occurrence.next_after(start, inclusive=False) is None
+
+
+def test_cron_trigger_rejects_invalid_expression() -> None:
+    """Invalid cron expressions should raise a validation error."""
+
+    with pytest.raises(ValidationError) as exc:
+        CronTriggerConfig(expression="not-a-cron")
+
+    assert "Invalid cron expression" in str(exc.value)
+
+
+def test_cron_trigger_allows_missing_boundaries() -> None:
+    """Explicitly passing None boundaries should be accepted."""
+
+    config = CronTriggerConfig(start_at=None, end_at=None)
+
+    assert config.start_at is None
+    assert config.end_at is None
+
+
+@pytest.mark.parametrize("boundary", ["start_at", "end_at"])
+def test_cron_trigger_requires_timezone_aware_boundaries(boundary: str) -> None:
+    """Boundary datetimes must include timezone information."""
+
+    naive = datetime(2025, 1, 1, 9, 0)
+
+    with pytest.raises(ValidationError) as exc:
+        CronTriggerConfig(**{boundary: naive})
+
+    assert "timezone-aware" in str(exc.value)
+
+
+def test_cron_trigger_requires_minute_aligned_boundaries() -> None:
+    """Boundary datetimes must align exactly to minute intervals."""
+
+    misaligned = datetime(2025, 1, 1, 9, 0, 30, tzinfo=UTC)
+
+    with pytest.raises(ValidationError) as exc:
+        CronTriggerConfig(start_at=misaligned)
+
+    assert "align to whole minutes" in str(exc.value)
+
+
+def test_cron_trigger_start_must_precede_end() -> None:
+    """start_at must be earlier than end_at when both are provided."""
+
+    start = datetime(2025, 1, 2, 9, 0, tzinfo=UTC)
+    end = datetime(2025, 1, 1, 9, 0, tzinfo=UTC)
+
+    with pytest.raises(ValidationError) as exc:
+        CronTriggerConfig(start_at=start, end_at=end)
+
+    assert "start_at must be earlier" in str(exc.value)
 
 
 def test_cron_trigger_rejects_invalid_timezone() -> None:

--- a/tests/test_triggers_cron.py
+++ b/tests/test_triggers_cron.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+
+
+def test_cron_trigger_state_computes_next_occurrence() -> None:
+    """Cron trigger state should surface the next due time and advance."""
+
+    config = CronTriggerConfig(expression="0 9 * * *", timezone="UTC")
+    state = CronTriggerState(config)
+
+    first_due = state.peek_due(now=datetime(2025, 1, 1, 9, 0, tzinfo=UTC))
+    assert first_due == datetime(2025, 1, 1, 9, 0, tzinfo=UTC)
+
+    consumed = state.consume_due()
+    assert consumed == first_due
+
+    assert state.peek_due(now=datetime(2025, 1, 1, 9, 5, tzinfo=UTC)) is None
+
+    next_due = state.peek_due(now=datetime(2025, 1, 2, 9, 0, tzinfo=UTC))
+    assert next_due == datetime(2025, 1, 2, 9, 0, tzinfo=UTC)
+
+
+def test_cron_trigger_respects_timezone() -> None:
+    """Schedules should be evaluated according to the configured timezone."""
+
+    config = CronTriggerConfig(expression="30 9 * * *", timezone="America/New_York")
+    state = CronTriggerState(config)
+
+    reference = datetime(2025, 1, 1, 14, 30, tzinfo=UTC)
+    due = state.peek_due(now=reference)
+    assert due == reference
+
+
+def test_cron_trigger_overlap_guard() -> None:
+    """Overlap protection prevents multiple pending runs."""
+
+    config = CronTriggerConfig(expression="0 * * * *", allow_overlapping=False)
+    state = CronTriggerState(config)
+
+    now = datetime(2025, 1, 1, 0, 0, tzinfo=UTC)
+    assert state.peek_due(now=now) is not None
+
+    run_id = uuid4()
+    state.register_run(run_id)
+    assert state.can_dispatch() is False
+
+    state.release_run(run_id)
+    assert state.can_dispatch() is True
+
+
+def test_cron_trigger_rejects_invalid_timezone() -> None:
+    """Invalid timezone identifiers should raise a validation error."""
+
+    with pytest.raises(ValidationError):
+        CronTriggerConfig(expression="0 * * * *", timezone="Mars/Phobos")

--- a/tests/test_triggers_webhook.py
+++ b/tests/test_triggers_webhook.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.triggers.webhook import (
+    RateLimitConfig,
+    RateLimitExceededError,
+    WebhookAuthenticationError,
+    WebhookRequest,
+    WebhookTriggerConfig,
+    WebhookTriggerState,
+    WebhookValidationError,
+)
+
+
+def make_request(**overrides: object) -> WebhookRequest:
+    """Helper to construct webhook requests with sensible defaults."""
+
+    params: dict[str, object] = {
+        "method": "POST",
+        "headers": {},
+        "query_params": {},
+        "payload": None,
+    }
+    params.update(overrides)
+    return WebhookRequest(**params)  # type: ignore[arg-type]
+
+
+def _extract_inner_error(exc: ValidationError) -> WebhookValidationError:
+    """Retrieve the underlying webhook error from a validation error."""
+
+    inner = exc.errors()[0]["ctx"]["error"]
+    assert isinstance(inner, WebhookValidationError)
+    return inner
+
+
+def test_webhook_config_rejects_empty_methods() -> None:
+    """Webhook configuration must allow at least one HTTP method."""
+
+    with pytest.raises(ValidationError) as exc:
+        WebhookTriggerConfig(allowed_methods=[])
+
+    inner = _extract_inner_error(exc.value)
+    assert inner.status_code == 400
+    assert "At least one HTTP method" in str(inner)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        {"shared_secret_header": "x-hook-secret"},
+        {"shared_secret": "secret-value"},
+    ],
+)
+def test_webhook_config_requires_secret_pairs(config_kwargs: dict[str, str]) -> None:
+    """Secret header and value must be provided together."""
+
+    with pytest.raises(ValidationError) as exc:
+        WebhookTriggerConfig(**config_kwargs)
+
+    inner = _extract_inner_error(exc.value)
+    assert inner.status_code == 400
+
+
+def test_webhook_authentication_error_includes_status_code() -> None:
+    """Invalid authentication should raise the dedicated error."""
+
+    config = WebhookTriggerConfig(
+        shared_secret_header="x-secret",
+        shared_secret="expected",
+    )
+    state = WebhookTriggerState(config)
+
+    request = make_request(headers={"x-secret": "invalid"})
+
+    with pytest.raises(WebhookAuthenticationError) as exc:
+        state.validate(request)
+
+    assert exc.value.status_code == 401
+
+
+def test_webhook_required_headers_validation() -> None:
+    """Missing required headers should fail validation with status 400."""
+
+    config = WebhookTriggerConfig(required_headers={"X-Custom": "expected"})
+    state = WebhookTriggerState(config)
+
+    request = make_request(headers={})
+
+    with pytest.raises(WebhookValidationError) as exc:
+        state.validate(request)
+
+    assert exc.value.status_code == 400
+    assert "header" in str(exc.value)
+
+
+def test_webhook_required_headers_success() -> None:
+    """Requests with all required headers should succeed."""
+
+    config = WebhookTriggerConfig(required_headers={"X-Custom": "expected"})
+    state = WebhookTriggerState(config)
+
+    state.validate(make_request(headers={"X-Custom": "expected"}))
+
+
+def test_webhook_required_query_validation() -> None:
+    """Missing required query parameters should fail validation."""
+
+    config = WebhookTriggerConfig(required_query_params={"token": "abc"})
+    state = WebhookTriggerState(config)
+
+    request = make_request(query_params={})
+
+    with pytest.raises(WebhookValidationError) as exc:
+        state.validate(request)
+
+    assert exc.value.status_code == 400
+    assert "query" in str(exc.value)
+
+
+def test_webhook_required_query_success() -> None:
+    """Requests containing required query parameters should validate."""
+
+    config = WebhookTriggerConfig(required_query_params={"token": "abc"})
+    state = WebhookTriggerState(config)
+
+    state.validate(make_request(query_params={"token": "abc"}))
+
+
+def test_webhook_rate_limit_purges_outdated_entries() -> None:
+    """Rate limit enforcement should drop invocations outside the window."""
+
+    config = WebhookTriggerConfig(
+        rate_limit=RateLimitConfig(limit=2, interval_seconds=1)
+    )
+    state = WebhookTriggerState(config)
+
+    stale_time = datetime.now(tz=UTC) - timedelta(seconds=5)
+    state._recent_invocations.append(stale_time)
+
+    state.validate(make_request())
+
+    assert len(state._recent_invocations) == 1
+    assert state._recent_invocations[0] >= stale_time
+
+
+def test_webhook_rate_limit_exceeded() -> None:
+    """Exceeding the configured rate limit should raise an error."""
+
+    config = WebhookTriggerConfig(
+        rate_limit=RateLimitConfig(limit=1, interval_seconds=60)
+    )
+    state = WebhookTriggerState(config)
+
+    state.validate(make_request())
+
+    with pytest.raises(RateLimitExceededError):
+        state.validate(make_request())

--- a/tests/test_triggers_webhook.py
+++ b/tests/test_triggers_webhook.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
-
 import pytest
 from pydantic import ValidationError
-
 from orcheo.triggers.webhook import (
     RateLimitConfig,
     RateLimitExceededError,

--- a/uv.lock
+++ b/uv.lock
@@ -374,6 +374,19 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481, upload-time = "2024-12-17T17:17:47.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", size = 25468, upload-time = "2024-12-17T17:17:45.359Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "45.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1801,6 +1814,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "croniter" },
     { name = "cryptography" },
     { name = "dynaconf" },
     { name = "fastapi" },
@@ -1849,6 +1863,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "croniter", specifier = ">=2.0.0" },
     { name = "cryptography", specifier = ">=43.0.1" },
     { name = "dynaconf", specifier = ">=3.2.4" },
     { name = "fastapi", specifier = ">=0.104.0" },
@@ -2480,6 +2495,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/8c/0bd0d5c6de549ee0ebc2ddf4d49618eec1ece6d25084f3b4ef72bba6590c/python_telegram_bot-22.0.tar.gz", hash = "sha256:acf86f28d86d81cab736177d2988e5bcb27f2248137efd62e02c46e9ba1fe44c", size = 440017, upload-time = "2025-03-15T08:57:43.752Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/9f/b8c116f606074c19ec2600a7edc222f158c307ca949de568d67fe2b9d364/python_telegram_bot-22.0-py3-none-any.whl", hash = "sha256:23237f778655e634f08cfebbada96ed3692c2bdd3c20c122e90a6d606d6a4516", size = 673473, upload-time = "2025-03-15T08:57:41.637Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add cron trigger configuration and scheduling utilities backed by croniter
- persist cron trigger state in the repository and expose FastAPI endpoints to configure and dispatch cron runs
- cover cron behaviour with repository/api/unit tests and mark the roadmap milestone entry complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e81db04a54832788b6a1031f6ad853