### PR TITLE
Add AES-256 credential vault with rotation policies

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -77,7 +77,7 @@ Current automation platforms force teams to choose between ease of use and advan
 - Execution engine with history, retries, and support for loops, branching, and parallelization.
 
 #### Credential & Security Handling
-- AES-256 encrypted vault with per-workflow scoping, token rotation, and masked logs.
+- AES-256 encrypted vault with shareable credentials by default, plus optional workflow, workspace, or role scope policies, token rotation, and masked logs.
 - Pre-built credential templates for popular services with validation before execution.
 - Automatic OAuth refresh and credential testing to guard against misconfiguration.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ### Milestone 3 – Credential Vault & Security
 - [x] Introduce a SQLite-backed developer repository with a pluggable storage abstraction so local workflows persist without requiring Postgres while keeping production defaults intact.
-- [x] Ship AES-256 encrypted credential vault with per-workflow scoping, rotation policies, and masked logging.
+- [x] Ship AES-256 encrypted credential vault with shareable credentials, optional scope policies, rotation workflows, and masked logging.
 - [ ] Implement OAuth refresh flows, credential validation/testing, and health checks to block misconfigured automations.
 - [ ] Create credential templates and UI/API for secure storage, token issuance, and secret governance alerts.
 - [ ] Run security reviews, penetration tests, and threat modeling across vault, triggers, and execution surfaces.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ### Milestone 3 – Credential Vault & Security
 - [x] Introduce a SQLite-backed developer repository with a pluggable storage abstraction so local workflows persist without requiring Postgres while keeping production defaults intact.
-- [ ] Ship AES-256 encrypted credential vault with per-workflow scoping, rotation policies, and masked logging.
+- [x] Ship AES-256 encrypted credential vault with per-workflow scoping, rotation policies, and masked logging.
 - [ ] Implement OAuth refresh flows, credential validation/testing, and health checks to block misconfigured automations.
 - [ ] Create credential templates and UI/API for secure storage, token issuance, and secret governance alerts.
 - [ ] Run security reviews, penetration tests, and threat modeling across vault, triggers, and execution surfaces.

