### PR TITLE
Add unified trigger layer and integrate repository orchestration

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -10,13 +10,11 @@ from difflib import unified_diff
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
-from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.cron import CronTriggerConfig
+from orcheo.triggers.layer import TriggerLayer
 from orcheo.triggers.manual import ManualDispatchRequest
-from orcheo.triggers.webhook import (
-    WebhookRequest,
-    WebhookTriggerConfig,
-    WebhookTriggerState,
-)
+from orcheo.triggers.retry import RetryDecision, RetryPolicyConfig
+from orcheo.triggers.webhook import WebhookRequest, WebhookTriggerConfig
 
 
 class RepositoryError(RuntimeError):
@@ -55,9 +53,7 @@ class InMemoryWorkflowRepository:
         self._versions: dict[UUID, WorkflowVersion] = {}
         self._runs: dict[UUID, WorkflowRun] = {}
         self._version_runs: dict[UUID, list[UUID]] = {}
-        self._webhook_states: dict[UUID, WebhookTriggerState] = {}
-        self._cron_states: dict[UUID, CronTriggerState] = {}
-        self._cron_run_index: dict[UUID, UUID] = {}
+        self._trigger_layer = TriggerLayer()
 
     async def list_workflows(self) -> list[Workflow]:
         """Return all workflows stored within the repository."""
@@ -332,8 +328,9 @@ class InMemoryWorkflowRepository:
         run.record_event(actor=actor or triggered_by, action="run_created")
         self._runs[run.id] = run
         self._version_runs.setdefault(workflow_version_id, []).append(run.id)
+        self._trigger_layer.track_run(workflow_id, run.id)
         if triggered_by == "cron":
-            self._cron_run_index[run.id] = workflow_id
+            self._trigger_layer.register_cron_run(run.id)
         return run
 
     async def _update_run(
@@ -364,6 +361,7 @@ class InMemoryWorkflowRepository:
             lambda run: run.mark_succeeded(actor=actor, output=output),
         )
         self._release_cron_run(run_id)
+        self._trigger_layer.clear_retry_state(run_id)
         return run
 
     async def mark_run_failed(
@@ -394,6 +392,7 @@ class InMemoryWorkflowRepository:
             lambda run: run.mark_cancelled(actor=actor, reason=reason),
         )
         self._release_cron_run(run_id)
+        self._trigger_layer.clear_retry_state(run_id)
         return run
 
     async def reset(self) -> None:
@@ -404,19 +403,11 @@ class InMemoryWorkflowRepository:
             self._versions.clear()
             self._runs.clear()
             self._version_runs.clear()
-            self._webhook_states.clear()
-            self._cron_states.clear()
-            self._cron_run_index.clear()
+            self._trigger_layer.reset()
 
     def _release_cron_run(self, run_id: UUID) -> None:
         """Release overlap tracking for the provided cron run."""
