### PR TITLE
docs: capture frontend experience plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ directly to the backend importer, execute it, and stream live updates.
 See [`docs/deployment.md`](docs/deployment.md) for Docker Compose and managed
 PostgreSQL deployment recipes.
 
+## Frontend experience plan
+
+The path to a production-quality canvas is captured in
+[`docs/frontend_plan.md`](docs/frontend_plan.md), outlining research, design
+system development, architectural refactors, and QA milestones for the React
+application. Start there when kicking off frontend workstreams so design and
+engineering stay aligned.
+
 ## Workflow repository configuration
 
 The FastAPI backend now supports pluggable workflow repositories so local

--- a/docs/frontend_plan.md
+++ b/docs/frontend_plan.md
@@ -26,8 +26,8 @@ This document captures the actionable plan for evolving the Orcheo canvas from i
 ## Implementation Track
 | Workstream | Description | Owner Roles | Milestones |
 | --- | --- | --- | --- |
-| Frontend Architecture | Restructure codebase into `features/<domain>` folders, introduce routing, and centralize API services (consider React Query). | Frontend lead, supporting engineers | Week 1: file structure refactor; Week 2: shared services & hooks in place |
-| Component Library | Implement primitives (buttons, inputs, panels, banners) powered by the new token system, with Storybook or equivalent playground for regression checks. | UI engineer, designer | Week 2: tokens + base components; Week 3: complex components (tables, forms) |
+| Frontend Architecture | Restructure codebase into `features/<domain>` folders, introduce routing, and centralize API services by standardizing on React Query for data fetching and caching. | Frontend lead, supporting engineers | Week 1: file structure refactor; Week 2: shared services & hooks in place |
+| Component Library | Implement primitives (buttons, inputs, panels, banners) powered by the new token system, documenting them in Storybook to enable visual regression checks. | UI engineer, designer | Week 2: tokens + base components; Week 3: complex components (tables, forms) |
 | Feature Implementation | Rebuild templates, issuance, and alerts screens with new components, state handling, and clear empty/loading/error states. | Feature squads | Week 3: templates; Week 4: issuance; Week 5: alerts |
 | Quality & Tooling | Expand Vitest/Test Library coverage, add axe-based accessibility checks, and wire lint/test to pre-commit CI gates. | QA engineer, frontend lead | Week 2: test harness scaffolding; Week 5: >80% critical flow coverage |
 | Documentation & Handoff | Maintain design system docs, contribution guidelines, and release notes for frontend changes. | Designer, tech writer | Ongoing; Week 5: publish contribution guide |

