### PR TITLE
Relax ingestion execution timeout

### DIFF
--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 from uuid import UUID
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 
 
 class WorkflowCreateRequest(BaseModel):
@@ -44,6 +45,18 @@ class WorkflowVersionIngestRequest(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     notes: str | None = None
     created_by: str
+
+    @field_validator("script")
+    @classmethod
+    def _enforce_script_size(cls, value: str) -> str:
+        size = len(value.encode("utf-8"))
+        if size > DEFAULT_SCRIPT_SIZE_LIMIT:
+            msg = (
+                "LangGraph script exceeds the maximum allowed size of "
+                f"{DEFAULT_SCRIPT_SIZE_LIMIT} bytes"
+            )
+            raise ValueError(msg)
+        return value
 
 
 class WorkflowRunCreateRequest(BaseModel):

--- a/docs/design.md
+++ b/docs/design.md
@@ -130,6 +130,9 @@ Workflow runs execute concurrently across worker pools while honoring per-workfl
 #### 2.2.16 Behavioral
 Behavioral expectations follow PRD goals: visual edits update backend configuration once the user saves changes (auto-save remains a potential future enhancement); SDK commits remain version-controlled; triggers guarantee at-least-once execution; observability delivers near real-time run telemetry; failures raise alerts aligned with operational SLAs.
 
+#### 2.2.17 LangGraph Script Guardrails
+LangGraph ingestion now enforces explicit safety and performance guardrails beyond FastAPI defaults. Scripts larger than 128 KiB (measured post UTF-8 encoding) are rejected early to avoid allocator pressure and abuse from oversized submissions. Execution is wrapped in a sixty-second wall-clock timeout that interrupts unbounded loops to prevent ingestion workers from hanging under denial-of-service attempts. Additionally, compiled bytecode is cached across identical script bodies so repeat imports avoid redundant RestrictedPython compilation, lowering latency for common iteration loops without sacrificing isolation.
+
 ### 2.3 Views
 This section captures concrete views derived from the selected viewpoints.
 

--- a/tests/backend/test_schemas.py
+++ b/tests/backend/test_schemas.py
@@ -1,0 +1,24 @@
+"""Validation tests for FastAPI request schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
+from orcheo_backend.app.schemas import WorkflowVersionIngestRequest
+
+
+def test_workflow_version_ingest_request_rejects_large_scripts() -> None:
+    """Submitting a script larger than the configured limit raises a validation error."""
+
+    oversized = "a" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)
+
+    with pytest.raises(ValidationError):
+        WorkflowVersionIngestRequest(
+            script=oversized,
+            entrypoint=None,
+            metadata={},
+            notes=None,
+            created_by="tester",
+        )

--- a/tests/graph/test_ingestion.py
+++ b/tests/graph/test_ingestion.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 import pytest
 from orcheo.graph.builder import build_graph
 from orcheo.graph.ingestion import (
+    DEFAULT_SCRIPT_SIZE_LIMIT,
     LANGGRAPH_SCRIPT_FORMAT,
     ScriptIngestionError,
+    _compile_langgraph_script,
     _resolve_graph,
     _serialise_branch,
     _unwrap_runnable,
@@ -238,6 +240,59 @@ def test_serialise_branch_without_optional_fields() -> None:
     payload = _serialise_branch("node", "result", branch)
 
     assert payload == {"source": "node", "branch": "result"}
+
+
+def test_ingest_script_exceeding_size_limit() -> None:
+    """Scripts larger than the configured limit are rejected."""
+
+    oversized = "a" * (DEFAULT_SCRIPT_SIZE_LIMIT + 1)
+
+    with pytest.raises(ScriptIngestionError, match="exceeds the permitted size"):
+        ingest_langgraph_script(oversized)
+
+
+def test_ingest_script_enforces_execution_timeout() -> None:
+    """Infinite loops trigger a timeout during script execution."""
+
+    script = "while True:\n    pass\n"
+
+    with pytest.raises(
+        ScriptIngestionError, match="execution exceeded the configured timeout"
+    ):
+        ingest_langgraph_script(script, execution_timeout_seconds=0.1)
+
+
+def test_compile_langgraph_script_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated ingestion of the same script reuses the cached bytecode."""
+
+    script = textwrap.dedent(
+        """
+        from langgraph.graph import StateGraph
+        from orcheo.graph.state import State
+
+        graph = StateGraph(State)
+        graph.set_entry_point("first")
+        graph.set_finish_point("first")
+        """
+    )
+
+    call_count = 0
+
+    def _fake_compile(source: str, filename: str, mode: str):
+        nonlocal call_count
+        call_count += 1
+        return compile(source, filename, mode)
+
+    _compile_langgraph_script.cache_clear()
+    monkeypatch.setattr("orcheo.graph.ingestion.compile_restricted", _fake_compile)
+
+    try:
+        ingest_langgraph_script(script)
+        ingest_langgraph_script(script)
+    finally:
+        _compile_langgraph_script.cache_clear()
+
+    assert call_count == 1
 
 
 def test_resolve_graph_with_unknown_object_returns_none() -> None:


### PR DESCRIPTION
## Summary
- enforce size limits, execution timeouts (defaulting to 60s), and bytecode caching when ingesting LangGraph scripts
- validate ingestion request payload size within the FastAPI schema
- document the new guardrails and cover them with targeted tests

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f08e64026883278282caef0b32dab6