-        workflow_id = self._cron_run_index.pop(run_id, None)
-        if workflow_id is None:
-            return
-        state = self._cron_states.get(workflow_id)
-        if state is None:
-            return
-        state.release_run(run_id)
+        self._trigger_layer.release_cron_run(run_id)
 
     async def configure_webhook_trigger(
         self, workflow_id: UUID, config: WebhookTriggerConfig
@@ -425,9 +416,7 @@ class InMemoryWorkflowRepository:
         async with self._lock:
             if workflow_id not in self._workflows:
                 raise WorkflowNotFoundError(str(workflow_id))
-            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
-            state.update_config(config)
-            return state.config
+            return self._trigger_layer.configure_webhook(workflow_id, config)
 
     async def get_webhook_trigger_config(
         self, workflow_id: UUID
@@ -436,8 +425,7 @@ class InMemoryWorkflowRepository:
         async with self._lock:
             if workflow_id not in self._workflows:
                 raise WorkflowNotFoundError(str(workflow_id))
-            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
-            return state.config
+            return self._trigger_layer.get_webhook_config(workflow_id)
 
     async def handle_webhook_trigger(
         self,
@@ -463,7 +451,6 @@ class InMemoryWorkflowRepository:
             if version is None:
                 raise WorkflowVersionNotFoundError(str(latest_version_id))
 
-            state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
             request = WebhookRequest(
                 method=method,
                 headers=headers,
@@ -471,22 +458,16 @@ class InMemoryWorkflowRepository:
                 payload=payload,
                 source_ip=source_ip,
             )
-            state.validate(request)
-
-            normalized_payload = state.serialize_payload(payload)
-            run = WorkflowRun(
-                workflow_version_id=version.id,
-                triggered_by="webhook",
-                input_payload={
-                    "body": normalized_payload,
-                    "headers": request.normalized_headers(),
-                    "query_params": request.normalized_query(),
-                    "source_ip": source_ip,
-                },
+            dispatch = self._trigger_layer.prepare_webhook_dispatch(
+                workflow_id, request
             )
-            run.record_event(actor="webhook", action="run_created")
-            self._runs[run.id] = run
-            self._version_runs.setdefault(version.id, []).append(run.id)
+            run = self._create_run_locked(
+                workflow_id=workflow_id,
+                workflow_version_id=version.id,
+                triggered_by=dispatch.triggered_by,
+                input_payload=dispatch.input_payload,
+                actor=dispatch.actor,
+            )
             return run.model_copy(deep=True)
 
     async def configure_cron_trigger(
@@ -496,17 +477,14 @@ class InMemoryWorkflowRepository:
         async with self._lock:
             if workflow_id not in self._workflows:
                 raise WorkflowNotFoundError(str(workflow_id))
-            state = self._cron_states.setdefault(workflow_id, CronTriggerState())
-            state.update_config(config)
-            return state.config
+            return self._trigger_layer.configure_cron(workflow_id, config)
 
     async def get_cron_trigger_config(self, workflow_id: UUID) -> CronTriggerConfig:
         """Return the configured cron trigger definition."""
         async with self._lock:
             if workflow_id not in self._workflows:
                 raise WorkflowNotFoundError(str(workflow_id))
-            state = self._cron_states.setdefault(workflow_id, CronTriggerState())
-            return state.config
+            return self._trigger_layer.get_cron_config(workflow_id)
 
     async def dispatch_due_cron_runs(
         self, *, now: datetime | None = None
@@ -518,15 +496,11 @@ class InMemoryWorkflowRepository:
 
         async with self._lock:
             runs: list[WorkflowRun] = []
-            for workflow_id, state in self._cron_states.items():
+            plans = self._trigger_layer.collect_due_cron_dispatches(now=reference)
+            for plan in plans:
+                workflow_id = plan.workflow_id
                 if workflow_id not in self._workflows:
                     continue
-                due_at = state.peek_due(now=reference)
-                if due_at is None:
-                    continue
-                if not state.can_dispatch():
-                    continue
-
                 version_ids = self._workflow_versions.get(workflow_id)
                 if not version_ids:
                     continue
@@ -535,18 +509,16 @@ class InMemoryWorkflowRepository:
                 if version is None:
                     continue
 
-                fire_at = state.consume_due()
                 run = self._create_run_locked(
                     workflow_id=workflow_id,
                     workflow_version_id=version.id,
                     triggered_by="cron",
                     input_payload={
-                        "scheduled_for": fire_at.isoformat(),
-                        "timezone": state.config.timezone,
+                        "scheduled_for": plan.scheduled_for.isoformat(),
+                        "timezone": plan.timezone,
                     },
                     actor="cron",
                 )
-                state.register_run(run.id)
                 runs.append(run.model_copy(deep=True))
             return runs
 
@@ -564,11 +536,11 @@ class InMemoryWorkflowRepository:
 
             default_version_id = version_ids[-1]
             runs: list[WorkflowRun] = []
-            triggered_by = request.trigger_label()
-
-            resolved_runs = request.resolve_runs(
-                default_workflow_version_id=default_version_id
+            plan = self._trigger_layer.prepare_manual_dispatch(
+                request, default_workflow_version_id=default_version_id
             )
+            triggered_by = plan.triggered_by
+            resolved_runs = plan.runs
 
             for resolved in resolved_runs:
                 version = self._versions.get(resolved.workflow_version_id)
@@ -583,10 +555,35 @@ class InMemoryWorkflowRepository:
                     workflow_version_id=resolved.workflow_version_id,
                     triggered_by=triggered_by,
                     input_payload=resolved.input_payload,
-                    actor=request.actor,
+                    actor=plan.actor,
                 )
                 runs.append(run.model_copy(deep=True))
             return runs
+
+    async def configure_retry_policy(
+        self, workflow_id: UUID, config: RetryPolicyConfig
+    ) -> RetryPolicyConfig:
+        """Persist retry policy configuration for the workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            return self._trigger_layer.configure_retry_policy(workflow_id, config)
+
+    async def get_retry_policy_config(self, workflow_id: UUID) -> RetryPolicyConfig:
+        """Return the retry policy configuration for the workflow."""
+        async with self._lock:
+            if workflow_id not in self._workflows:
+                raise WorkflowNotFoundError(str(workflow_id))
+            return self._trigger_layer.get_retry_policy_config(workflow_id)
+
+    async def schedule_retry_for_run(
+        self, run_id: UUID, *, failed_at: datetime | None = None
+    ) -> RetryDecision | None:
+        """Return the next retry decision for the specified run."""
+        async with self._lock:
+            if run_id not in self._runs:
+                raise WorkflowRunNotFoundError(str(run_id))
+            return self._trigger_layer.next_retry_for_run(run_id, failed_at=failed_at)
 
 
 __all__ = [

--- a/apps/backend/src/orcheo_backend/app/repository.py
+++ b/apps/backend/src/orcheo_backend/app/repository.py
@@ -519,6 +519,7 @@ class InMemoryWorkflowRepository:
                     },
                     actor="cron",
                 )
+                self._trigger_layer.commit_cron_dispatch(workflow_id)
                 runs.append(run.model_copy(deep=True))
             return runs
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ### Milestone 2 – Backend Orchestration & Triggers
 - [x] Implement Python SDK with typed node authoring, local execution parity, and deployment hooks that sync with the server.
 - [x] Build FastAPI services for workflow CRUD, execution lifecycle, version diffing, and WebSocket streaming telemetry.
-- [ ] Deliver trigger layer covering webhook validation (verbs, filtering, rate limits), cron scheduler (timezone aware, overlap guards), manual/batch runs, and retry policies.
+- [x] Deliver trigger layer covering webhook validation (verbs, filtering, rate limits), cron scheduler (timezone aware, overlap guards), manual/batch runs, and retry policies.
   - [x] Implement webhook trigger configuration with verb filtering, shared secrets, and rate limiting.
   - [x] Build cron scheduler supporting timezone-aware execution and overlap protection.
   - [x] Support manual and batch run dispatch from the trigger layer.

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -6,6 +6,12 @@ from orcheo.triggers.cron import (
     CronTriggerState,
     CronValidationError,
 )
+from orcheo.triggers.layer import (
+    CronDispatchPlan,
+    ManualDispatchPlan,
+    TriggerDispatch,
+    TriggerLayer,
+)
 from orcheo.triggers.manual import (
     ManualDispatchItem,
     ManualDispatchRequest,
@@ -34,10 +40,12 @@ __all__ = [
     "CronTriggerState",
     "CronValidationError",
     "CronOverlapError",
+    "CronDispatchPlan",
     "ManualDispatchItem",
     "ManualDispatchRequest",
     "ManualDispatchRun",
     "ManualDispatchValidationError",
+    "ManualDispatchPlan",
     "RetryPolicyConfig",
     "RetryPolicyState",
     "RetryPolicyValidationError",
@@ -49,4 +57,6 @@ __all__ = [
     "MethodNotAllowedError",
     "WebhookAuthenticationError",
     "RateLimitExceededError",
+    "TriggerDispatch",
+    "TriggerLayer",
 ]

--- a/src/orcheo/triggers/__init__.py
+++ b/src/orcheo/triggers/__init__.py
@@ -9,6 +9,7 @@ from orcheo.triggers.cron import (
 from orcheo.triggers.layer import (
     CronDispatchPlan,
     ManualDispatchPlan,
+    StateCleanupConfig,
     TriggerDispatch,
     TriggerLayer,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "RetryPolicyValidationError",
     "RetryDecision",
     "RateLimitConfig",
+    "StateCleanupConfig",
     "WebhookRequest",
     "WebhookTriggerConfig",
     "WebhookValidationError",

--- a/src/orcheo/triggers/layer.py
+++ b/src/orcheo/triggers/layer.py
@@ -1,0 +1,230 @@
+"""Unified trigger orchestration layer for workflow executions."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.manual import ManualDispatchRequest, ManualDispatchRun
+from orcheo.triggers.retry import (
+    RetryDecision,
+    RetryPolicyConfig,
+    RetryPolicyState,
+)
+from orcheo.triggers.webhook import (
+    WebhookRequest,
+    WebhookTriggerConfig,
+    WebhookTriggerState,
+)
+
+
+@dataclass(slots=True)
+class TriggerDispatch:
+    """Represents a normalized trigger dispatch payload."""
+
+    triggered_by: str
+    actor: str
+    input_payload: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ManualDispatchPlan:
+    """Resolved manual dispatch plan for a workflow."""
+
+    triggered_by: str
+    actor: str
+    runs: list[ManualDispatchRun]
+
+
+@dataclass(slots=True)
+class CronDispatchPlan:
+    """Dispatch plan produced when a cron trigger is due."""
+
+    workflow_id: UUID
+    scheduled_for: datetime
+    timezone: str
+
+
+class TriggerLayer:
+    """Coordinate trigger configuration, validation, and dispatch state."""
+
+    def __init__(self) -> None:
+        """Initialize trigger state stores for the layer."""
+        self._webhook_states: dict[UUID, WebhookTriggerState] = {}
+        self._cron_states: dict[UUID, CronTriggerState] = {}
+        self._cron_run_index: dict[UUID, UUID] = {}
+        self._retry_configs: dict[UUID, RetryPolicyConfig] = {}
+        self._retry_states: dict[UUID, RetryPolicyState] = {}
+        self._run_workflows: dict[UUID, UUID] = {}
+
+    # ------------------------------------------------------------------
+    # Webhook triggers
+    # ------------------------------------------------------------------
+    def configure_webhook(
+        self, workflow_id: UUID, config: WebhookTriggerConfig
+    ) -> WebhookTriggerConfig:
+        """Persist webhook configuration for the workflow and return a copy."""
+        state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+        state.update_config(config)
+        return state.config
+
+    def get_webhook_config(self, workflow_id: UUID) -> WebhookTriggerConfig:
+        """Return the stored webhook configuration, creating defaults if needed."""
+        state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+        return state.config
+
+    def prepare_webhook_dispatch(
+        self, workflow_id: UUID, request: WebhookRequest
+    ) -> TriggerDispatch:
+        """Validate an inbound webhook request and return the dispatch payload."""
+        state = self._webhook_states.setdefault(workflow_id, WebhookTriggerState())
+        state.validate(request)
+
+        normalized_payload = state.serialize_payload(request.payload)
+        return TriggerDispatch(
+            triggered_by="webhook",
+            actor="webhook",
+            input_payload={
+                "body": normalized_payload,
+                "headers": request.normalized_headers(),
+                "query_params": request.normalized_query(),
+                "source_ip": request.source_ip,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Cron triggers
+    # ------------------------------------------------------------------
+    def configure_cron(
+        self, workflow_id: UUID, config: CronTriggerConfig
+    ) -> CronTriggerConfig:
+        """Persist cron configuration for the workflow and return a copy."""
+        state = self._cron_states.setdefault(workflow_id, CronTriggerState())
+        state.update_config(config)
+        return state.config
+
+    def get_cron_config(self, workflow_id: UUID) -> CronTriggerConfig:
+        """Return the stored cron configuration, creating defaults if needed."""
+        state = self._cron_states.setdefault(workflow_id, CronTriggerState())
+        return state.config
+
+    def collect_due_cron_dispatches(self, *, now: datetime) -> list[CronDispatchPlan]:
+        """Return cron dispatch plans that are due at the provided reference time."""
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=UTC)
+
+        plans: list[CronDispatchPlan] = []
+        for workflow_id, state in self._cron_states.items():
+            due_at = state.peek_due(now=now)
+            if due_at is None or not state.can_dispatch():
+                continue
+            scheduled_for = state.consume_due()
+            plans.append(
+                CronDispatchPlan(
+                    workflow_id=workflow_id,
+                    scheduled_for=scheduled_for,
+                    timezone=state.config.timezone,
+                )
+            )
+        return plans
+
+    def register_cron_run(self, run_id: UUID) -> None:
+        """Register a cron-triggered run so overlap guards are enforced."""
+        workflow_id = self._run_workflows.get(run_id)
+        if workflow_id is None:
+            return
+
+        state = self._cron_states.get(workflow_id)
+        self._cron_run_index[run_id] = workflow_id
+        if state is None:
+            return
+
+        state.register_run(run_id)
+
+    def release_cron_run(self, run_id: UUID) -> None:
+        """Release overlap tracking for the provided cron run."""
+        workflow_id = self._cron_run_index.pop(run_id, None)
+        if workflow_id is None:
+            return
+        state = self._cron_states.get(workflow_id)
+        if state is not None:
+            state.release_run(run_id)
+
+    # ------------------------------------------------------------------
+    # Manual triggers
+    # ------------------------------------------------------------------
+    def prepare_manual_dispatch(
+        self, request: ManualDispatchRequest, *, default_workflow_version_id: UUID
+    ) -> ManualDispatchPlan:
+        """Resolve manual dispatch runs and return the dispatch plan."""
+        resolved_runs = request.resolve_runs(
+            default_workflow_version_id=default_workflow_version_id
+        )
+        return ManualDispatchPlan(
+            triggered_by=request.trigger_label(),
+            actor=request.actor,
+            runs=resolved_runs,
+        )
+
+    # ------------------------------------------------------------------
+    # Retry policies
+    # ------------------------------------------------------------------
+    def configure_retry_policy(
+        self, workflow_id: UUID, config: RetryPolicyConfig
+    ) -> RetryPolicyConfig:
+        """Persist the retry policy configuration for a workflow."""
+        self._retry_configs[workflow_id] = config.model_copy(deep=True)
+        return self.get_retry_policy_config(workflow_id)
+
+    def get_retry_policy_config(self, workflow_id: UUID) -> RetryPolicyConfig:
+        """Return the retry policy configuration for the workflow."""
+        config = self._retry_configs.get(workflow_id)
+        if config is None:
+            config = RetryPolicyConfig()
+            self._retry_configs[workflow_id] = config
+        return config.model_copy(deep=True)
+
+    def track_run(self, workflow_id: UUID, run_id: UUID) -> None:
+        """Track a newly created run for cron overlap and retry scheduling."""
+        self._run_workflows[run_id] = workflow_id
+        config = self._retry_configs.get(workflow_id)
+        self._retry_states[run_id] = RetryPolicyState(config)
+
+    def next_retry_for_run(
+        self, run_id: UUID, *, failed_at: datetime | None = None
+    ) -> RetryDecision | None:
+        """Return the next retry decision for the provided run."""
+        state = self._retry_states.get(run_id)
+        if state is None:
+            return None
+        decision = state.next_retry(failed_at=failed_at)
+        if decision is None:
+            self._retry_states.pop(run_id, None)
+            self._run_workflows.pop(run_id, None)
+        return decision
+
+    def clear_retry_state(self, run_id: UUID) -> None:
+        """Remove retry tracking for the specified run."""
+        self._retry_states.pop(run_id, None)
+        self._run_workflows.pop(run_id, None)
+
+    # ------------------------------------------------------------------
+    # Reset helpers
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Clear all stored trigger state."""
+        self._webhook_states.clear()
+        self._cron_states.clear()
+        self._cron_run_index.clear()
+        self._retry_configs.clear()
+        self._retry_states.clear()
+        self._run_workflows.clear()
+
+
+__all__ = [
+    "CronDispatchPlan",
+    "ManualDispatchPlan",
+    "TriggerDispatch",
+    "TriggerLayer",
+]

--- a/tests/backend/test_repository.py
+++ b/tests/backend/test_repository.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import uuid4
 import pytest
-from orcheo.triggers.cron import CronTriggerConfig, CronTriggerState
+from orcheo.triggers.cron import CronTriggerConfig
+from orcheo.triggers.retry import RetryPolicyConfig
 from orcheo.triggers.manual import ManualDispatchItem, ManualDispatchRequest
 from orcheo.triggers.webhook import WebhookTriggerConfig
 from orcheo_backend.app.repository import (
@@ -447,6 +448,55 @@ async def test_manual_dispatch_rejects_unknown_versions(
 
 
 @pytest.mark.asyncio()
+async def test_configure_retry_policy_and_schedule_decision(
+    repository: InMemoryWorkflowRepository,
+) -> None:
+    """Retry policy configuration surfaces scheduling decisions."""
+
+    workflow = await repository.create_workflow(
+        name="Retry Flow",
+        slug=None,
+        description=None,
+        tags=None,
+        actor="owner",
+    )
+    version = await repository.create_version(
+        workflow.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    config = RetryPolicyConfig(
+        max_attempts=2,
+        initial_delay_seconds=10.0,
+        jitter_factor=0.0,
+    )
+    stored = await repository.configure_retry_policy(workflow.id, config)
+    assert stored.max_attempts == 2
+
+    run = await repository.create_run(
+        workflow.id,
+        workflow_version_id=version.id,
+        triggered_by="webhook",
+        input_payload={},
+        actor="tester",
+    )
+
+    first = await repository.schedule_retry_for_run(
+        run.id, failed_at=datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
+    )
+    assert first is not None
+    assert first.retry_number == 1
+
+    second = await repository.schedule_retry_for_run(
+        run.id, failed_at=datetime(2025, 1, 1, 10, 10, tzinfo=UTC)
+    )
+    assert second is None
+
+
+@pytest.mark.asyncio()
 async def test_create_run_with_cron_source_tracks_overlap(
     repository: InMemoryWorkflowRepository,
 ) -> None:
@@ -473,11 +523,11 @@ async def test_create_run_with_cron_source_tracks_overlap(
         triggered_by="cron",
         input_payload={},
     )
-    assert repository._cron_run_index[run.id] == workflow.id
+    assert repository._trigger_layer._cron_run_index[run.id] == workflow.id
 
     await repository.mark_run_started(run.id, actor="cron")
     await repository.mark_run_succeeded(run.id, actor="cron", output=None)
-    assert run.id not in repository._cron_run_index
+    assert run.id not in repository._trigger_layer._cron_run_index
 
 
 @pytest.mark.asyncio()
@@ -755,7 +805,7 @@ async def test_dispatch_due_cron_runs_handles_edge_cases(
     naive_now = datetime(2025, 1, 1, 11, 0)
 
     # Entry without a persisted workflow.
-    repository._cron_states[uuid4()] = CronTriggerState()
+    repository._trigger_layer.configure_cron(uuid4(), CronTriggerConfig())
 
     # Workflow without versions.
     workflow_without_versions = await repository.create_workflow(
@@ -765,8 +815,9 @@ async def test_dispatch_due_cron_runs_handles_edge_cases(
         tags=None,
         actor="owner",
     )
-    repository._cron_states[workflow_without_versions.id] = CronTriggerState(
-        CronTriggerConfig(expression="0 11 * * *", timezone="UTC")
+    repository._trigger_layer.configure_cron(
+        workflow_without_versions.id,
+        CronTriggerConfig(expression="0 11 * * *", timezone="UTC"),
     )
 
     # Workflow with a missing latest version object.
@@ -785,8 +836,9 @@ async def test_dispatch_due_cron_runs_handles_edge_cases(
         created_by="owner",
     )
     repository._versions.pop(orphaned_version.id)
-    repository._cron_states[workflow_missing_version.id] = CronTriggerState(
-        CronTriggerConfig(expression="0 11 * * *", timezone="UTC")
+    repository._trigger_layer.configure_cron(
+        workflow_missing_version.id,
+        CronTriggerConfig(expression="0 11 * * *", timezone="UTC"),
     )
 
     # Workflow that is not yet due.
@@ -804,8 +856,9 @@ async def test_dispatch_due_cron_runs_handles_edge_cases(
         notes=None,
         created_by="owner",
     )
-    repository._cron_states[workflow_not_due.id] = CronTriggerState(
-        CronTriggerConfig(expression="0 12 * * *", timezone="UTC")
+    repository._trigger_layer.configure_cron(
+        workflow_not_due.id,
+        CronTriggerConfig(expression="0 12 * * *", timezone="UTC"),
     )
 
     runs = await repository.dispatch_due_cron_runs(now=naive_now)
@@ -837,8 +890,9 @@ async def test_dispatch_due_cron_runs_respects_overlap_without_creating_runs(
         workflow.id,
         CronTriggerConfig(expression="0 7 * * *", timezone="UTC"),
     )
-    state = repository._cron_states[workflow.id]
-    state.register_run(uuid4())
+    active_run_id = uuid4()
+    repository._trigger_layer.track_run(workflow.id, active_run_id)
+    repository._trigger_layer.register_cron_run(active_run_id)
 
     runs = await repository.dispatch_due_cron_runs(
         now=datetime(2025, 1, 1, 7, 0, tzinfo=UTC)

--- a/tests/backend/test_repository.py
+++ b/tests/backend/test_repository.py
@@ -864,6 +864,21 @@ async def test_dispatch_due_cron_runs_handles_edge_cases(
     runs = await repository.dispatch_due_cron_runs(now=naive_now)
     assert runs == []
 
+    # Once the missing version is created the original occurrence is dispatched.
+    await repository.create_version(
+        workflow_without_versions.id,
+        graph={},
+        metadata={},
+        notes=None,
+        created_by="owner",
+    )
+
+    retried_runs = await repository.dispatch_due_cron_runs(
+        now=datetime(2025, 1, 1, 11, 0, tzinfo=UTC)
+    )
+    assert len(retried_runs) == 1
+    assert retried_runs[0].triggered_by == "cron"
+
 
 @pytest.mark.asyncio()
 async def test_dispatch_due_cron_runs_respects_overlap_without_creating_runs(

--- a/tests/test_triggers_layer.py
+++ b/tests/test_triggers_layer.py
@@ -18,6 +18,7 @@ from orcheo.triggers import (
     RateLimitConfig,
     RetryDecision,
     RetryPolicyConfig,
+    StateCleanupConfig,
     TriggerDispatch,
     TriggerLayer,
     WebhookRequest,
@@ -163,3 +164,232 @@ def test_retry_policy_decisions_are_tracked_per_run() -> None:
 
     # Additional cleanup should be idempotent once retries are exhausted.
     layer.clear_retry_state(run_id)
+
+
+def test_memory_management_and_cleanup() -> None:
+    """Memory management automatically cleans up expired states."""
+    
+    cleanup_config = StateCleanupConfig(
+        max_retry_states=2,
+        max_completed_workflows=1,
+        cleanup_interval_hours=0,  # Always cleanup
+        completed_workflow_ttl_hours=0,  # Immediate expiry
+    )
+    layer = TriggerLayer(cleanup_config)
+    
+    # Create some workflows and runs
+    workflow1 = uuid4()
+    workflow2 = uuid4()
+    workflow3 = uuid4()
+    
+    run1 = uuid4()
+    run2 = uuid4()
+    run3 = uuid4()
+    
+    # Track runs to trigger cleanup logic
+    layer.track_run(workflow1, run1)
+    layer.track_run(workflow2, run2)
+    
+    initial_metrics = layer.get_state_metrics()
+    assert initial_metrics["retry_states"] == 2
+    assert initial_metrics["run_workflows"] == 2
+    
+    # Clear first run (marks workflow as completed)
+    layer.clear_retry_state(run1)
+    
+    # Track third run, should trigger cleanup due to size limit
+    layer.track_run(workflow3, run3)
+    
+    final_metrics = layer.get_state_metrics()
+    # Should have cleaned up completed workflow due to TTL expiry
+    assert final_metrics["completed_workflows"] <= 1
+
+
+def test_workflow_removal() -> None:
+    """Workflow removal cleans up all associated state."""
+    
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+    run_id = uuid4()
+    
+    # Set up various states for the workflow
+    layer.configure_webhook(workflow_id, WebhookTriggerConfig())
+    layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
+    layer.configure_retry_policy(workflow_id, RetryPolicyConfig())
+    layer.track_run(workflow_id, run_id)
+    layer.register_cron_run(run_id)
+    
+    initial_metrics = layer.get_state_metrics()
+    assert initial_metrics["webhook_states"] == 1
+    assert initial_metrics["cron_states"] == 1
+    assert initial_metrics["retry_configs"] == 1
+    assert initial_metrics["retry_states"] == 1
+    assert initial_metrics["cron_run_index"] == 1
+    
+    # Remove workflow should clean up all state
+    layer.remove_workflow(workflow_id)
+    
+    final_metrics = layer.get_state_metrics()
+    assert final_metrics["webhook_states"] == 0
+    assert final_metrics["cron_states"] == 0
+    assert final_metrics["retry_configs"] == 0
+    assert final_metrics["retry_states"] == 0
+    assert final_metrics["cron_run_index"] == 0
+    assert final_metrics["completed_workflows"] == 1
+
+
+def test_state_metrics() -> None:
+    """State metrics accurately reflect current state."""
+    
+    layer = TriggerLayer()
+    
+    # Initially empty
+    metrics = layer.get_state_metrics()
+    assert all(count == 0 for count in metrics.values())
+    
+    # Add some state
+    workflow_id = uuid4()
+    run_id = uuid4()
+    
+    layer.configure_webhook(workflow_id, WebhookTriggerConfig())
+    layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
+    layer.track_run(workflow_id, run_id)
+    
+    metrics = layer.get_state_metrics()
+    assert metrics["webhook_states"] == 1
+    assert metrics["cron_states"] == 1
+    assert metrics["retry_states"] == 1
+    assert metrics["run_workflows"] == 1
+
+
+def test_error_handling_and_validation() -> None:
+    """Error handling validates inputs and logs appropriately."""
+    
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+    
+    # Test None validation for webhook dispatch
+    with pytest.raises(ValueError, match="workflow_id cannot be None"):
+        layer.prepare_webhook_dispatch(None, WebhookRequest())
+    
+    with pytest.raises(ValueError, match="request cannot be None"):
+        layer.prepare_webhook_dispatch(workflow_id, None)
+    
+    # Test None validation for cron dispatches
+    with pytest.raises(ValueError, match="now parameter cannot be None"):
+        layer.collect_due_cron_dispatches(now=None)
+    
+    with pytest.raises(ValueError, match="workflow_id cannot be None"):
+        layer.commit_cron_dispatch(None)
+    
+    # Test None validation for manual dispatch
+    with pytest.raises(ValueError, match="request cannot be None"):
+        layer.prepare_manual_dispatch(None, default_workflow_version_id=uuid4())
+    
+    with pytest.raises(ValueError, match="default_workflow_version_id cannot be None"):
+        layer.prepare_manual_dispatch(ManualDispatchRequest(workflow_id=workflow_id, actor="test"), default_workflow_version_id=None)
+    
+    # Test None validation for retry decisions
+    with pytest.raises(ValueError, match="run_id cannot be None"):
+        layer.next_retry_for_run(None)
+
+
+def test_malformed_configuration_handling() -> None:
+    """Malformed configurations are handled gracefully."""
+    
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+    
+    # Test invalid webhook request (missing required headers)
+    layer.configure_webhook(workflow_id, WebhookTriggerConfig(required_headers={"X-Auth": "secret"}))
+    
+    invalid_request = WebhookRequest(
+        method="POST",
+        headers={},  # Missing required header
+        payload={"test": "data"}
+    )
+    
+    # Should raise validation error from the underlying webhook state
+    with pytest.raises(Exception):  # Specific error type depends on webhook validation
+        layer.prepare_webhook_dispatch(workflow_id, invalid_request)
+
+
+def test_concurrent_access_patterns() -> None:
+    """Concurrent operations don't corrupt state."""
+    
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+    
+    # Configure cron trigger
+    layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
+    
+    # Simulate concurrent run registration attempts
+    run1 = uuid4()
+    run2 = uuid4()
+    
+    layer.track_run(workflow_id, run1)
+    layer.register_cron_run(run1)
+    
+    # Second run should fail due to overlap protection
+    layer.track_run(workflow_id, run2)
+    with pytest.raises(CronOverlapError):
+        layer.register_cron_run(run2)
+    
+    # State should remain consistent
+    metrics = layer.get_state_metrics()
+    assert metrics["cron_run_index"] == 1
+    assert metrics["retry_states"] == 2  # Both runs tracked for retry
+
+
+def test_edge_cases_and_missing_state() -> None:
+    """Edge cases with missing state are handled gracefully."""
+    
+    layer = TriggerLayer()
+    
+    # Operations on non-existent workflows/runs should not crash
+    non_existent_workflow = uuid4()
+    non_existent_run = uuid4()
+    
+    # These should not raise errors
+    layer.commit_cron_dispatch(non_existent_workflow)
+    layer.register_cron_run(non_existent_run)
+    layer.release_cron_run(non_existent_run)
+    layer.clear_retry_state(non_existent_run)
+    
+    # Should return None for missing retry state
+    assert layer.next_retry_for_run(non_existent_run) is None
+    
+    # Should return default configs for non-existent workflows
+    webhook_config = layer.get_webhook_config(non_existent_workflow)
+    assert isinstance(webhook_config, WebhookTriggerConfig)
+    
+    cron_config = layer.get_cron_config(non_existent_workflow)
+    assert isinstance(cron_config, CronTriggerConfig)
+    
+    retry_config = layer.get_retry_policy_config(non_existent_workflow)
+    assert isinstance(retry_config, RetryPolicyConfig)
+
+
+def test_cleanup_config_validation() -> None:
+    """StateCleanupConfig provides reasonable defaults and validation."""
+    
+    # Test default config
+    config = StateCleanupConfig()
+    assert config.max_retry_states > 0
+    assert config.max_completed_workflows > 0
+    assert config.cleanup_interval_hours > 0
+    assert config.completed_workflow_ttl_hours > 0
+    
+    # Test custom config
+    custom_config = StateCleanupConfig(
+        max_retry_states=100,
+        max_completed_workflows=50,
+        cleanup_interval_hours=2,
+        completed_workflow_ttl_hours=48
+    )
+    
+    layer = TriggerLayer(custom_config)
+    assert layer._cleanup_config.max_retry_states == 100
+    assert layer._cleanup_config.max_completed_workflows == 50
+    assert layer._cleanup_config.cleanup_interval_hours == 2
+    assert layer._cleanup_config.completed_workflow_ttl_hours == 48

--- a/tests/test_triggers_layer.py
+++ b/tests/test_triggers_layer.py
@@ -1,0 +1,160 @@
+"""End-to-end tests covering the unified trigger layer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.triggers import (
+    CronDispatchPlan,
+    CronOverlapError,
+    CronTriggerConfig,
+    ManualDispatchItem,
+    ManualDispatchPlan,
+    ManualDispatchRequest,
+    RateLimitConfig,
+    RetryDecision,
+    RetryPolicyConfig,
+    TriggerDispatch,
+    TriggerLayer,
+    WebhookRequest,
+    WebhookTriggerConfig,
+)
+
+
+def test_webhook_dispatch_validation_and_normalization() -> None:
+    """Webhook dispatch plans include normalized payload and metadata."""
+
+    workflow_id = uuid4()
+    layer = TriggerLayer()
+
+    config = WebhookTriggerConfig(
+        allowed_methods=["post"],
+        required_headers={"X-Auth": "secret"},
+        required_query_params={"team": "ops"},
+        rate_limit=RateLimitConfig(limit=10, interval_seconds=60),
+    )
+    stored = layer.configure_webhook(workflow_id, config)
+    assert stored.allowed_methods == ["POST"]
+
+    request = WebhookRequest(
+        method="POST",
+        headers={"X-Auth": "secret"},
+        query_params={"team": "ops"},
+        payload={"key": "value"},
+        source_ip="203.0.113.5",
+    )
+
+    dispatch = layer.prepare_webhook_dispatch(workflow_id, request)
+    assert isinstance(dispatch, TriggerDispatch)
+    assert dispatch.triggered_by == "webhook"
+    assert dispatch.actor == "webhook"
+    assert dispatch.input_payload["headers"]["x-auth"] == "secret"
+    assert dispatch.input_payload["query_params"] == {"team": "ops"}
+    assert dispatch.input_payload["source_ip"] == "203.0.113.5"
+
+
+def test_cron_dispatch_and_overlap_controls() -> None:
+    """Cron dispatch plans honour timezone and overlap guards."""
+
+    workflow_id = uuid4()
+    layer = TriggerLayer()
+    layer.configure_cron(
+        workflow_id,
+        CronTriggerConfig(expression="0 9 * * *", timezone="UTC"),
+    )
+
+    reference = datetime(2025, 1, 1, 9, 0, tzinfo=UTC)
+    plans = layer.collect_due_cron_dispatches(now=reference)
+    assert plans == [
+        CronDispatchPlan(
+            workflow_id=workflow_id,
+            scheduled_for=reference,
+            timezone="UTC",
+        )
+    ]
+
+    run_id = uuid4()
+    layer.track_run(workflow_id, run_id)
+    layer.register_cron_run(run_id)
+
+    with pytest.raises(CronOverlapError):
+        conflicting_run = uuid4()
+        layer.track_run(workflow_id, conflicting_run)
+        layer.register_cron_run(conflicting_run)
+
+    layer.release_cron_run(run_id)
+    next_plans = layer.collect_due_cron_dispatches(
+        now=datetime(2025, 1, 2, 9, 0, tzinfo=UTC)
+    )
+    assert next_plans[0].timezone == "UTC"
+
+
+def test_manual_dispatch_plan_resolution() -> None:
+    """Manual dispatch plans normalise actor, label, and run payloads."""
+
+    workflow_id = uuid4()
+    default_version = uuid4()
+    layer = TriggerLayer()
+
+    with pytest.raises(ValidationError):
+        ManualDispatchRequest(workflow_id=workflow_id, actor=" ", runs=[])
+
+    explicit_version = uuid4()
+    request = ManualDispatchRequest(
+        workflow_id=workflow_id,
+        actor="  ops  ",
+        runs=[
+            ManualDispatchItem(input_payload={"foo": "bar"}),
+            ManualDispatchItem(
+                workflow_version_id=explicit_version,
+                input_payload={"baz": 1},
+            ),
+        ],
+    )
+
+    plan = layer.prepare_manual_dispatch(
+        request, default_workflow_version_id=default_version
+    )
+    assert isinstance(plan, ManualDispatchPlan)
+    assert plan.actor == "ops"
+    assert plan.triggered_by == "manual_batch"
+    assert plan.runs[0].workflow_version_id == default_version
+    assert plan.runs[1].workflow_version_id == explicit_version
+
+
+def test_retry_policy_decisions_are_tracked_per_run() -> None:
+    """Retry decisions honour configured policy and clear exhausted state."""
+
+    workflow_id = uuid4()
+    layer = TriggerLayer()
+
+    config = RetryPolicyConfig(
+        max_attempts=2,
+        initial_delay_seconds=5.0,
+        jitter_factor=0.0,
+    )
+    layer.configure_retry_policy(workflow_id, config)
+    stored = layer.get_retry_policy_config(workflow_id)
+    assert stored.max_attempts == 2
+
+    run_id = uuid4()
+    layer.track_run(workflow_id, run_id)
+
+    first = layer.next_retry_for_run(
+        run_id, failed_at=datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+    )
+    assert isinstance(first, RetryDecision)
+    assert first.retry_number == 1
+    assert pytest.approx(first.delay_seconds) == 5.0
+
+    exhausted = layer.next_retry_for_run(
+        run_id, failed_at=datetime(2025, 1, 1, 12, 5, tzinfo=UTC)
+    )
+    assert exhausted is None
+
+    # Additional cleanup should be idempotent once retries are exhausted.
+    layer.clear_retry_state(run_id)

--- a/tests/test_triggers_layer.py
+++ b/tests/test_triggers_layer.py
@@ -1,13 +1,10 @@
 """End-to-end tests covering the unified trigger layer."""
 
 from __future__ import annotations
-
-from datetime import UTC, datetime
-from uuid import uuid4
-
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
 import pytest
 from pydantic import ValidationError
-
 from orcheo.triggers import (
     CronDispatchPlan,
     CronOverlapError,
@@ -15,6 +12,7 @@ from orcheo.triggers import (
     ManualDispatchItem,
     ManualDispatchPlan,
     ManualDispatchRequest,
+    ManualDispatchValidationError,
     RateLimitConfig,
     RetryDecision,
     RetryPolicyConfig,
@@ -23,6 +21,7 @@ from orcheo.triggers import (
     TriggerLayer,
     WebhookRequest,
     WebhookTriggerConfig,
+    WebhookValidationError,
 )
 
 
@@ -168,7 +167,7 @@ def test_retry_policy_decisions_are_tracked_per_run() -> None:
 
 def test_memory_management_and_cleanup() -> None:
     """Memory management automatically cleans up expired states."""
-    
+
     cleanup_config = StateCleanupConfig(
         max_retry_states=2,
         max_completed_workflows=1,
@@ -176,30 +175,30 @@ def test_memory_management_and_cleanup() -> None:
         completed_workflow_ttl_hours=0,  # Immediate expiry
     )
     layer = TriggerLayer(cleanup_config)
-    
+
     # Create some workflows and runs
     workflow1 = uuid4()
     workflow2 = uuid4()
     workflow3 = uuid4()
-    
+
     run1 = uuid4()
     run2 = uuid4()
     run3 = uuid4()
-    
+
     # Track runs to trigger cleanup logic
     layer.track_run(workflow1, run1)
     layer.track_run(workflow2, run2)
-    
+
     initial_metrics = layer.get_state_metrics()
     assert initial_metrics["retry_states"] == 2
     assert initial_metrics["run_workflows"] == 2
-    
+
     # Clear first run (marks workflow as completed)
     layer.clear_retry_state(run1)
-    
+
     # Track third run, should trigger cleanup due to size limit
     layer.track_run(workflow3, run3)
-    
+
     final_metrics = layer.get_state_metrics()
     # Should have cleaned up completed workflow due to TTL expiry
     assert final_metrics["completed_workflows"] <= 1
@@ -207,28 +206,28 @@ def test_memory_management_and_cleanup() -> None:
 
 def test_workflow_removal() -> None:
     """Workflow removal cleans up all associated state."""
-    
+
     layer = TriggerLayer()
     workflow_id = uuid4()
     run_id = uuid4()
-    
+
     # Set up various states for the workflow
     layer.configure_webhook(workflow_id, WebhookTriggerConfig())
     layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
     layer.configure_retry_policy(workflow_id, RetryPolicyConfig())
     layer.track_run(workflow_id, run_id)
     layer.register_cron_run(run_id)
-    
+
     initial_metrics = layer.get_state_metrics()
     assert initial_metrics["webhook_states"] == 1
     assert initial_metrics["cron_states"] == 1
     assert initial_metrics["retry_configs"] == 1
     assert initial_metrics["retry_states"] == 1
     assert initial_metrics["cron_run_index"] == 1
-    
+
     # Remove workflow should clean up all state
     layer.remove_workflow(workflow_id)
-    
+
     final_metrics = layer.get_state_metrics()
     assert final_metrics["webhook_states"] == 0
     assert final_metrics["cron_states"] == 0
@@ -240,21 +239,21 @@ def test_workflow_removal() -> None:
 
 def test_state_metrics() -> None:
     """State metrics accurately reflect current state."""
-    
+
     layer = TriggerLayer()
-    
+
     # Initially empty
     metrics = layer.get_state_metrics()
     assert all(count == 0 for count in metrics.values())
-    
+
     # Add some state
     workflow_id = uuid4()
     run_id = uuid4()
-    
+
     layer.configure_webhook(workflow_id, WebhookTriggerConfig())
     layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
     layer.track_run(workflow_id, run_id)
-    
+
     metrics = layer.get_state_metrics()
     assert metrics["webhook_states"] == 1
     assert metrics["cron_states"] == 1
@@ -264,31 +263,46 @@ def test_state_metrics() -> None:
 
 def test_error_handling_and_validation() -> None:
     """Error handling validates inputs and logs appropriately."""
-    
+
     layer = TriggerLayer()
     workflow_id = uuid4()
-    
+
     # Test None validation for webhook dispatch
     with pytest.raises(ValueError, match="workflow_id cannot be None"):
-        layer.prepare_webhook_dispatch(None, WebhookRequest())
-    
+        layer.prepare_webhook_dispatch(
+            None,
+            WebhookRequest(
+                method="POST",
+                headers={},
+                query_params={},
+                payload=None,
+            ),
+        )
+
     with pytest.raises(ValueError, match="request cannot be None"):
         layer.prepare_webhook_dispatch(workflow_id, None)
-    
+
     # Test None validation for cron dispatches
     with pytest.raises(ValueError, match="now parameter cannot be None"):
         layer.collect_due_cron_dispatches(now=None)
-    
+
     with pytest.raises(ValueError, match="workflow_id cannot be None"):
         layer.commit_cron_dispatch(None)
-    
+
     # Test None validation for manual dispatch
     with pytest.raises(ValueError, match="request cannot be None"):
         layer.prepare_manual_dispatch(None, default_workflow_version_id=uuid4())
-    
+
     with pytest.raises(ValueError, match="default_workflow_version_id cannot be None"):
-        layer.prepare_manual_dispatch(ManualDispatchRequest(workflow_id=workflow_id, actor="test"), default_workflow_version_id=None)
-    
+        layer.prepare_manual_dispatch(
+            ManualDispatchRequest(
+                workflow_id=workflow_id,
+                actor="test",
+                runs=[ManualDispatchItem()],
+            ),
+            default_workflow_version_id=None,
+        )
+
     # Test None validation for retry decisions
     with pytest.raises(ValueError, match="run_id cannot be None"):
         layer.next_retry_for_run(None)
@@ -296,98 +310,230 @@ def test_error_handling_and_validation() -> None:
 
 def test_malformed_configuration_handling() -> None:
     """Malformed configurations are handled gracefully."""
-    
+
     layer = TriggerLayer()
     workflow_id = uuid4()
-    
+
     # Test invalid webhook request (missing required headers)
-    layer.configure_webhook(workflow_id, WebhookTriggerConfig(required_headers={"X-Auth": "secret"}))
-    
+    layer.configure_webhook(
+        workflow_id, WebhookTriggerConfig(required_headers={"X-Auth": "secret"})
+    )
+
     invalid_request = WebhookRequest(
         method="POST",
         headers={},  # Missing required header
-        payload={"test": "data"}
+        query_params={},
+        payload={"test": "data"},
     )
-    
+
     # Should raise validation error from the underlying webhook state
-    with pytest.raises(Exception):  # Specific error type depends on webhook validation
+    with pytest.raises(WebhookValidationError):
         layer.prepare_webhook_dispatch(workflow_id, invalid_request)
 
 
 def test_concurrent_access_patterns() -> None:
     """Concurrent operations don't corrupt state."""
-    
+
     layer = TriggerLayer()
     workflow_id = uuid4()
-    
+
     # Configure cron trigger
     layer.configure_cron(workflow_id, CronTriggerConfig(expression="0 9 * * *"))
-    
+
     # Simulate concurrent run registration attempts
     run1 = uuid4()
     run2 = uuid4()
-    
+
     layer.track_run(workflow_id, run1)
     layer.register_cron_run(run1)
-    
+
     # Second run should fail due to overlap protection
     layer.track_run(workflow_id, run2)
     with pytest.raises(CronOverlapError):
         layer.register_cron_run(run2)
-    
+
     # State should remain consistent
     metrics = layer.get_state_metrics()
     assert metrics["cron_run_index"] == 1
     assert metrics["retry_states"] == 2  # Both runs tracked for retry
 
 
+def test_collect_due_cron_dispatches_handles_naive_datetime_and_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cron dispatch collection normalizes naive timestamps and logs failures."""
+
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+
+    class ExplodingState:
+        config = CronTriggerConfig(expression="0 0 * * *", timezone="UTC")
+
+        def peek_due(self, *, now: datetime) -> datetime:
+            raise RuntimeError("boom")
+
+        def can_dispatch(self) -> bool:
+            return True
+
+    layer._cron_states[workflow_id] = ExplodingState()
+    naive_now = datetime(2025, 1, 1, 0, 0)
+
+    with caplog.at_level("ERROR"):
+        plans = layer.collect_due_cron_dispatches(now=naive_now)
+
+    assert plans == []
+    assert any("Error checking cron dispatch" in message for message in caplog.messages)
+
+
+def test_commit_cron_dispatch_logs_and_reraises_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Commit failures propagate after being logged."""
+
+    layer = TriggerLayer()
+    workflow_id = uuid4()
+
+    class FailingState:
+        def consume_due(self) -> None:
+            raise RuntimeError("consume failed")
+
+    layer._cron_states[workflow_id] = FailingState()
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError):
+            layer.commit_cron_dispatch(workflow_id)
+
+    assert any("Failed to commit cron dispatch" in msg for msg in caplog.messages)
+
+
+def test_prepare_manual_dispatch_logs_and_reraises_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Manual dispatch preparation surfaces resolution failures."""
+
+    layer = TriggerLayer()
+    default_version_id = uuid4()
+
+    class BrokenRequest:
+        actor = "manual"
+
+        def trigger_label(self) -> str:
+            return "manual"
+
+        def resolve_runs(self, *, default_workflow_version_id: UUID) -> None:
+            raise ManualDispatchValidationError("broken request")
+
+    request = BrokenRequest()
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ManualDispatchValidationError):
+            layer.prepare_manual_dispatch(
+                request, default_workflow_version_id=default_version_id
+            )
+
+    assert any("Failed to prepare manual dispatch" in msg for msg in caplog.messages)
+
+
+def test_next_retry_for_run_logs_and_reraises_state_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retry state errors are logged and re-raised."""
+
+    layer = TriggerLayer()
+    run_id = uuid4()
+    workflow_id = uuid4()
+
+    class FailingRetryState:
+        def next_retry(self, *, failed_at: datetime | None) -> None:
+            raise RuntimeError("retry failure")
+
+    layer._retry_states[run_id] = FailingRetryState()
+    layer._run_workflows[run_id] = workflow_id
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError):
+            layer.next_retry_for_run(run_id)
+
+    assert any("Error computing retry decision" in msg for msg in caplog.messages)
+
+
+def test_cleanup_completed_workflows_removes_expired_and_oldest(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cleanup removes expired entries and trims excess workflows."""
+
+    config = StateCleanupConfig(
+        cleanup_interval_hours=1,
+        max_retry_states=10,
+        max_completed_workflows=1,
+        completed_workflow_ttl_hours=1,
+    )
+    layer = TriggerLayer(cleanup_config=config)
+    now = datetime.now(tz=UTC)
+    expired_workflow = uuid4()
+    recent_one = uuid4()
+    recent_two = uuid4()
+    layer._completed_workflows = {
+        expired_workflow: now - timedelta(hours=2),
+        recent_one: now - timedelta(minutes=30),
+        recent_two: now - timedelta(minutes=10),
+    }
+
+    with caplog.at_level("INFO"):
+        layer._cleanup_completed_workflows(now)
+
+    assert expired_workflow not in layer._completed_workflows
+    assert len(layer._completed_workflows) == 1
+    assert any("Cleaned up" in msg for msg in caplog.messages)
+
+
 def test_edge_cases_and_missing_state() -> None:
     """Edge cases with missing state are handled gracefully."""
-    
+
     layer = TriggerLayer()
-    
+
     # Operations on non-existent workflows/runs should not crash
     non_existent_workflow = uuid4()
     non_existent_run = uuid4()
-    
+
     # These should not raise errors
     layer.commit_cron_dispatch(non_existent_workflow)
     layer.register_cron_run(non_existent_run)
     layer.release_cron_run(non_existent_run)
     layer.clear_retry_state(non_existent_run)
-    
+
     # Should return None for missing retry state
     assert layer.next_retry_for_run(non_existent_run) is None
-    
+
     # Should return default configs for non-existent workflows
     webhook_config = layer.get_webhook_config(non_existent_workflow)
     assert isinstance(webhook_config, WebhookTriggerConfig)
-    
+
     cron_config = layer.get_cron_config(non_existent_workflow)
     assert isinstance(cron_config, CronTriggerConfig)
-    
+
     retry_config = layer.get_retry_policy_config(non_existent_workflow)
     assert isinstance(retry_config, RetryPolicyConfig)
 
 
 def test_cleanup_config_validation() -> None:
     """StateCleanupConfig provides reasonable defaults and validation."""
-    
+
     # Test default config
     config = StateCleanupConfig()
     assert config.max_retry_states > 0
     assert config.max_completed_workflows > 0
     assert config.cleanup_interval_hours > 0
     assert config.completed_workflow_ttl_hours > 0
-    
+
     # Test custom config
     custom_config = StateCleanupConfig(
         max_retry_states=100,
         max_completed_workflows=50,
         cleanup_interval_hours=2,
-        completed_workflow_ttl_hours=48
+        completed_workflow_ttl_hours=48,
     )
-    
+
     layer = TriggerLayer(custom_config)
     assert layer._cleanup_config.max_retry_states == 100
     assert layer._cleanup_config.max_completed_workflows == 50

--- a/tests/test_triggers_layer.py
+++ b/tests/test_triggers_layer.py
@@ -77,6 +77,10 @@ def test_cron_dispatch_and_overlap_controls() -> None:
         )
     ]
 
+    # Cron occurrences remain pending until they are explicitly committed.
+    repeat_plans = layer.collect_due_cron_dispatches(now=reference)
+    assert repeat_plans == plans
+
     run_id = uuid4()
     layer.track_run(workflow_id, run_id)
     layer.register_cron_run(run_id)
@@ -86,6 +90,7 @@ def test_cron_dispatch_and_overlap_controls() -> None:
         layer.track_run(workflow_id, conflicting_run)
         layer.register_cron_run(conflicting_run)
 
+    layer.commit_cron_dispatch(workflow_id)
     layer.release_cron_run(run_id)
     next_plans = layer.collect_due_cron_dispatches(
         now=datetime(2025, 1, 2, 9, 0, tzinfo=UTC)

--- a/tests/test_triggers_retry.py
+++ b/tests/test_triggers_retry.py
@@ -1,12 +1,9 @@
 """Unit tests for trigger retry policy helpers."""
 
 from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from random import Random
-
 import pytest
-
 from orcheo.triggers import (
     RetryDecision,
     RetryPolicyConfig,


### PR DESCRIPTION
## Summary
- add a TriggerLayer module that unifies webhook, cron, manual, and retry trigger orchestration
- integrate the backend repository with the new trigger layer and expose retry policy helpers
- cover the trigger layer with unit tests, extend repository tests, and mark the roadmap task complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ebbfd396f483279e121ce3f3c8299d