--- a/src/orcheo/models/__init__.py
+++ b/src/orcheo/models/__init__.py
@@ -1,6 +1,7 @@
 """Domain models representing workflows and credentials."""
 
 from orcheo.models.workflow import (
+    AesGcmCredentialCipher,
     AuditRecord,
     CredentialCipher,
     CredentialMetadata,
@@ -15,6 +16,7 @@ from orcheo.models.workflow import (
 
 __all__ = [
     "AuditRecord",
+    "AesGcmCredentialCipher",
     "CredentialCipher",
     "CredentialMetadata",
     "EncryptionEnvelope",

--- a/src/orcheo/models/__init__.py
+++ b/src/orcheo/models/__init__.py
@@ -3,8 +3,10 @@
 from orcheo.models.workflow import (
     AesGcmCredentialCipher,
     AuditRecord,
+    CredentialAccessContext,
     CredentialCipher,
     CredentialMetadata,
+    CredentialScope,
     EncryptionEnvelope,
     FernetCredentialCipher,
     Workflow,
@@ -17,8 +19,10 @@ from orcheo.models.workflow import (
 __all__ = [
     "AuditRecord",
     "AesGcmCredentialCipher",
+    "CredentialAccessContext",
     "CredentialCipher",
     "CredentialMetadata",
+    "CredentialScope",
     "EncryptionEnvelope",
     "FernetCredentialCipher",
     "Workflow",

--- a/src/orcheo/models/workflow.py
+++ b/src/orcheo/models/workflow.py
@@ -305,13 +305,120 @@ class AesGcmCredentialCipher:
         return plaintext.decode("utf-8")
 
 
-class CredentialMetadata(TimestampedAuditModel):
-    """Metadata describing encrypted credentials associated with a workflow."""
+class CredentialAccessContext(OrcheoBaseModel):
+    """Describes the caller attempting to access a credential."""
 
-    workflow_id: UUID
+    workflow_id: UUID | None = None
+    workspace_id: UUID | None = None
+    roles: list[str] = Field(default_factory=list)
+
+    @field_validator("roles", mode="after")
+    @classmethod
+    def _normalize_roles(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for role in value:
+            candidate = role.strip().lower()
+            if candidate and candidate not in seen:
+                seen.add(candidate)
+                normalized.append(candidate)
+        return normalized
+
+
+class CredentialScope(OrcheoBaseModel):
+    """Scope configuration declaring which callers may access a credential."""
+
+    workflow_ids: list[UUID] = Field(default_factory=list)
+    workspace_ids: list[UUID] = Field(default_factory=list)
+    roles: list[str] = Field(default_factory=list)
+
+    @field_validator("workflow_ids", "workspace_ids", mode="after")
+    @classmethod
+    def _dedupe_uuid_list(cls, value: list[UUID]) -> list[UUID]:
+        seen: set[UUID] = set()
+        deduped: list[UUID] = []
+        for item in value:
+            if item not in seen:
+                seen.add(item)
+                deduped.append(item)
+        return deduped
+
+    @field_validator("roles", mode="after")
+    @classmethod
+    def _normalize_roles(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for role in value:
+            candidate = role.strip().lower()
+            if candidate and candidate not in seen:
+                seen.add(candidate)
+                normalized.append(candidate)
+        return normalized
+
+    @classmethod
+    def unrestricted(cls) -> CredentialScope:
+        """Return a scope that allows access from any context."""
+        return cls()
+
+    @classmethod
+    def for_workflows(cls, *workflow_ids: UUID) -> CredentialScope:
+        """Create a scope limited to the provided workflow identifiers."""
+        return cls(workflow_ids=list(workflow_ids))
+
+    @classmethod
+    def for_workspaces(cls, *workspace_ids: UUID) -> CredentialScope:
+        """Create a scope limited to the provided workspace identifiers."""
+        return cls(workspace_ids=list(workspace_ids))
+
+    @classmethod
+    def for_roles(cls, *roles: str) -> CredentialScope:
+        """Create a scope limited to callers possessing at least one role."""
+        return cls(roles=[role for role in roles])
+
+    def allows(self, context: CredentialAccessContext) -> bool:
+        """Return whether the provided access context satisfies the scope."""
+        if self.workflow_ids:
+            if (
+                context.workflow_id is None
+                or context.workflow_id not in self.workflow_ids
+            ):
+                return False
+        if self.workspace_ids:
+            if (
+                context.workspace_id is None
+                or context.workspace_id not in self.workspace_ids
+            ):
+                return False
+        if self.roles:
+            if not context.roles:
+                return False
+            context_roles = set(context.roles)
+            if not context_roles.intersection(self.roles):
+                return False
+        return True
+
+    def is_unrestricted(self) -> bool:
+        """Return whether the scope allows access from any context."""
+        return not (self.workflow_ids or self.workspace_ids or self.roles)
+
+    def scope_hint(self) -> str:
+        """Return a stable string hint representing the most specific scope."""
+        if self.workflow_ids:
+            return str(self.workflow_ids[0])
+        if self.workspace_ids:
+            return str(self.workspace_ids[0])
+        if self.roles:
+            return self.roles[0]
+        return "GLOBAL"
+
+
+class CredentialMetadata(TimestampedAuditModel):
+    """Metadata describing encrypted credentials with configurable scope."""
+
     name: str
     provider: str
     scopes: list[str] = Field(default_factory=list)
+    scope: CredentialScope = Field(default_factory=CredentialScope.unrestricted)
     encryption: EncryptionEnvelope
     last_rotated_at: datetime | None = None
 
@@ -331,21 +438,21 @@ class CredentialMetadata(TimestampedAuditModel):
     def create(
         cls,
         *,
-        workflow_id: UUID,
         name: str,
         provider: str,
         scopes: Sequence[str],
         secret: str,
         cipher: CredentialCipher,
         actor: str,
+        scope: CredentialScope | None = None,
     ) -> CredentialMetadata:
         """Construct a credential metadata record with encrypted secret."""
         encryption = cipher.encrypt(secret)
         metadata = cls(
-            workflow_id=workflow_id,
             name=name,
             provider=provider,
             scopes=list(scopes),
+            scope=scope or CredentialScope.unrestricted(),
             encryption=encryption,
         )
         metadata.record_event(actor=actor, action="credential_created")
@@ -373,10 +480,10 @@ class CredentialMetadata(TimestampedAuditModel):
         """Return a redacted representation suitable for logs."""
         return {
             "id": str(self.id),
-            "workflow_id": str(self.workflow_id),
             "name": self.name,
             "provider": self.provider,
             "scopes": list(self.scopes),
+            "scope": self.scope.model_dump(),
             "last_rotated_at": self.last_rotated_at.isoformat()
             if self.last_rotated_at
             else None,

--- a/src/orcheo/models/workflow.py
+++ b/src/orcheo/models/workflow.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 import hashlib
 import json
+import os
 import re
-from base64 import urlsafe_b64encode
+from base64 import b64decode, b64encode, urlsafe_b64encode
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Protocol
 from uuid import UUID, uuid4
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
@@ -254,6 +256,50 @@ class FernetCredentialCipher:
         try:
             plaintext = self._fernet.decrypt(envelope.ciphertext.encode("utf-8"))
         except InvalidToken as exc:  # pragma: no cover - defensive
+            msg = "Unable to decrypt credential payload with provided key."
+            raise ValueError(msg) from exc
+        return plaintext.decode("utf-8")
+
+
+class AesGcmCredentialCipher:
+    """Credential cipher backed by AES-256 GCM."""
+
+    algorithm: str = "aes256-gcm.v1"
+
+    def __init__(self, *, key: str, key_id: str = "primary") -> None:
+        """Derive a 256-bit AES key from the provided secret."""
+        digest = hashlib.sha256(key.encode("utf-8")).digest()
+        self._aesgcm = AESGCM(digest)
+        self.key_id = key_id
+
+    def encrypt(self, plaintext: str) -> EncryptionEnvelope:
+        """Encrypt plaintext and return an envelope with nonce+ciphertext."""
+        nonce = os.urandom(12)
+        ciphertext = self._aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+        payload = b64encode(nonce + ciphertext).decode("utf-8")
+        return EncryptionEnvelope(
+            algorithm=self.algorithm,
+            key_id=self.key_id,
+            ciphertext=payload,
+        )
+
+    def decrypt(self, envelope: EncryptionEnvelope) -> str:
+        """Decrypt an :class:`EncryptionEnvelope` produced by this cipher."""
+        try:
+            decoded = b64decode(envelope.ciphertext.encode("utf-8"))
+        except Exception as exc:  # pragma: no cover - defensive
+            msg = "Encrypted payload is not valid base64 data."
+            raise ValueError(msg) from exc
+
+        if len(decoded) < 12:
+            msg = "Encrypted payload is too short to contain a nonce."
+            raise ValueError(msg)
+
+        nonce = decoded[:12]
+        ciphertext = decoded[12:]
+        try:
+            plaintext = self._aesgcm.decrypt(nonce, ciphertext, None)
+        except Exception as exc:  # pragma: no cover - defensive
             msg = "Unable to decrypt credential payload with provided key."
             raise ValueError(msg) from exc
         return plaintext.decode("utf-8")

--- a/src/orcheo/vault/__init__.py
+++ b/src/orcheo/vault/__init__.py
@@ -1,0 +1,248 @@
+"""Credential vault implementations with AES-256 encryption support."""
+
+from __future__ import annotations
+import secrets
+import sqlite3
+import threading
+from collections.abc import Iterable, MutableMapping, Sequence
+from pathlib import Path
+from uuid import UUID
+from orcheo.models import (
+    AesGcmCredentialCipher,
+    CredentialCipher,
+    CredentialMetadata,
+)
+
+
+class VaultError(RuntimeError):
+    """Base error type for vault operations."""
+
+
+class CredentialNotFoundError(VaultError):
+    """Raised when a credential cannot be found for the workflow."""
+
+
+class WorkflowScopeError(VaultError):
+    """Raised when attempting to access a credential from another workflow."""
+
+
+class RotationPolicyError(VaultError):
+    """Raised when a rotation violates configured policies."""
+
+
+class BaseCredentialVault:
+    """Base helper that implements common credential vault workflows."""
+
+    def __init__(self, *, cipher: CredentialCipher | None = None) -> None:
+        """Initialize the vault with an encryption cipher."""
+        self._cipher = cipher or AesGcmCredentialCipher(key=secrets.token_hex(32))
+
+    def create_credential(
+        self,
+        *,
+        workflow_id: UUID,
+        name: str,
+        provider: str,
+        scopes: Sequence[str],
+        secret: str,
+        actor: str,
+    ) -> CredentialMetadata:
+        """Encrypt and persist a new credential."""
+        metadata = CredentialMetadata.create(
+            workflow_id=workflow_id,
+            name=name,
+            provider=provider,
+            scopes=scopes,
+            secret=secret,
+            cipher=self._cipher,
+            actor=actor,
+        )
+        self._persist_metadata(metadata)
+        return metadata.model_copy(deep=True)
+
+    def rotate_secret(
+        self,
+        *,
+        workflow_id: UUID,
+        credential_id: UUID,
+        secret: str,
+        actor: str,
+    ) -> CredentialMetadata:
+        """Rotate an existing credential secret enforcing policy constraints."""
+        metadata = self._get_metadata(
+            workflow_id=workflow_id, credential_id=credential_id
+        )
+        current_secret = metadata.reveal(cipher=self._cipher)
+        if current_secret == secret:
+            msg = "Rotated secret must differ from the previous value."
+            raise RotationPolicyError(msg)
+        metadata.rotate_secret(secret=secret, cipher=self._cipher, actor=actor)
+        self._persist_metadata(metadata)
+        return metadata.model_copy(deep=True)
+
+    def reveal_secret(self, *, workflow_id: UUID, credential_id: UUID) -> str:
+        """Return the decrypted secret for the credential."""
+        metadata = self._get_metadata(
+            workflow_id=workflow_id, credential_id=credential_id
+        )
+        return metadata.reveal(cipher=self._cipher)
+
+    def list_credentials(self, *, workflow_id: UUID) -> list[CredentialMetadata]:
+        """Return credential metadata for a workflow."""
+        return [item.model_copy(deep=True) for item in self._iter_metadata(workflow_id)]
+
+    def describe_credentials(
+        self, *, workflow_id: UUID
+    ) -> list[MutableMapping[str, object]]:
+        """Return masked representations suitable for logging."""
+        return [item.redact() for item in self._iter_metadata(workflow_id)]
+
+    def _get_metadata(
+        self, *, workflow_id: UUID, credential_id: UUID
+    ) -> CredentialMetadata:
+        metadata = self._load_metadata(credential_id)
+        if metadata.workflow_id != workflow_id:
+            msg = "Credential does not belong to the provided workflow."
+            raise WorkflowScopeError(msg)
+        return metadata
+
+    def _persist_metadata(
+        self, metadata: CredentialMetadata
+    ) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def _load_metadata(
+        self, credential_id: UUID
+    ) -> CredentialMetadata:  # pragma: no cover
+        raise NotImplementedError
+
+    def _iter_metadata(
+        self, workflow_id: UUID
+    ) -> Iterable[CredentialMetadata]:  # pragma: no cover
+        raise NotImplementedError
+
+
+class InMemoryCredentialVault(BaseCredentialVault):
+    """In-memory credential vault used for tests and local workflows."""
+
+    def __init__(self, *, cipher: CredentialCipher | None = None) -> None:
+        """Create an ephemeral in-memory vault instance."""
+        super().__init__(cipher=cipher)
+        self._store: dict[UUID, CredentialMetadata] = {}
+
+    def _persist_metadata(self, metadata: CredentialMetadata) -> None:
+        self._store[metadata.id] = metadata.model_copy(deep=True)
+
+    def _load_metadata(self, credential_id: UUID) -> CredentialMetadata:
+        try:
+            return self._store[credential_id].model_copy(deep=True)
+        except KeyError as exc:
+            msg = "Credential was not found."
+            raise CredentialNotFoundError(msg) from exc
+
+    def _iter_metadata(self, workflow_id: UUID) -> Iterable[CredentialMetadata]:
+        for metadata in self._store.values():
+            if metadata.workflow_id == workflow_id:
+                yield metadata.model_copy(deep=True)
+
+
+class FileCredentialVault(BaseCredentialVault):
+    """File-backed credential vault stored in a SQLite database."""
+
+    def __init__(
+        self, path: str | Path, *, cipher: CredentialCipher | None = None
+    ) -> None:
+        """Create a SQLite-backed credential vault."""
+        super().__init__(cipher=cipher)
+        self._path = Path(path).expanduser()
+        self._lock = threading.Lock()
+        self._initialize()
+
+    def _initialize(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS credentials (
+                    id TEXT PRIMARY KEY,
+                    workflow_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_credentials_workflow
+                    ON credentials(workflow_id)
+                """
+            )
+            conn.commit()
+
+    def _persist_metadata(self, metadata: CredentialMetadata) -> None:
+        payload = metadata.model_dump_json()
+        with self._lock, sqlite3.connect(self._path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO credentials (
+                    id,
+                    workflow_id,
+                    name,
+                    provider,
+                    created_at,
+                    updated_at,
+                    payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(metadata.id),
+                    str(metadata.workflow_id),
+                    metadata.name,
+                    metadata.provider,
+                    metadata.created_at.isoformat(),
+                    metadata.updated_at.isoformat(),
+                    payload,
+                ),
+            )
+            conn.commit()
+
+    def _load_metadata(self, credential_id: UUID) -> CredentialMetadata:
+        with self._lock, sqlite3.connect(self._path) as conn:
+            cursor = conn.execute(
+                "SELECT payload FROM credentials WHERE id = ?",
+                (str(credential_id),),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            msg = "Credential was not found."
+            raise CredentialNotFoundError(msg)
+        return CredentialMetadata.model_validate_json(row[0])
+
+    def _iter_metadata(self, workflow_id: UUID) -> Iterable[CredentialMetadata]:
+        with self._lock, sqlite3.connect(self._path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT payload
+                  FROM credentials
+                 WHERE workflow_id = ?
+              ORDER BY created_at ASC
+                """,
+                (str(workflow_id),),
+            )
+            rows = cursor.fetchall()
+        for row in rows:
+            yield CredentialMetadata.model_validate_json(row[0])
+
+
+__all__ = [
+    "VaultError",
+    "CredentialNotFoundError",
+    "WorkflowScopeError",
+    "RotationPolicyError",
+    "BaseCredentialVault",
+    "InMemoryCredentialVault",
+    "FileCredentialVault",
+]

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,121 @@
+"""Tests covering credential vault implementations."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from orcheo.models import AesGcmCredentialCipher
+from orcheo.vault import (
+    CredentialNotFoundError,
+    FileCredentialVault,
+    InMemoryCredentialVault,
+    RotationPolicyError,
+    WorkflowScopeError,
+)
+
+
+def test_inmemory_vault_scopes_credentials_and_masks_logs() -> None:
+    cipher = AesGcmCredentialCipher(key="unit-test-key")
+    vault = InMemoryCredentialVault(cipher=cipher)
+    workflow_id = uuid4()
+
+    metadata = vault.create_credential(
+        workflow_id=workflow_id,
+        name="OpenAI",
+        provider="openai",
+        scopes=["chat:write"],
+        secret="initial-token",
+        actor="alice",
+    )
+
+    assert (
+        vault.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        == "initial-token"
+    )
+
+    listed = vault.list_credentials(workflow_id=workflow_id)
+    assert [item.id for item in listed] == [metadata.id]
+
+    masked = vault.describe_credentials(workflow_id=workflow_id)
+    assert masked[0]["encryption"]["algorithm"] == cipher.algorithm
+    assert "ciphertext" not in masked[0]["encryption"]
+
+    unrelated = vault.list_credentials(workflow_id=uuid4())
+    assert unrelated == []
+
+    with pytest.raises(RotationPolicyError):
+        vault.rotate_secret(
+            workflow_id=workflow_id,
+            credential_id=metadata.id,
+            secret="initial-token",
+            actor="security-bot",
+        )
+
+    rotated = vault.rotate_secret(
+        workflow_id=workflow_id,
+        credential_id=metadata.id,
+        secret="rotated-token",
+        actor="security-bot",
+    )
+    assert rotated.last_rotated_at >= metadata.last_rotated_at
+    assert (
+        vault.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        == "rotated-token"
+    )
+
+    other_workflow_id = uuid4()
+    with pytest.raises(WorkflowScopeError):
+        vault.reveal_secret(workflow_id=other_workflow_id, credential_id=metadata.id)
+
+    unknown_id = UUID(int=0)
+    with pytest.raises(CredentialNotFoundError):
+        vault.reveal_secret(workflow_id=workflow_id, credential_id=unknown_id)
+    assert vault.describe_credentials(workflow_id=uuid4()) == []
+
+
+def test_file_vault_persists_credentials(tmp_path) -> None:
+    cipher = AesGcmCredentialCipher(key="file-backend-key")
+    vault_path = tmp_path / "vault.sqlite"
+
+    vault = FileCredentialVault(vault_path, cipher=cipher)
+    workflow_id = uuid4()
+    metadata = vault.create_credential(
+        workflow_id=workflow_id,
+        name="Stripe",
+        provider="stripe",
+        scopes=["payments:write"],
+        secret="sk_live_initial",
+        actor="alice",
+    )
+
+    restored = FileCredentialVault(vault_path, cipher=cipher)
+    assert (
+        restored.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        == "sk_live_initial"
+    )
+
+    restored.rotate_secret(
+        workflow_id=workflow_id,
+        credential_id=metadata.id,
+        secret="sk_live_rotated",
+        actor="security-bot",
+    )
+
+    reloaded = FileCredentialVault(vault_path, cipher=cipher)
+    assert (
+        reloaded.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        == "sk_live_rotated"
+    )
+
+    listed = reloaded.list_credentials(workflow_id=workflow_id)
+    assert len(listed) == 1
+    assert listed[0].provider == "stripe"
+
+    masked = reloaded.describe_credentials(workflow_id=workflow_id)
+    assert masked[0]["provider"] == "stripe"
+    assert "ciphertext" not in masked[0]["encryption"]
+
+    with pytest.raises(CredentialNotFoundError):
+        reloaded.reveal_secret(workflow_id=workflow_id, credential_id=uuid4())

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -6,7 +6,11 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from orcheo.models import AesGcmCredentialCipher
+from orcheo.models import (
+    AesGcmCredentialCipher,
+    CredentialAccessContext,
+    CredentialScope,
+)
 from orcheo.vault import (
     CredentialNotFoundError,
     FileCredentialVault,
@@ -16,13 +20,15 @@ from orcheo.vault import (
 )
 
 
-def test_inmemory_vault_scopes_credentials_and_masks_logs() -> None:
+def test_inmemory_vault_supports_shared_and_restricted_credentials() -> None:
     cipher = AesGcmCredentialCipher(key="unit-test-key")
     vault = InMemoryCredentialVault(cipher=cipher)
-    workflow_id = uuid4()
+    workflow_a = uuid4()
+    workflow_b = uuid4()
+    context_a = CredentialAccessContext(workflow_id=workflow_a)
+    context_b = CredentialAccessContext(workflow_id=workflow_b)
 
     metadata = vault.create_credential(
-        workflow_id=workflow_id,
         name="OpenAI",
         provider="openai",
         scopes=["chat:write"],
@@ -31,48 +37,104 @@ def test_inmemory_vault_scopes_credentials_and_masks_logs() -> None:
     )
 
     assert (
-        vault.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        vault.reveal_secret(credential_id=metadata.id, context=context_a)
+        == "initial-token"
+    )
+    assert (
+        vault.reveal_secret(credential_id=metadata.id, context=context_b)
         == "initial-token"
     )
 
-    listed = vault.list_credentials(workflow_id=workflow_id)
-    assert [item.id for item in listed] == [metadata.id]
+    listed_a = vault.list_credentials(context=context_a)
+    listed_b = vault.list_credentials(context=context_b)
+    assert [item.id for item in listed_a] == [metadata.id]
+    assert [item.id for item in listed_b] == [metadata.id]
 
-    masked = vault.describe_credentials(workflow_id=workflow_id)
+    masked = vault.describe_credentials(context=context_a)
     assert masked[0]["encryption"]["algorithm"] == cipher.algorithm
     assert "ciphertext" not in masked[0]["encryption"]
-
-    unrelated = vault.list_credentials(workflow_id=uuid4())
-    assert unrelated == []
+    assert masked[0]["scope"]["workflow_ids"] == []
 
     with pytest.raises(RotationPolicyError):
         vault.rotate_secret(
-            workflow_id=workflow_id,
             credential_id=metadata.id,
             secret="initial-token",
             actor="security-bot",
+            context=context_a,
         )
 
     rotated = vault.rotate_secret(
-        workflow_id=workflow_id,
         credential_id=metadata.id,
         secret="rotated-token",
         actor="security-bot",
+        context=context_a,
     )
     assert rotated.last_rotated_at >= metadata.last_rotated_at
     assert (
-        vault.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        vault.reveal_secret(credential_id=metadata.id, context=context_a)
+        == "rotated-token"
+    )
+    assert (
+        vault.reveal_secret(credential_id=metadata.id, context=context_b)
         == "rotated-token"
     )
 
-    other_workflow_id = uuid4()
+    shared = vault.describe_credentials(context=context_b)
+    assert shared[0]["scope"]["workflow_ids"] == []
+
+    restricted_scope = CredentialScope.for_workflows(workflow_a)
+    restricted = vault.create_credential(
+        name="Slack",
+        provider="slack",
+        scopes=["chat:write"],
+        secret="slack-token",
+        actor="alice",
+        scope=restricted_scope,
+    )
+
+    assert (
+        vault.reveal_secret(credential_id=restricted.id, context=context_a)
+        == "slack-token"
+    )
+
     with pytest.raises(WorkflowScopeError):
-        vault.reveal_secret(workflow_id=other_workflow_id, credential_id=metadata.id)
+        vault.reveal_secret(credential_id=restricted.id, context=context_b)
+
+    assert {item.id for item in vault.list_credentials(context=context_a)} == {
+        metadata.id,
+        restricted.id,
+    }
+    assert [item.id for item in vault.list_credentials(context=context_b)] == [
+        metadata.id
+    ]
+
+    role_scope = CredentialScope.for_roles("admin")
+    role_metadata = vault.create_credential(
+        name="PagerDuty",
+        provider="pagerduty",
+        scopes=[],
+        secret="pd-key",
+        actor="alice",
+        scope=role_scope,
+    )
+
+    admin_context = CredentialAccessContext(roles=["Admin", "operator"])
+    viewer_context = CredentialAccessContext(roles=["viewer"])
+
+    assert (
+        vault.reveal_secret(credential_id=role_metadata.id, context=admin_context)
+        == "pd-key"
+    )
+
+    with pytest.raises(WorkflowScopeError):
+        vault.reveal_secret(credential_id=role_metadata.id, context=viewer_context)
 
     unknown_id = UUID(int=0)
     with pytest.raises(CredentialNotFoundError):
-        vault.reveal_secret(workflow_id=workflow_id, credential_id=unknown_id)
-    assert vault.describe_credentials(workflow_id=uuid4()) == []
+        vault.reveal_secret(credential_id=unknown_id, context=context_a)
+    viewer_describe = vault.describe_credentials(context=viewer_context)
+    assert [entry["id"] for entry in viewer_describe] == [str(metadata.id)]
+    assert viewer_describe[0]["scope"]["roles"] == []
 
 
 def test_file_vault_persists_credentials(tmp_path) -> None:
@@ -81,8 +143,8 @@ def test_file_vault_persists_credentials(tmp_path) -> None:
 
     vault = FileCredentialVault(vault_path, cipher=cipher)
     workflow_id = uuid4()
+    workflow_context = CredentialAccessContext(workflow_id=workflow_id)
     metadata = vault.create_credential(
-        workflow_id=workflow_id,
         name="Stripe",
         provider="stripe",
         scopes=["payments:write"],
@@ -92,30 +154,33 @@ def test_file_vault_persists_credentials(tmp_path) -> None:
 
     restored = FileCredentialVault(vault_path, cipher=cipher)
     assert (
-        restored.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        restored.reveal_secret(credential_id=metadata.id, context=workflow_context)
         == "sk_live_initial"
     )
 
     restored.rotate_secret(
-        workflow_id=workflow_id,
         credential_id=metadata.id,
         secret="sk_live_rotated",
         actor="security-bot",
+        context=workflow_context,
     )
 
     reloaded = FileCredentialVault(vault_path, cipher=cipher)
     assert (
-        reloaded.reveal_secret(workflow_id=workflow_id, credential_id=metadata.id)
+        reloaded.reveal_secret(credential_id=metadata.id, context=workflow_context)
         == "sk_live_rotated"
     )
 
-    listed = reloaded.list_credentials(workflow_id=workflow_id)
+    listed = reloaded.list_credentials(context=workflow_context)
     assert len(listed) == 1
     assert listed[0].provider == "stripe"
 
-    masked = reloaded.describe_credentials(workflow_id=workflow_id)
+    masked = reloaded.describe_credentials(context=workflow_context)
     assert masked[0]["provider"] == "stripe"
     assert "ciphertext" not in masked[0]["encryption"]
 
     with pytest.raises(CredentialNotFoundError):
-        reloaded.reveal_secret(workflow_id=workflow_id, credential_id=uuid4())
+        reloaded.reveal_secret(
+            credential_id=uuid4(),
+            context=CredentialAccessContext(workflow_id=workflow_id),
+        )

--- a/tests/test_workflow_models.py
+++ b/tests/test_workflow_models.py
@@ -7,8 +7,10 @@ from uuid import uuid4
 import pytest
 from orcheo.models import (
     AesGcmCredentialCipher,
+    CredentialAccessContext,
     CredentialCipher,
     CredentialMetadata,
+    CredentialScope,
     EncryptionEnvelope,
     FernetCredentialCipher,
     Workflow,
@@ -122,7 +124,6 @@ def test_credential_metadata_encrypts_and_redacts_secrets() -> None:
     cipher = AesGcmCredentialCipher(key="super-secret-key", key_id="k1")
 
     metadata = CredentialMetadata.create(
-        workflow_id=uuid4(),
         name="OpenAI",
         provider="openai",
         scopes=["chat:write", "chat:write"],
@@ -144,6 +145,11 @@ def test_credential_metadata_encrypts_and_redacts_secrets() -> None:
     assert "ciphertext" not in redacted["encryption"]
     assert redacted["encryption"]["algorithm"] == cipher.algorithm
     assert redacted["encryption"]["key_id"] == cipher.key_id
+    assert redacted["scope"] == {
+        "workflow_ids": [],
+        "workspace_ids": [],
+        "roles": [],
+    }
 
     wrong_cipher = AesGcmCredentialCipher(key="other-key", key_id="k1")
     with pytest.raises(ValueError):
@@ -177,6 +183,53 @@ def test_credential_metadata_encrypts_and_redacts_secrets() -> None:
     dummy_cipher: CredentialCipher = DummyCipher()
     with pytest.raises(ValueError):
         metadata.encryption.decrypt(dummy_cipher)
+
+
+def test_credential_scope_allows_multiple_constraints() -> None:
+    workflow_id = uuid4()
+    workspace_id = uuid4()
+
+    unrestricted = CredentialScope.unrestricted()
+    assert unrestricted.is_unrestricted()
+    assert unrestricted.allows(CredentialAccessContext())
+
+    workflow_scope = CredentialScope.for_workflows(workflow_id, workflow_id)
+    assert workflow_scope.allows(CredentialAccessContext(workflow_id=workflow_id))
+    assert not workflow_scope.allows(CredentialAccessContext(workflow_id=uuid4()))
+
+    workspace_scope = CredentialScope.for_workspaces(workspace_id)
+    assert workspace_scope.allows(CredentialAccessContext(workspace_id=workspace_id))
+    assert not workspace_scope.allows(CredentialAccessContext())
+    assert workspace_scope.scope_hint() == str(workspace_id)
+
+    combined = CredentialScope(
+        workflow_ids=[workflow_id],
+        workspace_ids=[workspace_id],
+        roles=["Admin", "admin"],
+    )
+    context = CredentialAccessContext(
+        workflow_id=workflow_id,
+        workspace_id=workspace_id,
+        roles=["operator", "Admin"],
+    )
+    assert combined.allows(context)
+    assert combined.scope_hint() == str(workflow_id)
+    assert not combined.is_unrestricted()
+
+    mismatched_roles = CredentialAccessContext(
+        workflow_id=workflow_id,
+        workspace_id=workspace_id,
+        roles=["viewer"],
+    )
+    assert not combined.allows(mismatched_roles)
+
+    role_only_scope = CredentialScope.for_roles("Admin", "Admin", " ")
+    assert role_only_scope.scope_hint() == "admin"
+    assert role_only_scope.roles == ["admin"]
+    assert not role_only_scope.allows(CredentialAccessContext())
+
+    normalized_context = CredentialAccessContext(roles=["Admin", "admin", " "])
+    assert normalized_context.roles == ["admin"]
 
 
 def test_fernet_cipher_round_trip_and_algorithm_mismatch() -> None:

--- a/tests/test_workflow_models.py
+++ b/tests/test_workflow_models.py
@@ -5,10 +5,10 @@ from typing import Protocol
 from uuid import uuid4
 import pytest
 from orcheo.models import (
+    AesGcmCredentialCipher,
     CredentialCipher,
     CredentialMetadata,
     EncryptionEnvelope,
-    FernetCredentialCipher,
     Workflow,
     WorkflowRun,
     WorkflowRunStatus,
@@ -117,7 +117,7 @@ def test_workflow_run_cancel_without_reason() -> None:
 
 
 def test_credential_metadata_encrypts_and_redacts_secrets() -> None:
-    cipher = FernetCredentialCipher(key="super-secret-key", key_id="k1")
+    cipher = AesGcmCredentialCipher(key="super-secret-key", key_id="k1")
 
     metadata = CredentialMetadata.create(
         workflow_id=uuid4(),
@@ -143,11 +143,11 @@ def test_credential_metadata_encrypts_and_redacts_secrets() -> None:
     assert redacted["encryption"]["algorithm"] == cipher.algorithm
     assert redacted["encryption"]["key_id"] == cipher.key_id
 
-    wrong_cipher = FernetCredentialCipher(key="other-key", key_id="k1")
+    wrong_cipher = AesGcmCredentialCipher(key="other-key", key_id="k1")
     with pytest.raises(ValueError):
         metadata.reveal(cipher=wrong_cipher)
 
-    mismatched_cipher = FernetCredentialCipher(key="super-secret-key", key_id="k2")
+    mismatched_cipher = AesGcmCredentialCipher(key="super-secret-key", key_id="k2")
     with pytest.raises(ValueError):
         metadata.reveal(cipher=mismatched_cipher)
 


### PR DESCRIPTION
## Summary
- add an AES-GCM credential cipher and surface it from the models package
- implement in-memory and SQLite-backed credential vaults with per-workflow scoping, rotation policies, and masked logging helpers
- cover the vault behavior with targeted tests and mark the roadmap item complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f269793a308327b5094c69380d6dd0