### PR TITLE
Add backend ingestion for LangGraph scripts

### DIFF
--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 from uuid import UUID
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 
 
 class WorkflowCreateRequest(BaseModel):
@@ -44,6 +45,18 @@ class WorkflowVersionIngestRequest(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     notes: str | None = None
     created_by: str
+
+    @field_validator("script")
+    @classmethod
+    def _enforce_script_size(cls, value: str) -> str:
+        size = len(value.encode("utf-8"))
+        if size > DEFAULT_SCRIPT_SIZE_LIMIT:
+            msg = (
+                "LangGraph script exceeds the maximum allowed size of "
+                f"{DEFAULT_SCRIPT_SIZE_LIMIT} bytes"
+            )
+            raise ValueError(msg)
+        return value
 
 
 class WorkflowRunCreateRequest(BaseModel):

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -36,6 +36,16 @@ class WorkflowVersionCreateRequest(BaseModel):
     created_by: str
 
 
+class WorkflowVersionIngestRequest(BaseModel):
+    """Payload for ingesting a LangGraph Python script."""
+
+    script: str
+    entrypoint: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    notes: str | None = None
+    created_by: str
+
+
 class WorkflowRunCreateRequest(BaseModel):
     """Payload for creating a new workflow execution run."""
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -130,6 +130,9 @@ Workflow runs execute concurrently across worker pools while honoring per-workfl
 #### 2.2.16 Behavioral
 Behavioral expectations follow PRD goals: visual edits update backend configuration once the user saves changes (auto-save remains a potential future enhancement); SDK commits remain version-controlled; triggers guarantee at-least-once execution; observability delivers near real-time run telemetry; failures raise alerts aligned with operational SLAs.
 
+#### 2.2.17 LangGraph Script Guardrails
+LangGraph ingestion now enforces explicit safety and performance guardrails beyond FastAPI defaults. Scripts larger than 128 KiB (measured post UTF-8 encoding) are rejected early to avoid allocator pressure and abuse from oversized submissions. Execution is wrapped in a sixty-second wall-clock timeout that interrupts unbounded loops to prevent ingestion workers from hanging under denial-of-service attempts. Additionally, compiled bytecode is cached across identical script bodies so repeat imports avoid redundant RestrictedPython compilation, lowering latency for common iteration loops without sacrificing isolation.
+
 ### 2.3 Views
 This section captures concrete views derived from the selected viewpoints.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
   - [x] Introduce configurable retry policies for trigger-driven runs.
 - [x] Layer in SDK HTTP execution helpers (httpx client, retry/backoff, auth headers) paired with integration tests against local backend deployments.
 - [x] Add execution engine support for loops, branching, parallelization, run history, and replay/debug APIs.
-- [ ] Expose backend ingestion that accepts LangGraph Python scripts, converts them to workflow graphs, and preserves parity with LangGraph dev's authoring experience.
+- [x] Expose backend ingestion that accepts LangGraph Python scripts, converts them to workflow graphs, and preserves parity with LangGraph dev's authoring experience.
 
 ### Milestone 3 – Credential Vault & Security
 - [ ] Introduce a SQLite-backed developer repository with a pluggable storage abstraction so local workflows persist without requiring Postgres while keeping production defaults intact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dependencies = [
   "mcp[cli]>=1.12.0",
   "pymongo>=4.13.2",
   "dynaconf>=3.2.4",
-  "cryptography>=43.0.1"
+  "cryptography>=43.0.1",
+  "RestrictedPython>=7.2"
 ]
 description = "Add your description here"
 name = "orcheo"

--- a/src/orcheo/graph/builder.py
+++ b/src/orcheo/graph/builder.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 from langgraph.graph import END, START, StateGraph
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT, load_graph_from_script
 from orcheo.graph.state import State
 from orcheo.nodes.registry import registry
 
 
 def build_graph(graph_json: Mapping[str, Any]) -> StateGraph:
-    """Build a LangGraph graph from a JSON configuration."""
+    """Build a LangGraph graph from a configuration payload."""
+    if graph_json.get("format") == LANGGRAPH_SCRIPT_FORMAT:
+        source = graph_json.get("source")
+        if not isinstance(source, str) or not source.strip():
+            msg = "Script graph configuration requires a non-empty source"
+            raise ValueError(msg)
+        entrypoint_value = graph_json.get("entrypoint")
+        if entrypoint_value is not None and not isinstance(entrypoint_value, str):
+            msg = "Entrypoint must be a string when provided"
+            raise ValueError(msg)
+        return load_graph_from_script(source, entrypoint=entrypoint_value)
+
     graph = StateGraph(State)
     nodes = list(graph_json.get("nodes", []))
     edges = list(graph_json.get("edges", []))

--- a/src/orcheo/graph/ingestion.py
+++ b/src/orcheo/graph/ingestion.py
@@ -1,0 +1,230 @@
+"""Utilities for ingesting LangGraph Python scripts."""
+
+from __future__ import annotations
+import inspect
+from typing import Any
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from pydantic import BaseModel
+from orcheo.nodes.registry import registry
+
+
+LANGGRAPH_SCRIPT_FORMAT = "langgraph-script"
+
+
+class ScriptIngestionError(RuntimeError):
+    """Raised when a LangGraph script cannot be converted into a workflow graph."""
+
+
+def ingest_langgraph_script(
+    source: str,
+    *,
+    entrypoint: str | None = None,
+) -> dict[str, Any]:
+    """Return a workflow graph payload produced from a LangGraph Python script.
+
+    The returned payload embeds the original script alongside a lightweight
+    summary of the discovered LangGraph state graph. The summary is useful for
+    visualisation and quick inspection while the original script is required to
+    faithfully rebuild the graph during execution.
+    """
+    graph = load_graph_from_script(source, entrypoint=entrypoint)
+    summary = _summarise_state_graph(graph)
+    return {
+        "format": LANGGRAPH_SCRIPT_FORMAT,
+        "source": source,
+        "entrypoint": entrypoint,
+        "summary": summary,
+    }
+
+
+def load_graph_from_script(
+    source: str,
+    *,
+    entrypoint: str | None = None,
+) -> StateGraph:
+    """Execute a LangGraph Python script and return the discovered ``StateGraph``.
+
+    Args:
+        source: Python source code containing the LangGraph definition.
+        entrypoint: Optional name of the variable or zero-argument callable that
+            resolves to a ``StateGraph``. When omitted, the loader attempts to
+            discover a single ``StateGraph`` instance defined in the module
+            namespace.
+
+    Raises:
+        ScriptIngestionError: if the script cannot be executed or no graph can
+            be resolved from the resulting namespace.
+    """
+    namespace: dict[str, Any] = {"__name__": "__orcheo_ingest__"}
+
+    try:
+        exec(compile(source, "<langgraph-script>", "exec"), namespace)
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        message = "Failed to execute LangGraph script"
+        raise ScriptIngestionError(message) from exc
+
+    module_name = namespace["__name__"]
+
+    if entrypoint is not None:
+        if entrypoint not in namespace:
+            msg = f"Entrypoint '{entrypoint}' not found in script"
+            raise ScriptIngestionError(msg)
+        candidates = [namespace[entrypoint]]
+    else:
+        candidates = [
+            value
+            for value in namespace.values()
+            if _is_graph_candidate(value, module_name)
+        ]
+        if not candidates:
+            msg = "Script did not produce a LangGraph StateGraph"
+            raise ScriptIngestionError(msg)
+
+    resolved_graphs = [
+        graph for candidate in candidates if (graph := _resolve_graph(candidate))
+    ]
+
+    if not resolved_graphs:
+        msg = "Unable to resolve a LangGraph StateGraph from the script"
+        raise ScriptIngestionError(msg)
+
+    if entrypoint is None and len(resolved_graphs) > 1:
+        msg = "Multiple StateGraph candidates discovered; specify an entrypoint"
+        raise ScriptIngestionError(msg)
+
+    return resolved_graphs[0]
+
+
+def _is_graph_candidate(obj: Any, module_name: str) -> bool:
+    """Return ``True`` when ``obj`` may resolve to a ``StateGraph``."""
+    if isinstance(obj, StateGraph | CompiledStateGraph):
+        return True
+
+    if inspect.isfunction(obj) or inspect.iscoroutinefunction(obj):
+        return getattr(obj, "__module__", "") == module_name
+
+    return False
+
+
+def _resolve_graph(obj: Any) -> StateGraph | None:
+    """Return a ``StateGraph`` from the supplied object if possible."""
+    if isinstance(obj, StateGraph):
+        return obj
+
+    if isinstance(obj, CompiledStateGraph):
+        return obj.builder
+
+    if callable(obj):
+        signature = inspect.signature(obj)
+        if any(
+            parameter.default is inspect.Parameter.empty
+            and parameter.kind
+            not in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            )
+            for parameter in signature.parameters.values()
+        ):
+            return None
+        try:
+            result = obj()
+        except Exception:  # pragma: no cover - the caller will raise a clearer error
+            return None
+        return _resolve_graph(result)
+
+    return None
+
+
+def _summarise_state_graph(graph: StateGraph) -> dict[str, Any]:
+    """Return a JSON-serialisable summary of the ``StateGraph`` structure."""
+    nodes = [_serialise_node(name, spec.runnable) for name, spec in graph.nodes.items()]
+    edges = [_normalise_edge(edge) for edge in sorted(graph.edges)]
+    branches = [
+        _serialise_branch(source, branch_name, branch)
+        for source, branch_map in graph.branches.items()
+        for branch_name, branch in branch_map.items()
+    ]
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "conditional_edges": [
+            branch
+            for branch in branches
+            if branch.get("mapping") or branch.get("default")
+        ],
+    }
+
+
+def _serialise_node(name: str, runnable: Any) -> dict[str, Any]:
+    """Return a JSON representation for a LangGraph node."""
+    runnable_obj = _unwrap_runnable(runnable)
+    metadata = registry.get_metadata_by_callable(runnable_obj)
+    node_type = metadata.name if metadata else type(runnable_obj).__name__
+    payload = {"name": name, "type": node_type}
+
+    if isinstance(runnable_obj, BaseModel):
+        node_config = runnable_obj.model_dump(mode="json")
+        node_config.pop("name", None)
+        payload.update(node_config)
+
+    return payload
+
+
+def _unwrap_runnable(runnable: Any) -> Any:
+    """Return the underlying callable stored within LangGraph wrappers."""
+    if hasattr(runnable, "afunc") and isinstance(runnable.afunc, BaseModel):
+        return runnable.afunc
+    if hasattr(runnable, "func") and isinstance(runnable.func, BaseModel):
+        return runnable.func
+    return runnable
+
+
+def _serialise_branch(source: str, name: str, branch: Any) -> dict[str, Any]:
+    """Return metadata describing a conditional branch."""
+    mapping: dict[str, str] | None = None
+    ends = getattr(branch, "ends", None)
+    if isinstance(ends, dict):
+        mapping = {str(key): _normalise_vertex(target) for key, target in ends.items()}
+
+    default: str | None = None
+    then_target = getattr(branch, "then", None)
+    if isinstance(then_target, str):
+        default = _normalise_vertex(then_target)
+
+    payload: dict[str, Any] = {
+        "source": source,
+        "branch": name,
+    }
+    if mapping:
+        payload["mapping"] = mapping
+    if default is not None:
+        payload["default"] = default
+    if hasattr(branch, "path") and getattr(branch.path, "func", None):
+        payload["callable"] = getattr(branch.path.func, "__name__", "<lambda>")
+
+    return payload
+
+
+def _normalise_edge(edge: tuple[str, str]) -> tuple[str, str]:
+    """Convert LangGraph sentinel edge names into public constants."""
+    source, target = edge
+    return (_normalise_vertex(source), _normalise_vertex(target))
+
+
+def _normalise_vertex(value: str) -> str:
+    """Map LangGraph sentinel vertex names to ``START``/``END``."""
+    if value == "__start__":
+        return "START"
+    if value == "__end__":
+        return "END"
+    return value
+
+
+__all__ = [
+    "LANGGRAPH_SCRIPT_FORMAT",
+    "ScriptIngestionError",
+    "ingest_langgraph_script",
+    "load_graph_from_script",
+]

