### PR TITLE
Add retry policy helpers for trigger runs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,7 +29,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
   - [x] Implement webhook trigger configuration with verb filtering, shared secrets, and rate limiting.
   - [x] Build cron scheduler supporting timezone-aware execution and overlap protection.
   - [x] Support manual and batch run dispatch from the trigger layer.
-  - [ ] Introduce configurable retry policies for trigger-driven runs.
+  - [x] Introduce configurable retry policies for trigger-driven runs.
 - [ ] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
 - [ ] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.
 

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -12,6 +12,12 @@ from orcheo.triggers.manual import (
     ManualDispatchRun,
     ManualDispatchValidationError,
 )
+from orcheo.triggers.retry import (
+    RetryDecision,
+    RetryPolicyConfig,
+    RetryPolicyState,
+    RetryPolicyValidationError,
+)
 from orcheo.triggers.webhook import (
     MethodNotAllowedError,
     RateLimitConfig,
@@ -32,6 +38,10 @@ __all__ = [
     "ManualDispatchRequest",
     "ManualDispatchRun",
     "ManualDispatchValidationError",
+    "RetryPolicyConfig",
+    "RetryPolicyState",
+    "RetryPolicyValidationError",
+    "RetryDecision",
     "RateLimitConfig",
     "WebhookRequest",
     "WebhookTriggerConfig",

--- a/src/orcheo/triggers/retry.py
+++ b/src/orcheo/triggers/retry.py
@@ -1,0 +1,142 @@
+"""Retry policy configuration and scheduling helpers for trigger runs."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from random import Random
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RetryPolicyValidationError(ValueError):
+    """Raised when retry policy configuration cannot be validated."""
+
+
+class RetryPolicyConfig(BaseModel):
+    """Configuration describing retry behaviour for trigger-driven runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_attempts: int = Field(
+        default=3,
+        ge=1,
+        description="Total attempts including the initial execution.",
+    )
+    initial_delay_seconds: float = Field(
+        default=30.0,
+        ge=0.0,
+        description="Delay applied before the first retry attempt.",
+    )
+    backoff_factor: float = Field(
+        default=2.0,
+        ge=1.0,
+        description="Multiplier applied to the delay after each failed attempt.",
+    )
+    max_delay_seconds: float | None = Field(
+        default=300.0,
+        ge=0.0,
+        description="Optional ceiling for computed retry delays.",
+    )
+    jitter_factor: float = Field(
+        default=0.1,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Percentage of jitter applied to each delay. Values are expressed "
+            "as a fraction of the computed delay."
+        ),
+    )
+
+    def compute_delay_seconds(
+        self,
+        *,
+        attempt_index: int,
+        random_state: Random | None = None,
+    ) -> float:
+        """Return the delay in seconds before the provided retry attempt."""
+        if attempt_index < 0:
+            raise RetryPolicyValidationError("attempt_index must be non-negative")
+
+        delay = self.initial_delay_seconds * (self.backoff_factor**attempt_index)
+        if self.max_delay_seconds is not None:
+            delay = min(delay, self.max_delay_seconds)
+
+        jitter_factor = self.jitter_factor
+        if jitter_factor and delay:
+            rng = random_state or Random()
+            jitter_window = delay * jitter_factor
+            jitter = rng.uniform(-jitter_window, jitter_window)
+            delay = max(0.0, delay + jitter)
+
+        return delay
+
+
+@dataclass(slots=True)
+class RetryDecision:
+    """Represents a single retry attempt scheduling decision."""
+
+    retry_number: int
+    scheduled_for: datetime
+    delay_seconds: float
+
+
+class RetryPolicyState:
+    """Track retry attempts and compute scheduling decisions."""
+
+    def __init__(
+        self,
+        config: RetryPolicyConfig | None = None,
+        *,
+        random_state: Random | None = None,
+    ) -> None:
+        """Initialize the retry policy state with optional overrides."""
+        self._config = (config or RetryPolicyConfig()).model_copy(deep=True)
+        self._random = random_state or Random()
+        self._scheduled_retries = 0
+
+    @property
+    def config(self) -> RetryPolicyConfig:
+        """Return a deep copy of the retry configuration."""
+        return self._config.model_copy(deep=True)
+
+    @property
+    def remaining_attempts(self) -> int:
+        """Return the remaining retry attempts available."""
+        max_retries = max(self._config.max_attempts - 1, 0)
+        return max(0, max_retries - self._scheduled_retries)
+
+    def reset(self) -> None:
+        """Reset the retry tracker so a new run can start fresh."""
+        self._scheduled_retries = 0
+
+    def next_retry(
+        self,
+        *,
+        failed_at: datetime | None = None,
+    ) -> RetryDecision | None:
+        """Return the next retry decision or ``None`` when exhausted."""
+        if self.remaining_attempts <= 0:
+            return None
+
+        attempt_index = self._scheduled_retries
+        delay_seconds = self._config.compute_delay_seconds(
+            attempt_index=attempt_index,
+            random_state=self._random,
+        )
+
+        base_time = failed_at or datetime.now(tz=UTC)
+        scheduled_for = base_time + timedelta(seconds=delay_seconds)
+
+        self._scheduled_retries += 1
+        return RetryDecision(
+            retry_number=attempt_index + 1,
+            scheduled_for=scheduled_for,
+            delay_seconds=delay_seconds,
+        )
+
+
+__all__ = [
+    "RetryPolicyConfig",
+    "RetryPolicyState",
+    "RetryPolicyValidationError",
+    "RetryDecision",
+]

--- a/tests/test_triggers_retry.py
+++ b/tests/test_triggers_retry.py
@@ -1,0 +1,106 @@
+"""Unit tests for trigger retry policy helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from random import Random
+
+import pytest
+
+from orcheo.triggers import (
+    RetryDecision,
+    RetryPolicyConfig,
+    RetryPolicyState,
+    RetryPolicyValidationError,
+)
+
+
+def test_retry_policy_state_produces_bounded_schedule() -> None:
+    """Retry decisions should honour max attempts and backoff configuration."""
+
+    config = RetryPolicyConfig(
+        max_attempts=3,
+        initial_delay_seconds=10.0,
+        backoff_factor=2.0,
+        max_delay_seconds=25.0,
+        jitter_factor=0.0,
+    )
+    state = RetryPolicyState(config)
+    failure_time = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+
+    config_clone = state.config
+    assert config_clone is not config
+    assert config_clone == config
+
+    first = state.next_retry(failed_at=failure_time)
+    assert isinstance(first, RetryDecision)
+    assert first.retry_number == 1
+    assert first.delay_seconds == pytest.approx(10.0)
+    assert first.scheduled_for == failure_time + timedelta(seconds=10)
+    assert state.remaining_attempts == 1
+
+    second = state.next_retry(failed_at=failure_time)
+    assert second is not None
+    assert second.retry_number == 2
+    assert second.delay_seconds == pytest.approx(20.0)
+    assert second.scheduled_for == failure_time + timedelta(seconds=20)
+    assert state.remaining_attempts == 0
+
+    assert state.next_retry(failed_at=failure_time) is None
+
+
+def test_retry_policy_state_reset_allows_new_sequence() -> None:
+    """Resetting the state should make retries available again."""
+
+    state = RetryPolicyState(
+        RetryPolicyConfig(max_attempts=2, initial_delay_seconds=5.0, jitter_factor=0.0)
+    )
+    state.next_retry(failed_at=datetime.now(tz=UTC))
+    assert state.remaining_attempts == 0
+
+    state.reset()
+    assert state.remaining_attempts == 1
+
+
+def test_retry_policy_applies_deterministic_jitter() -> None:
+    """Providing a seeded RNG should yield deterministic jittered delays."""
+
+    config = RetryPolicyConfig(
+        max_attempts=2,
+        initial_delay_seconds=8.0,
+        jitter_factor=0.5,
+    )
+    state = RetryPolicyState(config, random_state=Random(7))
+    decision = state.next_retry(failed_at=datetime(2024, 5, 10, 12, tzinfo=UTC))
+    assert decision is not None
+    assert decision.delay_seconds == pytest.approx(6.590662118665299, rel=1e-9)
+    assert decision.scheduled_for.isoformat() == "2024-05-10T12:00:06.590662+00:00"
+
+
+def test_retry_policy_config_rejects_negative_attempt_index() -> None:
+    """Computing delays with a negative attempt index should fail."""
+
+    config = RetryPolicyConfig(initial_delay_seconds=1.0, jitter_factor=0.0)
+    with pytest.raises(RetryPolicyValidationError):
+        config.compute_delay_seconds(attempt_index=-1)
+
+
+def test_retry_policy_without_delay_cap() -> None:
+    """Policies without a delay cap should honour exponential backoff."""
+
+    config = RetryPolicyConfig(
+        max_attempts=3,
+        initial_delay_seconds=2.0,
+        backoff_factor=3.0,
+        max_delay_seconds=None,
+        jitter_factor=0.0,
+    )
+    state = RetryPolicyState(config)
+    failure_time = datetime(2024, 6, 1, 0, 0, tzinfo=UTC)
+
+    first = state.next_retry(failed_at=failure_time)
+    assert first is not None
+    assert first.delay_seconds == pytest.approx(2.0)
+    second = state.next_retry(failed_at=failure_time)
+    assert second is not None
+    assert second.delay_seconds == pytest.approx(6.0)


### PR DESCRIPTION
## Summary
- add reusable retry policy configuration and state helpers with jittered exponential backoff for trigger retries
- export the retry helpers through the triggers package and cover behaviour with dedicated tests
- mark the roadmap task for configurable trigger retry policies as complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68eb99b26144832783b30a32a6e5ff87