### PR TITLE
Add execution history APIs and advanced graph features

### DIFF
--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -170,6 +170,12 @@ async def execute_workflow(
                 except Exception as exc:  # pragma: no cover
                     logger.error("Error processing messages: %s", exc)
                     raise
+        except asyncio.CancelledError as exc:
+            reason = str(exc) or "Workflow execution cancelled"
+            cancellation_payload = {"status": "cancelled", "reason": reason}
+            await history_store.append_step(execution_id, cancellation_payload)
+            await history_store.mark_cancelled(execution_id, reason=reason)
+            raise
         except Exception as exc:
             error_payload = {"status": "error", "error": str(exc)}
             await history_store.append_step(execution_id, error_payload)

--- a/apps/backend/src/orcheo_backend/app/history.py
+++ b/apps/backend/src/orcheo_backend/app/history.py
@@ -1,0 +1,144 @@
+"""In-memory storage for workflow execution history and replay data."""
+
+from __future__ import annotations
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+    return datetime.now(tz=UTC)
+
+
+class RunHistoryError(RuntimeError):
+    """Base error raised for run history store issues."""
+
+
+class RunHistoryNotFoundError(RunHistoryError):
+    """Raised when requesting history for an unknown execution."""
+
+
+class RunHistoryStep(BaseModel):
+    """Single step captured during workflow execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    index: int
+    at: datetime = Field(default_factory=_utcnow)
+    payload: dict[str, Any]
+
+
+class RunHistoryRecord(BaseModel):
+    """Complete history for a workflow execution."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    workflow_id: str
+    execution_id: str
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    status: str = "running"
+    started_at: datetime = Field(default_factory=_utcnow)
+    completed_at: datetime | None = None
+    error: str | None = None
+    steps: list[RunHistoryStep] = Field(default_factory=list)
+
+    def append_step(self, payload: Mapping[str, Any]) -> RunHistoryStep:
+        """Append a step to the history with an auto-incremented index."""
+        step = RunHistoryStep(index=len(self.steps), payload=dict(payload))
+        self.steps.append(step)
+        return step
+
+    def mark_completed(self) -> None:
+        """Mark the execution as successfully completed."""
+        self.status = "completed"
+        self.completed_at = _utcnow()
+        self.error = None
+
+    def mark_failed(self, error: str) -> None:
+        """Mark the execution as failed with the provided error."""
+        self.status = "error"
+        self.completed_at = _utcnow()
+        self.error = error
+
+
+class InMemoryRunHistoryStore:
+    """Async-safe in-memory store for execution histories."""
+
+    def __init__(self) -> None:
+        """Initialize the in-memory store."""
+        self._lock = asyncio.Lock()
+        self._histories: dict[str, RunHistoryRecord] = {}
+
+    async def start_run(
+        self,
+        *,
+        workflow_id: str,
+        execution_id: str,
+        inputs: Mapping[str, Any] | None = None,
+    ) -> RunHistoryRecord:
+        """Initialise a history record for the provided execution."""
+        async with self._lock:
+            if execution_id in self._histories:
+                msg = f"History already exists for execution_id={execution_id}"
+                raise RunHistoryError(msg)
+
+            record = RunHistoryRecord(
+                workflow_id=workflow_id,
+                execution_id=execution_id,
+                inputs=dict(inputs or {}),
+            )
+            self._histories[execution_id] = record
+            return record.model_copy(deep=True)
+
+    async def append_step(
+        self, execution_id: str, payload: Mapping[str, Any]
+    ) -> RunHistoryStep:
+        """Append a step for the execution."""
+        async with self._lock:
+            record = self._require_record(execution_id)
+            return record.append_step(payload)
+
+    async def mark_completed(self, execution_id: str) -> RunHistoryRecord:
+        """Mark the execution as completed."""
+        async with self._lock:
+            record = self._require_record(execution_id)
+            record.mark_completed()
+            return record.model_copy(deep=True)
+
+    async def mark_failed(self, execution_id: str, error: str) -> RunHistoryRecord:
+        """Mark the execution as failed with the specified error message."""
+        async with self._lock:
+            record = self._require_record(execution_id)
+            record.mark_failed(error)
+            return record.model_copy(deep=True)
+
+    async def get_history(self, execution_id: str) -> RunHistoryRecord:
+        """Return a deep copy of the execution history."""
+        async with self._lock:
+            record = self._require_record(execution_id)
+            return record.model_copy(deep=True)
+
+    async def clear(self) -> None:
+        """Clear all stored histories. Intended for testing only."""
+        async with self._lock:
+            self._histories.clear()
+
+    def _require_record(self, execution_id: str) -> RunHistoryRecord:
+        """Return the record or raise an error if missing."""
+        record = self._histories.get(execution_id)
+        if record is None:
+            msg = f"History not found for execution_id={execution_id}"
+            raise RunHistoryNotFoundError(msg)
+        return record
+
+
+__all__ = [
+    "InMemoryRunHistoryStore",
+    "RunHistoryError",
+    "RunHistoryNotFoundError",
+    "RunHistoryRecord",
+    "RunHistoryStep",
+]

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -68,6 +68,33 @@ class RunCancelRequest(RunActionRequest):
     reason: str | None = None
 
 
+class RunHistoryStepResponse(BaseModel):
+    """Response payload describing a single run history step."""
+
+    index: int
+    at: datetime
+    payload: dict[str, Any]
+
+
+class RunHistoryResponse(BaseModel):
+    """Execution history response returned by the API."""
+
+    execution_id: str
+    workflow_id: str
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    error: str | None = None
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    steps: list[RunHistoryStepResponse] = Field(default_factory=list)
+
+
+class RunReplayRequest(BaseModel):
+    """Request body for replaying a run from a given step index."""
+
+    from_step: int = Field(default=0, ge=0)
+
+
 class WorkflowVersionDiffResponse(BaseModel):
     """Response payload for workflow version diffs."""
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [ ] Expose backend ingestion that accepts LangGraph Python scripts, converts them to workflow graphs, and preserves parity with LangGraph dev's authoring experience.
 
 ### Milestone 3 – Credential Vault & Security
+- [ ] Introduce a SQLite-backed developer repository with a pluggable storage abstraction so local workflows persist without requiring Postgres while keeping production defaults intact.
 - [ ] Ship AES-256 encrypted credential vault with per-workflow scoping, rotation policies, and masked logging.
 - [ ] Implement OAuth refresh flows, credential validation/testing, and health checks to block misconfigured automations.
 - [ ] Create credential templates and UI/API for secure storage, token issuance, and secret governance alerts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
   - [x] Support manual and batch run dispatch from the trigger layer.
   - [x] Introduce configurable retry policies for trigger-driven runs.
 - [x] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
-- [ ] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.
+- [x] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.
 - [ ] Expose backend ingestion that accepts LangGraph Python scripts, converts them to workflow graphs, and preserves parity with LangGraph dev's authoring experience.
 
 ### Milestone 3 – Credential Vault & Security

--- a/src/orcheo/graph/builder.py
+++ b/src/orcheo/graph/builder.py
@@ -1,30 +1,166 @@
 """Graph builder module for Orcheo."""
 
+from __future__ import annotations
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 from langgraph.graph import END, START, StateGraph
 from orcheo.graph.state import State
 from orcheo.nodes.registry import registry
 
 
-def build_graph(graph_json: dict[str, Any]) -> StateGraph:
-    """Build a graph from a JSON configuration."""
+def build_graph(graph_json: Mapping[str, Any]) -> StateGraph:
+    """Build a LangGraph graph from a JSON configuration."""
     graph = StateGraph(State)
-    for node in graph_json["nodes"]:
-        node_type = node["type"]
-        match node_type:
-            case "START" | "END":
-                pass
-            case _:
-                node_class = registry.get_node(node_type)
-                assert node_class
-                node_params = {k: v for k, v in node.items() if k != "type"}
-                node_instance = node_class(**node_params)
-                graph.add_node(node["name"], node_instance)
+    nodes = list(graph_json.get("nodes", []))
+    edges = list(graph_json.get("edges", []))
 
-    for source, target in graph_json["edges"]:
-        graph.add_edge(
-            source if source != "START" else START,
-            target if target != "END" else END,
-        )
+    for node in nodes:
+        node_type = node.get("type")
+        if node_type in {"START", "END"}:
+            continue
+        node_class = registry.get_node(str(node_type))
+        if node_class is None:
+            msg = f"Unknown node type: {node_type}"
+            raise ValueError(msg)
+        node_params = {k: v for k, v in node.items() if k != "type"}
+        node_instance = node_class(**node_params)
+        graph.add_node(str(node["name"]), node_instance)
+
+    for source, target in _normalise_edges(edges):
+        graph.add_edge(_normalise_vertex(source), _normalise_vertex(target))
+
+    for branch in graph_json.get("conditional_edges", []):
+        _add_conditional_edges(graph, branch)
+
+    for parallel in graph_json.get("parallel_branches", []):
+        _add_parallel_branches(graph, parallel)
 
     return graph
+
+
+def _normalise_edges(edges: Iterable[Any]) -> list[tuple[str, str]]:
+    """Normalise edge definitions into source/target pairs."""
+    normalised: list[tuple[str, str]] = []
+    for entry in edges:
+        if isinstance(entry, Mapping):
+            source = entry.get("source")
+            target = entry.get("target")
+        else:
+            try:
+                source, target = entry  # type: ignore[misc]
+            except (TypeError, ValueError) as exc:
+                msg = f"Invalid edge entry: {entry!r}"
+                raise ValueError(msg) from exc
+        if not isinstance(source, str) or not isinstance(target, str):
+            msg = f"Edge endpoints must be strings: {entry!r}"
+            raise ValueError(msg)
+        normalised.append((source, target))
+    return normalised
+
+
+def _normalise_vertex(name: str) -> Any:
+    """Map sentinel vertex names to LangGraph constants."""
+    if name == "START":
+        return START
+    if name == "END":
+        return END
+    return name
+
+
+def _add_conditional_edges(graph: StateGraph, config: Mapping[str, Any]) -> None:
+    """Add conditional edges enabling branching and loops."""
+    source = config.get("source")
+    path = config.get("path")
+    mapping = config.get("mapping")
+    default_target = config.get("default")
+
+    if not isinstance(source, str) or not source:
+        msg = f"Conditional edge requires a source string: {config!r}"
+        raise ValueError(msg)
+    if not isinstance(path, str) or not path:
+        msg = f"Conditional edge requires a path string: {config!r}"
+        raise ValueError(msg)
+    if not isinstance(mapping, Mapping) or not mapping:
+        msg = f"Conditional edge requires a non-empty mapping: {config!r}"
+        raise ValueError(msg)
+
+    normalised_mapping = {
+        str(key): _normalise_vertex(str(target)) for key, target in mapping.items()
+    }
+    resolved_default = None
+    if isinstance(default_target, str) and default_target:
+        resolved_default = _normalise_vertex(default_target)
+
+    condition = _make_condition(path, normalised_mapping, resolved_default)
+
+    graph.add_conditional_edges(
+        _normalise_vertex(source),
+        condition,
+    )
+
+
+def _add_parallel_branches(graph: StateGraph, config: Mapping[str, Any]) -> None:
+    """Add fan-out/fan-in style parallel branches."""
+    source = config.get("source")
+    targets = config.get("targets")
+    join = config.get("join")
+
+    if not isinstance(source, str) or not source:
+        msg = f"Parallel branch requires a source string: {config!r}"
+        raise ValueError(msg)
+    if isinstance(targets, str) or not isinstance(targets, Iterable):
+        msg = f"Parallel branch requires a list of targets: {config!r}"
+        raise ValueError(msg)
+
+    normalised_source = _normalise_vertex(source)
+    target_list = list(targets)
+    normalised_targets = []
+    for target in target_list:
+        if not isinstance(target, str):
+            msg = f"Parallel branch targets must be strings: {config!r}"
+            raise ValueError(msg)
+        normalised_targets.append(_normalise_vertex(target))
+    if not normalised_targets:
+        msg = f"Parallel branch targets must be strings: {config!r}"
+        raise ValueError(msg)
+
+    for target in normalised_targets:
+        graph.add_edge(normalised_source, target)
+
+    if isinstance(join, str) and join:
+        join_vertex = _normalise_vertex(join)
+        for target in normalised_targets:
+            graph.add_edge(target, join_vertex)
+
+
+def _make_condition(
+    path: str,
+    mapping: Mapping[str, Any],
+    default_target: Any | None,
+) -> Callable[[State], Any]:
+    """Return a callable that resolves a state path to a conditional destination."""
+    keys = path.split(".")
+
+    def resolve(state: State) -> Any:
+        current: Any = state
+        for key in keys:
+            if isinstance(current, Mapping):
+                current = current.get(key)
+            else:
+                current = None
+                break
+        if isinstance(current, bool):
+            condition_key = "true" if current else "false"
+        elif current is None:
+            condition_key = "null"
+        else:
+            condition_key = str(current)
+
+        destination = mapping.get(condition_key)
+        if destination is not None:
+            return destination
+        if default_target is not None:
+            return default_target
+        return END
+
+    return resolve

--- a/tests/backend/test_history.py
+++ b/tests/backend/test_history.py
@@ -1,0 +1,71 @@
+"""Tests for the in-memory execution history store."""
+
+from __future__ import annotations
+import pytest
+from orcheo_backend.app.history import (
+    InMemoryRunHistoryStore,
+    RunHistoryError,
+    RunHistoryNotFoundError,
+    RunHistoryRecord,
+)
+
+
+def test_run_history_record_mark_failed_sets_error() -> None:
+    """Marking a record as failed updates status, timestamp, and error."""
+
+    record = RunHistoryRecord(workflow_id="wf", execution_id="exec")
+    record.mark_failed("boom")
+
+    assert record.status == "error"
+    assert record.error == "boom"
+    assert record.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_start_run_duplicate_execution_id_raises() -> None:
+    """Starting the same execution twice surfaces a descriptive error."""
+
+    store = InMemoryRunHistoryStore()
+    await store.start_run(workflow_id="wf", execution_id="exec")
+
+    with pytest.raises(RunHistoryError, match="execution_id=exec"):
+        await store.start_run(workflow_id="wf", execution_id="exec")
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_returns_copy_and_persists() -> None:
+    """Marking a run as failed stores the status change and returns a copy."""
+
+    store = InMemoryRunHistoryStore()
+    await store.start_run(workflow_id="wf", execution_id="exec")
+
+    result = await store.mark_failed("exec", "boom")
+    assert result.status == "error"
+    assert result.error == "boom"
+
+    history = await store.get_history("exec")
+    assert history.status == "error"
+    assert history.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_missing_history_raises_not_found() -> None:
+    """Accessing an unknown execution raises the not-found error."""
+
+    store = InMemoryRunHistoryStore()
+
+    with pytest.raises(RunHistoryNotFoundError):
+        await store.get_history("missing")
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_all_histories() -> None:
+    """Clearing the store wipes tracked executions."""
+
+    store = InMemoryRunHistoryStore()
+    await store.start_run(workflow_id="wf", execution_id="exec")
+
+    await store.clear()
+
+    with pytest.raises(RunHistoryNotFoundError):
+        await store.get_history("exec")

--- a/tests/graph/test_builder.py
+++ b/tests/graph/test_builder.py
@@ -1,0 +1,178 @@
+"""Tests for the graph builder utilities."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+import pytest
+from langgraph.graph import END, START
+from orcheo.graph import builder
+
+
+class _DummyGraph:
+    """Minimal graph stub recording interactions."""
+
+    def __init__(self) -> None:
+        self.edges: list[tuple[Any, Any]] = []
+        self.conditional_calls: list[tuple[Any, Any]] = []
+
+    def add_edge(self, source: Any, target: Any) -> None:
+        self.edges.append((source, target))
+
+    def add_conditional_edges(self, source: Any, condition: Any) -> None:
+        self.conditional_calls.append((source, condition))
+
+
+def test_build_graph_unknown_node_type() -> None:
+    """Unknown node types produce a clear ValueError."""
+
+    with pytest.raises(ValueError, match="Unknown node type: missing"):
+        builder.build_graph({"nodes": [{"name": "foo", "type": "missing"}]})
+
+
+def test_normalise_edges_validation() -> None:
+    """Edge normalisation rejects malformed entries."""
+
+    with pytest.raises(ValueError, match="Invalid edge entry"):
+        builder._normalise_edges([object()])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Edge endpoints must be strings"):
+        builder._normalise_edges([("start", 1)])  # type: ignore[arg-type]
+
+
+def test_normalise_edges_supports_mapping_entries() -> None:
+    """Mapping-style edge definitions are normalised correctly."""
+
+    result = builder._normalise_edges([{"source": "A", "target": "B"}])
+    assert result == [("A", "B")]
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_message"),
+    [
+        ({"path": "foo", "mapping": {"x": "END"}}, "source string"),
+        ({"source": "A", "mapping": {"x": "END"}}, "path string"),
+        ({"source": "A", "path": "foo"}, "non-empty mapping"),
+    ],
+)
+def test_add_conditional_edges_validation(
+    config: Mapping[str, Any], expected_message: str
+) -> None:
+    """Invalid conditional branch definitions raise detailed errors."""
+
+    graph = _DummyGraph()
+
+    with pytest.raises(ValueError, match=expected_message):
+        builder._add_conditional_edges(graph, config)
+
+
+def test_add_conditional_edges_maps_vertices() -> None:
+    """Conditional edges normalise mapping keys and defaults."""
+
+    graph = _DummyGraph()
+
+    builder._add_conditional_edges(
+        graph,
+        {
+            "source": "START",
+            "path": "payload.flag",
+            "mapping": {"true": "node_a", 0: "node_b"},
+            "default": "END",
+        },
+    )
+
+    assert graph.conditional_calls, "conditional edges should be registered"
+    source, condition = graph.conditional_calls[0]
+    assert source is START
+    assert condition({"payload": {"flag": True}}) == "node_a"
+    assert condition({"payload": {"flag": 0}}) == "node_b"
+    assert condition({"payload": {}}) is END
+
+
+def test_add_conditional_edges_without_default_returns_end() -> None:
+    """When no default is provided, unmatched conditions resolve to END."""
+
+    graph = _DummyGraph()
+
+    builder._add_conditional_edges(
+        graph,
+        {
+            "source": "START",
+            "path": "payload.flag",
+            "mapping": {"true": "node_a"},
+        },
+    )
+
+    _, condition = graph.conditional_calls[0]
+    assert condition({"payload": {"flag": "unknown"}}) is END
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_message"),
+    [
+        ({"targets": ["A"]}, "source string"),
+        ({"source": "START", "targets": "A"}, "list of targets"),
+        (
+            {"source": "START", "targets": ["A", 1]},
+            "targets must be strings",
+        ),
+        ({"source": "START", "targets": []}, "targets must be strings"),
+    ],
+)
+def test_add_parallel_branches_validation(
+    config: Mapping[str, Any], expected_message: str
+) -> None:
+    """Parallel branch validation surfaces precise errors."""
+
+    graph = _DummyGraph()
+
+    with pytest.raises(ValueError, match=expected_message):
+        builder._add_parallel_branches(graph, config)
+
+
+def test_add_parallel_branches_with_join() -> None:
+    """Parallel branches normalise endpoints and add join edges."""
+
+    graph = _DummyGraph()
+
+    builder._add_parallel_branches(
+        graph,
+        {"source": "START", "targets": ["A", "END"], "join": "END"},
+    )
+
+    assert graph.edges[:2] == [(START, "A"), (START, END)]
+    # Join edges should point each branch to END
+    assert graph.edges[2:] == [("A", END), (END, END)]
+
+
+def test_add_parallel_branches_without_join() -> None:
+    """Parallel branches may omit a join target."""
+
+    graph = _DummyGraph()
+
+    builder._add_parallel_branches(
+        graph,
+        {"source": "A", "targets": ["B", "C"]},
+    )
+
+    assert graph.edges == [("A", "B"), ("A", "C")]
+
+
+def test_make_condition_falls_back_to_default_and_end() -> None:
+    """The generated resolver handles nulls, defaults and missing paths."""
+
+    mapping = {"true": "pos", "false": "neg", "value": "other"}
+    condition = builder._make_condition(
+        "payload.result",
+        mapping,
+        default_target="fallback",
+    )
+
+    assert condition({"payload": {"result": True}}) == "pos"
+    assert condition({"payload": {"result": False}}) == "neg"
+    assert condition({"payload": {"result": "value"}}) == "other"
+    assert condition({"payload": {"result": None}}) == "fallback"
+    assert condition({"payload": {}}) == "fallback"
+    assert condition({"payload": 7}) == "fallback"
+
+    no_default = builder._make_condition("payload.value", {}, default_target=None)
+    assert no_default({"payload": {"value": 123}}) is END

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -29,3 +29,74 @@ def test_build_graph():
     assert (
         graph.get_graph().draw_mermaid() == reference_graph.get_graph().draw_mermaid()
     )
+
+
+def test_build_graph_supports_branching_parallel_and_loops():
+    config = {
+        "nodes": [
+            {"name": "START", "type": "START"},
+            {
+                "name": "router",
+                "type": "PythonCode",
+                "code": "return {'route': 'left'}",
+            },
+            {
+                "name": "fanout",
+                "type": "PythonCode",
+                "code": "return state",
+            },
+            {
+                "name": "left_worker",
+                "type": "PythonCode",
+                "code": "return {'result': 'left'}",
+            },
+            {
+                "name": "right_worker",
+                "type": "PythonCode",
+                "code": "return {'result': 'right'}",
+            },
+            {
+                "name": "joiner",
+                "type": "PythonCode",
+                "code": "return state",
+            },
+            {"name": "END", "type": "END"},
+        ],
+        "edges": [
+            ("START", "router"),
+            ("router", "fanout"),
+            ("joiner", "END"),
+        ],
+        "conditional_edges": [
+            {
+                "source": "router",
+                "path": "outputs.router.route",
+                "mapping": {
+                    "left": "left_worker",
+                    "right": "right_worker",
+                    "repeat": "router",
+                },
+                "default": "joiner",
+            }
+        ],
+        "parallel_branches": [
+            {
+                "source": "fanout",
+                "targets": ["left_worker", "right_worker"],
+                "join": "joiner",
+            }
+        ],
+    }
+
+    graph = build_graph(config).compile()
+    edges = {(edge.source, edge.target) for edge in graph.get_graph().edges}
+    assert ("fanout", "left_worker") in edges
+    assert ("fanout", "right_worker") in edges
+    assert ("left_worker", "joiner") in edges
+    assert ("right_worker", "joiner") in edges
+
+    trigger_map = graph.trigger_to_nodes
+    assert trigger_map["branch:to:left_worker"] == ["left_worker"]
+    assert trigger_map["branch:to:right_worker"] == ["right_worker"]
+    assert trigger_map["branch:to:router"] == ["router"]  # loop support
+    assert trigger_map["branch:to:joiner"] == ["joiner"]

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,21 +1,19 @@
 """Tests for the lightweight Orcheo Python SDK."""
 
 from __future__ import annotations
-
 from collections.abc import Mapping
 from types import TracebackType
 from typing import Any
-
 import httpx
 import pytest
 from fastapi.testclient import TestClient
-from orcheo_backend.app import create_app
-from orcheo_backend.app.repository import InMemoryWorkflowRepository
 from orcheo_sdk import (
     HttpWorkflowExecutor,
     OrcheoClient,
     WorkflowExecutionError,
 )
+from orcheo_backend.app import create_app
+from orcheo_backend.app.repository import InMemoryWorkflowRepository
 
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,15 +1,18 @@
 """Tests for the FastAPI backend module."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import WebSocket
+from fastapi.testclient import TestClient
 from orcheo_backend.app import (
     create_app,
     execute_workflow,
     get_repository,
     workflow_websocket,
 )
+from orcheo_backend.app.history import InMemoryRunHistoryStore
 from orcheo_backend.app.repository import InMemoryWorkflowRepository
 
 
@@ -45,9 +48,12 @@ async def test_execute_workflow():
     async def fake_checkpointer(_settings):
         yield mock_checkpointer
 
+    history_store = InMemoryRunHistoryStore()
+
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
+        patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
         await execute_workflow(
             workflow_id, graph_config, inputs, execution_id, mock_websocket
@@ -56,6 +62,11 @@ async def test_execute_workflow():
     mock_graph.compile.assert_called_once_with(checkpointer=mock_checkpointer)
     mock_websocket.send_json.assert_any_call(steps[0])
     mock_websocket.send_json.assert_any_call(steps[1])
+
+    history = await history_store.get_history(execution_id)
+    assert history.status == "completed"
+    assert [step.payload for step in history.steps[:-1]] == steps
+    assert history.steps[-1].payload == {"status": "completed"}
 
 
 @pytest.mark.asyncio
@@ -70,7 +81,13 @@ async def test_workflow_websocket():
     }
 
     # Mock execute_workflow
-    with patch("orcheo_backend.app.execute_workflow") as mock_execute:
+    with (
+        patch("orcheo_backend.app.execute_workflow") as mock_execute,
+        patch(
+            "orcheo_backend.app._history_store_ref",
+            {"store": InMemoryRunHistoryStore()},
+        ),
+    ):
         mock_execute.return_value = None
         await workflow_websocket(mock_websocket, "test-workflow")
 
@@ -103,3 +120,43 @@ def test_create_app_allows_dependency_override() -> None:
 
     override = app.dependency_overrides[get_repository]
     assert override() is repository
+
+
+def test_execution_history_endpoints_return_steps() -> None:
+    """Execution history endpoints expose stored replay data."""
+
+    repository = InMemoryWorkflowRepository()
+    history_store = InMemoryRunHistoryStore()
+
+    execution_id = "exec-123"
+
+    async def seed_history() -> None:
+        await history_store.start_run(
+            workflow_id="wf-1", execution_id=execution_id, inputs={"foo": "bar"}
+        )
+        await history_store.append_step(execution_id, {"node": "first"})
+        await history_store.append_step(execution_id, {"node": "second"})
+        await history_store.append_step(execution_id, {"status": "completed"})
+        await history_store.mark_completed(execution_id)
+
+    asyncio.run(seed_history())
+
+    app = create_app(repository, history_store=history_store)
+    client = TestClient(app)
+
+    history_response = client.get(f"/api/executions/{execution_id}/history")
+    assert history_response.status_code == 200
+    history = history_response.json()
+    assert history["execution_id"] == execution_id
+    assert history["status"] == "completed"
+    assert len(history["steps"]) == 3
+    assert history["steps"][0]["payload"] == {"node": "first"}
+
+    replay_response = client.post(
+        f"/api/executions/{execution_id}/replay", json={"from_step": 1}
+    )
+    assert replay_response.status_code == 200
+    replay = replay_response.json()
+    assert len(replay["steps"]) == 2
+    assert replay["steps"][0]["index"] == 1
+    assert replay["steps"][0]["payload"] == {"node": "second"}


### PR DESCRIPTION
## Summary
- add an async-safe run history store and REST endpoints for history retrieval and replay
- record workflow execution steps in the websocket executor and allow overriding the history store in tests/app factories
- extend the graph builder to support conditional branching, loops, and parallel branches with updated tests and roadmap status

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ed6b9b8bd4832792fba7312a531e6b