--- a/src/orcheo/nodes/registry.py
+++ b/src/orcheo/nodes/registry.py
@@ -57,6 +57,15 @@ class NodeRegistry:
         """
         return self._nodes.get(name)
 
+    def get_metadata_by_callable(self, obj: Callable) -> NodeMetadata | None:
+        """Return metadata associated with a registered callable."""
+        for name, registered in self._nodes.items():
+            if registered is obj:
+                return self._metadata.get(name)
+            if isinstance(registered, type) and isinstance(obj, registered):
+                return self._metadata.get(name)
+        return None
+
 
 # Global registry instance
 registry = NodeRegistry()

--- a/tests/backend/test_schemas.py
+++ b/tests/backend/test_schemas.py
@@ -1,0 +1,24 @@
+"""Validation tests for FastAPI request schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
+from orcheo_backend.app.schemas import WorkflowVersionIngestRequest
+
+
+def test_workflow_version_ingest_request_rejects_large_scripts() -> None:
+    """Submitting a script larger than the configured limit raises a validation error."""
+
+    oversized = "a" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)
+
+    with pytest.raises(ValidationError):
+        WorkflowVersionIngestRequest(
+            script=oversized,
+            entrypoint=None,
+            metadata={},
+            notes=None,
+            created_by="tester",
+        )

