### PR TITLE
Add retry scheduling for failed workflow runs

### DIFF
--- a/src/orcheo/models/workflow.py
+++ b/src/orcheo/models/workflow.py
@@ -147,6 +147,10 @@ class WorkflowRun(TimestampedAuditModel):
     started_at: datetime | None = None
     completed_at: datetime | None = None
     error: str | None = None
+    attempt_number: int = Field(default=1, ge=1)
+    retry_parent_run_id: UUID | None = None
+    retry_root_run_id: UUID | None = None
+    retry_scheduled_for: datetime | None = None
 
     def mark_started(self, *, actor: str) -> None:
         """Transition the run into the running state."""


### PR DESCRIPTION
## Summary
- track retry metadata on workflow runs and repository state so failed attempts can be rescheduled
- reschedule failed runs with trigger-aware retry logic and audit events while clearing retry state on terminal outcomes
- expand repository tests to cover retry scheduling, attempt exhaustion, and cron overlap handling

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ec06c0187083279575c23b32988cc2