### PR TITLE
Add retry policy configuration API support

### DIFF
--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -25,7 +25,6 @@ from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
 from orcheo.persistence import create_checkpointer
 from orcheo.triggers.cron import CronTriggerConfig
 from orcheo.triggers.manual import ManualDispatchRequest
-from orcheo.triggers.retry import RetryPolicyConfig
 from orcheo.triggers.webhook import WebhookTriggerConfig, WebhookValidationError
 from orcheo_backend.app.repository import (
     InMemoryWorkflowRepository,
@@ -559,9 +558,9 @@ async def configure_retry_policy(
 ) -> RetryPolicyConfigResponse:
     """Persist retry policy configuration for a workflow."""
     try:
-        config = RetryPolicyConfig(**request.model_dump())
+        config = request.to_domain_model()
         stored = await repository.configure_retry_policy(workflow_id, config)
-        return RetryPolicyConfigResponse(**stored.model_dump())
+        return RetryPolicyConfigResponse.from_domain_model(stored)
     except WorkflowNotFoundError as exc:
         _raise_not_found("Workflow not found", exc)
 
@@ -577,7 +576,7 @@ async def get_retry_policy_config(
     """Return the retry policy configuration for the workflow."""
     try:
         config = await repository.get_retry_policy_config(workflow_id)
-        return RetryPolicyConfigResponse(**config.model_dump())
+        return RetryPolicyConfigResponse.from_domain_model(config)
     except WorkflowNotFoundError as exc:
         _raise_not_found("Workflow not found", exc)
 

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 from uuid import UUID
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+from orcheo.triggers.retry import RetryPolicyConfig
 
 
 class WorkflowCreateRequest(BaseModel):
@@ -85,6 +86,8 @@ class CronDispatchRequest(BaseModel):
 class RetryPolicyConfigBase(BaseModel):
     """Shared fields for retry policy configuration payloads."""
 
+    model_config = ConfigDict(extra="forbid")
+
     max_attempts: int = Field(
         default=3,
         ge=1,
@@ -119,6 +122,15 @@ class RetryPolicyConfigBase(BaseModel):
 class RetryPolicyConfigRequest(RetryPolicyConfigBase):
     """Payload for configuring retry policy settings."""
 
+    def to_domain_model(self) -> RetryPolicyConfig:
+        """Convert the request payload into the domain configuration model."""
+        return RetryPolicyConfig.model_validate(self.model_dump())
+
 
 class RetryPolicyConfigResponse(RetryPolicyConfigBase):
     """Response body containing retry policy configuration."""
+
+    @classmethod
+    def from_domain_model(cls, config: RetryPolicyConfig) -> RetryPolicyConfigResponse:
+        """Construct a response payload from the domain configuration."""
+        return cls.model_validate(config.model_dump())

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -80,3 +80,45 @@ class CronDispatchRequest(BaseModel):
     """Request body for dispatching cron triggers."""
 
     now: datetime | None = None
+
+
+class RetryPolicyConfigBase(BaseModel):
+    """Shared fields for retry policy configuration payloads."""
+
+    max_attempts: int = Field(
+        default=3,
+        ge=1,
+        description="Total attempts including the initial execution.",
+    )
+    initial_delay_seconds: float = Field(
+        default=30.0,
+        ge=0.0,
+        description="Delay applied before the first retry attempt.",
+    )
+    backoff_factor: float = Field(
+        default=2.0,
+        ge=1.0,
+        description="Multiplier applied to the delay after each failed attempt.",
+    )
+    max_delay_seconds: float | None = Field(
+        default=300.0,
+        ge=0.0,
+        description="Optional ceiling for computed retry delays.",
+    )
+    jitter_factor: float = Field(
+        default=0.1,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Percentage of jitter applied to each delay as a fraction of the "
+            "computed delay."
+        ),
+    )
+
+
+class RetryPolicyConfigRequest(RetryPolicyConfigBase):
+    """Payload for configuring retry policy settings."""
+
+
+class RetryPolicyConfigResponse(RetryPolicyConfigBase):
+    """Response body containing retry policy configuration."""


### PR DESCRIPTION
## Summary
- add Pydantic request/response schemas for retry policy configuration
- extend the repository and FastAPI app to persist and expose retry policy settings
- cover the new retry policy routes with repository-based API tests

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ec06ab57688327bf29578e9ca4b864