--- a/docs/frontend_plan.md
+++ b/docs/frontend_plan.md
@@ -1,0 +1,59 @@
+# Frontend Experience Design & Implementation Plan
+
+## Purpose
+This document captures the actionable plan for evolving the Orcheo canvas from its current developer-centric prototype into a production-ready, user-centered experience. It consolidates design and engineering activities so product, design, and frontend contributors can execute in lockstep while staying aligned with backend capabilities.
+
+## Current Baseline Assessment
+- **Monolithic application shell**: A single React component orchestrates data fetching, state management, and UI for credential templates, issuance, and governance alerts, making the codebase brittle and hard to extend.
+- **Ad-hoc styling**: One global stylesheet applies hard-coded gradients, colors, and breakpoints, offering no reusable tokens or component-level theming for future surfaces.
+- **Minimal UX coverage**: Empty, loading, and error states are limited to simple banners, and there is no formalized navigation or information architecture to guide feature growth.
+- **Testing gap**: Automated coverage is limited to a navigation smoke test, leaving interaction flows, validation logic, and API error handling unverified.
+
+## Objectives
+1. Establish a user-centered navigation and layout that separates credential templates, issuance workflows, and governance alerts into dedicated, deep-linkable views.
+2. Create a scalable design system with documented tokens, components, and responsive behavior to accelerate feature velocity while ensuring accessibility.
+3. Modularize the frontend architecture into feature-first domains with clear data/service boundaries, paving the way for richer workflows and real-time updates.
+4. Raise quality confidence by expanding component, integration, and accessibility testing around critical user journeys.
+
+## Design & Research Track
+| Phase | Goals | Key Activities | Deliverables |
+| --- | --- | --- | --- |
+| Discovery | Align on personas, jobs-to-be-done, and backend constraints | Stakeholder interviews, API contract review, audit of current fetch logic | Updated journey map, API capability matrix |
+| Information Architecture | Define navigation, routing, and content hierarchy | Task modeling, sitemap sketches, low-fidelity wireframes | Signed-off IA diagram, annotated wireframes |
+| Visual Design System | Establish reusable tokens and component patterns | Token palette creation, component inventory, responsive spec | Design tokens library, component spec sheets |
+| Validation | Confirm usability and accessibility of proposed flows | Usability walkthroughs, a11y heuristic review, design QA checklist | Usability findings log, accessibility checklist |
+
+## Implementation Track
+| Workstream | Description | Owner Roles | Milestones |
+| --- | --- | --- | --- |
+| Frontend Architecture | Restructure codebase into `features/<domain>` folders, introduce routing, and centralize API services (consider React Query). | Frontend lead, supporting engineers | Week 1: file structure refactor; Week 2: shared services & hooks in place |
+| Component Library | Implement primitives (buttons, inputs, panels, banners) powered by the new token system, with Storybook or equivalent playground for regression checks. | UI engineer, designer | Week 2: tokens + base components; Week 3: complex components (tables, forms) |
+| Feature Implementation | Rebuild templates, issuance, and alerts screens with new components, state handling, and clear empty/loading/error states. | Feature squads | Week 3: templates; Week 4: issuance; Week 5: alerts |
+| Quality & Tooling | Expand Vitest/Test Library coverage, add axe-based accessibility checks, and wire lint/test to pre-commit CI gates. | QA engineer, frontend lead | Week 2: test harness scaffolding; Week 5: >80% critical flow coverage |
+| Documentation & Handoff | Maintain design system docs, contribution guidelines, and release notes for frontend changes. | Designer, tech writer | Ongoing; Week 5: publish contribution guide |
+
+## Cross-Functional Dependencies
+- **Backend**: Confirm API stability for credential templates, issuance, and alerts; expose pagination and filtering endpoints needed for advanced UI controls.
+- **Security**: Validate that credential displays and alert acknowledgements meet compliance requirements before UI polish.
+- **DevOps**: Align on build pipeline (Vite, lint, tests) and preview environment strategy for stakeholder reviews.
+
+## Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Design debt persists due to split priorities | UI remains inconsistent and slows feature velocity | Timebox weekly design reviews and enforce component usage via lint rules or Storybook docs |
+| Backend contracts shift mid-implementation | Rework screens and data handling | Lock API change window during Weeks 3–5; document versioned contracts |
+| Accessibility gaps emerge late | Requires costly post-hoc fixes | Integrate axe checks in CI and run keyboard/screen-reader passes each sprint |
+
+## Success Metrics
+- **Adoption**: 90% of new UI work consumes shared components and tokens.
+- **Quality**: Frontend CI passes lint, test, and accessibility checks with zero regressions across critical flows.
+- **Usability**: Positive feedback from at least three usability walkthroughs covering each primary persona.
+- **Velocity**: Feature squads report <10% time spent on styling or layout churn after component library adoption.
+
+## Next Steps Checklist
+- [ ] Kick off the Discovery phase to synthesize personas, task flows, and API constraints.
+- [ ] Define the information architecture and navigation model through low-fidelity wireframes.
+- [ ] Establish design tokens and component guidelines for the shared UI library.
+- [ ] Restructure the frontend into feature-first modules with centralized data services.
+- [ ] Rebuild templates, issuance, and alerts experiences using the new components and state patterns.
+- [ ] Expand automated testing and accessibility checks to cover critical user journeys.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation.
 - [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
 - [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
+- [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.
 
 ### Milestone 5 – Node Ecosystem & Integrations
 - [ ] Deliver trigger nodes (Webhook, Cron, Manual, HTTP Polling) with both UI and SDK parity.


### PR DESCRIPTION
## Summary
- add a dedicated frontend experience plan covering design, implementation, and QA workstreams
- surface the plan in the main roadmap and README so contributors can discover it easily
- update the plan checklist to focus on actionable design and engineering tasks with trackable progress markers

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68f393b5f3d083278dfbbc6bbe041b3f