--- a/tests/backend/test_schemas.py
+++ b/tests/backend/test_schemas.py
@@ -1,16 +1,14 @@
 """Validation tests for FastAPI request schemas."""
 
 from __future__ import annotations
-
 import pytest
 from pydantic import ValidationError
-
 from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 from orcheo_backend.app.schemas import WorkflowVersionIngestRequest
 
 
 def test_workflow_version_ingest_request_rejects_large_scripts() -> None:
-    """Submitting a script larger than the configured limit raises a validation error."""
+    """Submitting scripts larger than the configured limit raises a validation error."""
 
     oversized = "a" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)
 

--- a/tests/graph/test_builder.py
+++ b/tests/graph/test_builder.py
@@ -29,6 +29,25 @@ def test_build_graph_unknown_node_type() -> None:
         builder.build_graph({"nodes": [{"name": "foo", "type": "missing"}]})
 
 
+def test_build_graph_script_format_empty_source() -> None:
+    """Script format with empty source raises ValueError."""
+
+    with pytest.raises(ValueError, match="non-empty source"):
+        builder.build_graph({"format": "langgraph-script", "source": ""})
+
+    with pytest.raises(ValueError, match="non-empty source"):
+        builder.build_graph({"format": "langgraph-script", "source": "   "})
+
+
+def test_build_graph_script_format_invalid_entrypoint_type() -> None:
+    """Script format with non-string entrypoint raises ValueError."""
+
+    with pytest.raises(ValueError, match="Entrypoint must be a string"):
+        builder.build_graph(
+            {"format": "langgraph-script", "source": "valid_code", "entrypoint": 123}
+        )
+
+
 def test_normalise_edges_validation() -> None:
     """Edge normalisation rejects malformed entries."""
 

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 import pytest
 from orcheo.graph.builder import build_graph
 from orcheo.graph.ingestion import (
+    DEFAULT_SCRIPT_SIZE_LIMIT,
     LANGGRAPH_SCRIPT_FORMAT,
     ScriptIngestionError,
+    _compile_langgraph_script,
     _resolve_graph,
     _serialise_branch,
     _unwrap_runnable,
@@ -238,6 +240,59 @@ def test_serialise_branch_without_optional_fields() -> None:
     payload = _serialise_branch("node", "result", branch)
 
     assert payload == {"source": "node", "branch": "result"}
+
+
+def test_ingest_script_exceeding_size_limit() -> None:
+    """Scripts larger than the configured limit are rejected."""
+
+    oversized = "a" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)
+
+    with pytest.raises(ScriptIngestionError, match="exceeds the permitted size"):
+        ingest_langgraph_script(oversized)
+
+
+def test_ingest_script_enforces_execution_timeout() -> None:
+    """Infinite loops trigger a timeout during script execution."""
+
+    script = "while True:\n    pass\n"
+
+    with pytest.raises(
+        ScriptIngestionError, match="execution exceeded the configured timeout"
+    ):
+        ingest_langgraph_script(script, execution_timeout_seconds=0.1)
+
+
+def test_compile_langgraph_script_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated ingestion of the same script reuses the cached bytecode."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    call_count = 0
+
+    def _fake_compile(source: str, filename: str, mode: str):
+        nonlocal call_count
+        call_count += 1
+        return compile(source, filename, mode)
+
+    _compile_langgraph_script.cache_clear()
+    monkeypatch.setattr("orcheo.graph.ingestion.compile_restricted", _fake_compile)
+
+    try:
+        ingest_langgraph_script(script)
+        ingest_langgraph_script(script)
+    finally:
+        _compile_langgraph_script.cache_clear()
+
+    assert call_count == 1
 
 
 def test_resolve_graph_with_unknown_object_returns_none() -> None:

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -1,0 +1,86 @@
+"""Tests for LangGraph script ingestion helpers."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from orcheo.graph.builder import build_graph
+from orcheo.graph.ingestion import (
+    LANGGRAPH_SCRIPT_FORMAT,
+    ScriptIngestionError,
+    ingest_langgraph_script,
+)
+
+
+def test_ingest_script_with_entrypoint() -> None:
+    """Scripts with an explicit entrypoint are converted into graph payloads."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+        from orcheo.nodes.rss import RSSNode
+
+        def build_graph():
+            graph = StateGraph(State)
+            graph.add_node("rss", RSSNode(name="rss", sources=["https://example.com/feed"]))
+            graph.set_entry_point("rss")
+            graph.set_finish_point("rss")
+            return graph
+        """
+    )
+
+    payload = ingest_langgraph_script(script, entrypoint="build_graph")
+
+    assert payload["format"] == LANGGRAPH_SCRIPT_FORMAT
+    assert (
+        payload["source"].strip().startswith("from langgraph.graph import StateGraph")
+    )
+    assert payload["entrypoint"] == "build_graph"
+    summary = payload["summary"]
+    assert summary["edges"] == [("START", "rss"), ("rss", "END")]
+    assert summary["nodes"][0]["type"] == "RSSNode"
+
+    graph = build_graph(payload)
+    assert set(graph.nodes.keys()) == {"rss"}
+
+
+def test_ingest_script_without_entrypoint_auto_discovers_graph() -> None:
+    """Scripts defining a single graph variable are auto-discovered."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.add_node("first", lambda state: state)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    payload = ingest_langgraph_script(script)
+
+    assert payload["entrypoint"] is None
+    summary = payload["summary"]
+    assert summary["edges"] == [("START", "first"), ("first", "END")]
+
+
+def test_ingest_script_with_multiple_candidates_requires_entrypoint() -> None:
+    """Multiple graphs require an explicit entrypoint to disambiguate."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        first = StateGraph(State)
+        second = StateGraph(State)
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script)

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,8 +11,12 @@ from orcheo.graph.builder import build_graph
 from orcheo.graph.ingestion import (
     LANGGRAPH_SCRIPT_FORMAT,
     ScriptIngestionError,
+    _serialise_branch,
+    _resolve_graph,
+    _unwrap_runnable,
     ingest_langgraph_script,
 )
+from orcheo.nodes.rss import RSSNode
 
 
 def test_ingest_script_with_entrypoint() -> None:
@@ -103,3 +108,142 @@ def test_ingest_script_rejects_forbidden_imports() -> None:
 
     with pytest.raises(ScriptIngestionError):
         ingest_langgraph_script(script)
+
+
+def test_ingest_script_rejects_relative_imports() -> None:
+    """Relative imports are blocked by the sandbox import hook."""
+
+    script = textwrap.dedent(
+        """
+        from .foo import bar
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script)
+
+
+def test_ingest_script_missing_entrypoint_errors() -> None:
+    """Referencing an entrypoint that does not exist raises an error."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script, entrypoint="missing")
+
+
+def test_ingest_script_without_candidates_errors() -> None:
+    """Scripts that fail to define a graph raise a conversion error."""
+
+    script = """value = 42"""
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script)
+
+
+def test_ingest_script_entrypoint_requires_arguments() -> None:
+    """Entrypoints requiring arguments are rejected."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        def build_graph(name: str):
+            graph = StateGraph(State)
+            graph.set_entry_point("first")
+            graph.set_finish_point("first")
+            return graph
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script, entrypoint="build_graph")
+
+
+def test_ingest_script_handles_compiled_graph_entrypoint() -> None:
+    """Compiled graphs referenced as entrypoints are resolved to builders."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.add_node("first", lambda state: state)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        compiled = graph.compile()
+        """
+    )
+
+    payload = ingest_langgraph_script(script, entrypoint="compiled")
+
+    summary = payload["summary"]
+    assert summary["edges"] == [("START", "first"), ("first", "END")]
+
+
+def test_ingest_script_entrypoint_not_resolvable() -> None:
+    """Entrypoints referencing non-graph objects raise an error."""
+
+    script = textwrap.dedent(
+        """
+        class Dummy:
+            pass
+
+        candidate = Dummy()
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script, entrypoint="candidate")
+
+
+def test_unwrap_runnable_prefers_wrapped_func() -> None:
+    """Wrappers exposing ``func`` with a BaseModel are unwrapped."""
+
+    node = RSSNode(name="rss", sources=["https://example.com/feed"])
+    wrapper = SimpleNamespace(func=node)
+
+    assert _unwrap_runnable(wrapper) is node
+
+
+def test_serialise_branch_with_mapping_and_default() -> None:
+    """Branch metadata includes mapping, default target, and callable names."""
+
+    branch = SimpleNamespace(
+        ends={"success": "__start__", "failure": "__end__"},
+        then="__end__",
+        path=SimpleNamespace(func=lambda: None),
+    )
+
+    payload = _serialise_branch("node", "result", branch)
+
+    assert payload["mapping"] == {"success": "START", "failure": "END"}
+    assert payload["default"] == "END"
+    assert payload["callable"] == "<lambda>"
+
+
+def test_serialise_branch_without_optional_fields() -> None:
+    """Branches without mapping or callables only expose core metadata."""
+
+    branch = SimpleNamespace(ends=None, then=None)
+
+    payload = _serialise_branch("node", "result", branch)
+
+    assert payload == {"source": "node", "branch": "result"}
+
+
+def test_resolve_graph_with_unknown_object_returns_none() -> None:
+    """Non-graph objects fall through the resolver."""
+
+    assert _resolve_graph(object()) is None

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -1,18 +1,15 @@
 """Tests for LangGraph script ingestion helpers."""
 
 from __future__ import annotations
-
 import textwrap
 from types import SimpleNamespace
-
 import pytest
-
 from orcheo.graph.builder import build_graph
 from orcheo.graph.ingestion import (
     LANGGRAPH_SCRIPT_FORMAT,
     ScriptIngestionError,
-    _serialise_branch,
     _resolve_graph,
+    _serialise_branch,
     _unwrap_runnable,
     ingest_langgraph_script,
 )

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -84,3 +84,22 @@ def test_ingest_script_with_multiple_candidates_requires_entrypoint() -> None:
 
     with pytest.raises(ScriptIngestionError):
         ingest_langgraph_script(script)
+
+
+def test_ingest_script_rejects_forbidden_imports() -> None:
+    """Scripts attempting to import forbidden modules are rejected."""
+
+    script = textwrap.dedent(
+        """
+        import os
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    with pytest.raises(ScriptIngestionError):
+        ingest_langgraph_script(script)

--- a/tests/nodes/test_registry.py
+++ b/tests/nodes/test_registry.py
@@ -1,0 +1,62 @@
+"""Tests for the node registry module."""
+
+from orcheo.nodes.registry import NodeMetadata, NodeRegistry
+
+
+def test_get_metadata_by_callable_exact_match() -> None:
+    """get_metadata_by_callable returns metadata for exact callable match."""
+
+    registry = NodeRegistry()
+
+    def my_node(state):
+        return state
+
+    metadata = NodeMetadata(
+        name="my_node",
+        description="A test node",
+        category="test",
+    )
+
+    registry.register(metadata)(my_node)
+
+    result = registry.get_metadata_by_callable(my_node)
+    assert result is not None
+    assert result.name == "my_node"
+    assert result.description == "A test node"
+    assert result.category == "test"
+
+
+def test_get_metadata_by_callable_instance_match() -> None:
+    """get_metadata_by_callable returns metadata for instance of registered class."""
+
+    registry = NodeRegistry()
+
+    class MyNode:
+        def __call__(self, state):
+            return state
+
+    metadata = NodeMetadata(
+        name="class_node",
+        description="A class-based node",
+        category="classes",
+    )
+
+    registry.register(metadata)(MyNode)
+
+    instance = MyNode()
+    result = registry.get_metadata_by_callable(instance)
+    assert result is not None
+    assert result.name == "class_node"
+    assert result.description == "A class-based node"
+
+
+def test_get_metadata_by_callable_no_match() -> None:
+    """get_metadata_by_callable returns None for unregistered callable."""
+
+    registry = NodeRegistry()
+
+    def unregistered_node(state):
+        return state
+
+    result = registry.get_metadata_by_callable(unregistered_node)
+    assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1833,6 +1833,7 @@ dependencies = [
     { name = "pymongo" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
+    { name = "restrictedpython" },
     { name = "selenium" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -1882,6 +1883,7 @@ requires-dist = [
     { name = "pymongo", specifier = ">=4.13.2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
+    { name = "restrictedpython", specifier = ">=7.2" },
     { name = "selenium", specifier = ">=4.32.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "websockets", specifier = ">=12.0" },
@@ -2682,6 +2684,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "restrictedpython"
+version = "8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/f3/3cfd684abf456f536a842e4fabe1ca360a8e94d1fc329f261c34c1d98825/restrictedpython-8.0.tar.gz", hash = "sha256:3af2312bc67e5fced887fb85b006c89861da72488128b155beea81eb6a0a9b24", size = 448747, upload-time = "2025-01-23T07:15:53.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/31/b33804f873742ab20c8ed82a75652bf60a6205116dfec8bb092a6ebef084/RestrictedPython-8.0-py3-none-any.whl", hash = "sha256:ed3d894efd7d6cac0a5f13f75583b8458378d400d7dd4c083b59233eba85fe69", size = 27238, upload-time = "2025-01-23T07:15:50.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a LangGraph script ingestion module that executes Python graph definitions and produces a reusable payload
- allow the workflow builder and FastAPI backend to accept script-based versions via a dedicated ingestion endpoint
- cover the ingestion flow with unit and API tests and update the roadmap milestone entry

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68edf1a42ed083279fd583701c56400b