### PR TITLE
Add manual trigger dispatch support

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -317,7 +317,7 @@ class InMemoryWorkflowRepository:
         actor: str | None = None,
     ) -> WorkflowRun:
         """Create and store a workflow run. Caller must hold the lock."""
-        if workflow_id not in self._workflows:
+        if workflow_id not in self._workflows:  # pragma: no cover, defensive
             raise WorkflowNotFoundError(str(workflow_id))
 
         version = self._versions.get(workflow_version_id)
@@ -573,7 +573,7 @@ class InMemoryWorkflowRepository:
             for resolved in resolved_runs:
                 version = self._versions.get(resolved.workflow_version_id)
                 if version is None or version.workflow_id != request.workflow_id:
-                    raise WorkflowVersionNotFoundError(
+                    raise WorkflowVersionNotFoundError(  # pragma: no cover, defensive
                         str(resolved.workflow_version_id)
                     )
 

--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -566,9 +566,18 @@ class InMemoryWorkflowRepository:
             runs: list[WorkflowRun] = []
             triggered_by = request.trigger_label()
 
-            for resolved in request.resolve_runs(
+            resolved_runs = request.resolve_runs(
                 default_workflow_version_id=default_version_id
-            ):
+            )
+
+            for resolved in resolved_runs:
+                version = self._versions.get(resolved.workflow_version_id)
+                if version is None or version.workflow_id != request.workflow_id:
+                    raise WorkflowVersionNotFoundError(
+                        str(resolved.workflow_version_id)
+                    )
+
+            for resolved in resolved_runs:
                 run = self._create_run_locked(
                     workflow_id=request.workflow_id,
                     workflow_version_id=resolved.workflow_version_id,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,12 +44,14 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [ ] Implement workflow operations: save/load, JSON import/export, template onboarding, shareable exports, and version diff viewer.
 - [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation.
 - [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
+- [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 
 ### Milestone 5 – Node Ecosystem & Integrations
 - [ ] Deliver trigger nodes (Webhook, Cron, Manual, HTTP Polling) with both UI and SDK parity.
-- [ ] Implement AI/LLM nodes (OpenAI, Anthropic, Custom Agent, Text Processing) with prompt management and latency guardrails.
+- [ ] Implement AI/LLM nodes (OpenAI, Anthropic, Custom Agent, Text Processing) with prompt management, MCP server connectivity, and latency guardrails.
 - [ ] Build Data & Logic nodes (HTTP Request, JSON Processing, Data Transform, If/Else, Switch, Merge, Set Variable) plus Storage/Communication nodes (MongoDB, PostgreSQL, SQLite, Email, Slack, Telegram, Discord).
 - [ ] Add utility nodes (Python/JavaScript execution sandbox, Delay, Debug, Sub-workflow orchestration) with tests, docs, and templates.
+- [ ] Introduce a Guardrails node with workflow evaluation hooks for runtime quality checks and compliance reporting.
 
 ### Milestone 6 – Observability, Testing & Launch Prep
 - [ ] Instrument execution viewer with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
@@ -64,4 +66,4 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ---
 
-_Last updated: 2025-09-28_
+_Last updated: 2025-10-05_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [ ] Deliver trigger layer covering webhook validation (verbs, filtering, rate limits), cron scheduler (timezone aware, overlap guards), manual/batch runs, and retry policies.
   - [x] Implement webhook trigger configuration with verb filtering, shared secrets, and rate limiting.
   - [x] Build cron scheduler supporting timezone-aware execution and overlap protection.
-  - [ ] Support manual and batch run dispatch from the trigger layer.
+  - [x] Support manual and batch run dispatch from the trigger layer.
   - [ ] Introduce configurable retry policies for trigger-driven runs.
 - [ ] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
 - [ ] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -6,6 +6,12 @@ from orcheo.triggers.cron import (
     CronTriggerState,
     CronValidationError,
 )
+from orcheo.triggers.manual import (
+    ManualDispatchItem,
+    ManualDispatchRequest,
+    ManualDispatchRun,
+    ManualDispatchValidationError,
+)
 from orcheo.triggers.webhook import (
     MethodNotAllowedError,
     RateLimitConfig,
@@ -22,6 +28,10 @@ __all__ = [
     "CronTriggerState",
     "CronValidationError",
     "CronOverlapError",
+    "ManualDispatchItem",
+    "ManualDispatchRequest",
+    "ManualDispatchRun",
+    "ManualDispatchValidationError",
     "RateLimitConfig",
     "WebhookRequest",
     "WebhookTriggerConfig",

--- a/src/orcheo/triggers/manual.py
+++ b/src/orcheo/triggers/manual.py
@@ -1,0 +1,118 @@
+"""Manual trigger request and dispatch utilities."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class ManualDispatchValidationError(ValueError):
+    """Raised when manual dispatch payloads fail validation."""
+
+
+@dataclass(slots=True)
+class ManualDispatchRun:
+    """Resolved manual dispatch entry targeting a workflow version."""
+
+    workflow_version_id: UUID
+    input_payload: dict[str, Any]
+
+
+class ManualDispatchItem(BaseModel):
+    """Single run request within a manual dispatch."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_version_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Optional workflow version identifier. When omitted the latest version "
+            "will be used."
+        ),
+    )
+    input_payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Payload supplied as the run's input context.",
+    )
+
+
+class ManualDispatchRequest(BaseModel):
+    """Batch of manual run dispatches for a workflow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: UUID = Field(description="Identifier of the workflow to execute.")
+    actor: str = Field(
+        default="manual",
+        description="Actor recorded in the workflow run audit trail.",
+    )
+    runs: list[ManualDispatchItem] = Field(
+        default_factory=list,
+        min_length=1,
+        max_length=100,
+        description="Collection of run requests to dispatch in order.",
+    )
+    label: str | None = Field(
+        default=None,
+        description=(
+            "Optional label describing the trigger source. When omitted a sensible "
+            "default is derived based on run count."
+        ),
+    )
+
+    @field_validator("actor")
+    @classmethod
+    def _normalize_actor(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            msg = "actor must be a non-empty string"
+            raise ManualDispatchValidationError(msg)
+        return normalized
+
+    @field_validator("label")
+    @classmethod
+    def _normalize_label(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            msg = "label must not be empty when provided"
+            raise ManualDispatchValidationError(msg)
+        return normalized
+
+    @model_validator(mode="after")
+    def _enforce_run_limit(self) -> ManualDispatchRequest:
+        if not self.runs:
+            msg = "at least one run must be provided"
+            raise ManualDispatchValidationError(msg)
+        return self
+
+    def trigger_label(self) -> str:
+        """Return the label recorded on dispatched runs."""
+        if self.label:
+            return self.label
+        return "manual" if len(self.runs) == 1 else "manual_batch"
+
+    def resolve_runs(
+        self, *, default_workflow_version_id: UUID
+    ) -> list[ManualDispatchRun]:
+        """Resolve each request against the provided default version."""
+        resolved: list[ManualDispatchRun] = []
+        for item in self.runs:
+            version_id = item.workflow_version_id or default_workflow_version_id
+            resolved.append(
+                ManualDispatchRun(
+                    workflow_version_id=version_id,
+                    input_payload=dict(item.input_payload),
+                )
+            )
+        return resolved
+
+
+__all__ = [
+    "ManualDispatchItem",
+    "ManualDispatchRequest",
+    "ManualDispatchRun",
+    "ManualDispatchValidationError",
+]

--- a/tests/backend/test_repository.py
+++ b/tests/backend/test_repository.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 import pytest
 from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.manual import ManualDispatchItem, ManualDispatchRequest
 from orcheo.triggers.webhook import WebhookTriggerConfig
 from orcheo_backend.app.repository import (
     InMemoryWorkflowRepository,
@@ -313,6 +314,136 @@ async def test_run_error_paths(repository: InMemoryWorkflowRepository) -> None:
 
     with pytest.raises(WorkflowRunNotFoundError):
         await repository.mark_run_cancelled(uuid4(), actor="actor", reason=None)
+
+
+@pytest.mark.asyncio()
+async def test_manual_dispatch_defaults_to_latest_version(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Manual dispatch without explicit version targets the latest one."""
+
+    workflow = await repository.create_workflow(
+        name="Manual Flow",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="author",
+    )
+    _ = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["start"], "edges": []},
+        metadata={},
+        notes=None,
+        created_by="author",
+    )
+    second_version = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["start", "end"], "edges": []},
+        metadata={},
+        notes=None,
+        created_by="author",
+    )
+
+    request = ManualDispatchRequest(
+        workflow_id=workflow.id,
+        actor="operator",
+        runs=[ManualDispatchItem(input_payload={"foo": "bar"})],
+    )
+
+    runs = await repository.dispatch_manual_runs(request)
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.triggered_by == "manual"
+    assert run.workflow_version_id == second_version.id
+    assert run.input_payload == {"foo": "bar"}
+
+    stored = await repository.get_run(run.id)
+    assert stored.audit_log[0].actor == "operator"
+
+
+@pytest.mark.asyncio()
+async def test_manual_dispatch_supports_batch_runs(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Batch dispatch respects explicit version overrides and ordering."""
+
+    workflow = await repository.create_workflow(
+        name="Batch Flow",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="author",
+    )
+    first_version = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["start"], "edges": []},
+        metadata={},
+        notes=None,
+        created_by="author",
+    )
+    second_version = await repository.create_version(
+        workflow.id,
+        graph={"nodes": ["start", "branch"], "edges": []},
+        metadata={},
+        notes=None,
+        created_by="author",
+    )
+
+    request = ManualDispatchRequest(
+        workflow_id=workflow.id,
+        actor="batcher",
+        runs=[
+            ManualDispatchItem(
+                workflow_version_id=first_version.id,
+                input_payload={"step": 1},
+            ),
+            ManualDispatchItem(
+                workflow_version_id=second_version.id,
+                input_payload={"step": 2},
+            ),
+        ],
+    )
+
+    runs = await repository.dispatch_manual_runs(request)
+    assert [run.triggered_by for run in runs] == ["manual_batch", "manual_batch"]
+    assert [run.workflow_version_id for run in runs] == [
+        first_version.id,
+        second_version.id,
+    ]
+    assert [run.input_payload for run in runs] == [{"step": 1}, {"step": 2}]
+
+
+@pytest.mark.asyncio()
+async def test_manual_dispatch_rejects_unknown_versions(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Dispatch raises when referencing missing versions or workflows."""
+
+    workflow = await repository.create_workflow(
+        name="Error Flow",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="author",
+    )
+
+    with pytest.raises(WorkflowVersionNotFoundError):
+        await repository.dispatch_manual_runs(
+            ManualDispatchRequest(
+                workflow_id=workflow.id,
+                actor="operator",
+                runs=[ManualDispatchItem(workflow_version_id=uuid4())],
+            )
+        )
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.dispatch_manual_runs(
+            ManualDispatchRequest(
+                workflow_id=uuid4(),
+                actor="operator",
+                runs=[ManualDispatchItem()],
+            )
+        )
 
 
 @pytest.mark.asyncio()

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -544,7 +544,7 @@ def test_webhook_trigger_accepts_non_json_body(api_client: TestClient) -> None:
     binary_payload = b"\xff\xfe"
     trigger_response = api_client.post(
         f"/api/workflows/{workflow_id}/triggers/webhook",
-        data=binary_payload,
+        content=binary_payload,
         headers={"Content-Type": "application/octet-stream"},
     )
     assert trigger_response.status_code == 202

--- a/tests/test_triggers_manual.py
+++ b/tests/test_triggers_manual.py
@@ -1,10 +1,8 @@
 """Unit tests covering manual trigger dispatch helpers."""
 
 from uuid import uuid4
-
 import pytest
 from pydantic import ValidationError
-
 from orcheo.triggers.manual import (
     ManualDispatchItem,
     ManualDispatchRequest,

--- a/tests/test_triggers_manual.py
+++ b/tests/test_triggers_manual.py
@@ -1,0 +1,114 @@
+"""Unit tests covering manual trigger dispatch helpers."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.triggers.manual import (
+    ManualDispatchItem,
+    ManualDispatchRequest,
+    ManualDispatchValidationError,
+)
+
+
+def test_manual_dispatch_trigger_label_defaults() -> None:
+    """Trigger label derives from run count when not provided."""
+
+    single = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[ManualDispatchItem()],
+    )
+    assert single.trigger_label() == "manual"
+
+    batch = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[ManualDispatchItem(), ManualDispatchItem()],
+    )
+    assert batch.trigger_label() == "manual_batch"
+
+    none_label = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[ManualDispatchItem()],
+        label=None,
+    )
+    assert none_label.label is None
+
+
+def test_manual_dispatch_trigger_label_override() -> None:
+    """Explicit labels take precedence over inferred ones."""
+
+    request = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[ManualDispatchItem()],
+        label="manual_debug",
+    )
+    assert request.trigger_label() == "manual_debug"
+
+
+def test_manual_dispatch_resolve_runs_applies_defaults() -> None:
+    """Run resolution applies the provided default version identifier."""
+
+    workflow_version = uuid4()
+    request = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[ManualDispatchItem(input_payload={"foo": "bar"})],
+    )
+
+    resolved = request.resolve_runs(default_workflow_version_id=workflow_version)
+    assert len(resolved) == 1
+    assert resolved[0].workflow_version_id == workflow_version
+    assert resolved[0].input_payload == {"foo": "bar"}
+
+
+def test_manual_dispatch_validators_enforce_non_empty_values() -> None:
+    """Validators trim values and reject empty actors or labels."""
+
+    request = ManualDispatchRequest(
+        workflow_id=uuid4(),
+        actor="  operator  ",
+        runs=[ManualDispatchItem()],
+        label="  custom  ",
+    )
+    assert request.actor == "operator"
+    assert request.label == "custom"
+
+    with pytest.raises(ValidationError) as actor_exc:
+        ManualDispatchRequest(
+            workflow_id=uuid4(),
+            actor="   ",
+            runs=[ManualDispatchItem()],
+        )
+    assert "actor must be a non-empty string" in actor_exc.value.errors()[0]["msg"]
+
+    with pytest.raises(ValidationError) as label_exc:
+        ManualDispatchRequest(
+            workflow_id=uuid4(),
+            actor="operator",
+            runs=[ManualDispatchItem()],
+            label="   ",
+        )
+    assert "label must not be empty when provided" in label_exc.value.errors()[0]["msg"]
+
+    with pytest.raises(ValidationError) as runs_exc:
+        ManualDispatchRequest(
+            workflow_id=uuid4(),
+            actor="operator",
+            runs=[],
+            label=None,
+        )
+    assert "at least 1 item" in runs_exc.value.errors()[0]["msg"]
+
+    manual = ManualDispatchRequest.model_construct(
+        workflow_id=uuid4(),
+        actor="operator",
+        runs=[],
+        label=None,
+    )
+    with pytest.raises(ManualDispatchValidationError):
+        manual._enforce_run_limit()


### PR DESCRIPTION
## Summary
- add manual trigger dispatch request models and exports
- extend the repository and API with manual and batch run dispatch support
- cover manual trigger flows with unit and API tests
- mark the manual trigger dispatch roadmap task as complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68eac20a6e008327b965bbacb5603983