### PR TITLE
Enhance canvas tooling and search

### DIFF
--- a/apps/canvas/src/features/workflow/components/canvas/workflow-controls.tsx
+++ b/apps/canvas/src/features/workflow/components/canvas/workflow-controls.tsx
@@ -27,6 +27,7 @@ import {
   MoreHorizontal,
   Share,
   GitBranch,
+  Search,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -44,6 +45,7 @@ interface WorkflowControlsProps {
   onImport?: () => void;
   onShare?: () => void;
   onVersionHistory?: () => void;
+  onSearchToggle?: () => void;
   className?: string;
 }
 
@@ -61,6 +63,7 @@ export default function WorkflowControls({
   onImport,
   onShare,
   onVersionHistory,
+  onSearchToggle,
   className,
 }: WorkflowControlsProps) {
   return (
@@ -104,6 +107,26 @@ export default function WorkflowControls({
             </TooltipTrigger>
             <TooltipContent>
               <p>Save Workflow</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={onSearchToggle}
+                aria-label="Search nodes"
+                disabled={!onSearchToggle}
+              >
+                <Search className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Search &amp; Filter (Ctrl+F)</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/canvas/src/features/workflow/components/canvas/workflow-search.tsx
+++ b/apps/canvas/src/features/workflow/components/canvas/workflow-search.tsx
@@ -93,6 +93,7 @@ export default function WorkflowSearch({
               setSearchQuery("");
               onSearch("");
             }}
+            aria-label="Clear search query"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -118,6 +119,7 @@ export default function WorkflowSearch({
           className="h-7 w-7"
           onClick={onHighlightPrevious}
           disabled={matchCount === 0}
+          aria-label="Highlight previous match"
         >
           <ArrowUp className="h-4 w-4" />
         </Button>
@@ -127,6 +129,7 @@ export default function WorkflowSearch({
           className="h-7 w-7"
           onClick={onHighlightNext}
           disabled={matchCount === 0}
+          aria-label="Highlight next match"
         >
           <ArrowDown className="h-4 w-4" />
         </Button>
@@ -135,6 +138,7 @@ export default function WorkflowSearch({
           size="icon"
           className="h-7 w-7 ml-1"
           onClick={onClose}
+          aria-label="Close search"
         >
           <X className="h-4 w-4" />
         </Button>

--- a/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
+++ b/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
@@ -37,7 +37,15 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
   const controlsRef = useRef<HTMLDivElement>(null);
   const nodeRef = useRef<HTMLDivElement>(null);
 
-  const { label, icon, status = "idle" as const, type, isDisabled } = nodeData;
+  const {
+    label,
+    icon,
+    status = "idle" as const,
+    type,
+    isDisabled,
+    isSearchMatch,
+    isSearchActive,
+  } = nodeData;
 
   // Handle clicks outside the controls to hide them
   useEffect(() => {
@@ -90,6 +98,15 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
     setControlsVisible(false);
   };
 
+  const highlightClasses = cn(
+    "transition-shadow duration-200",
+    isSearchActive &&
+      "ring-4 ring-primary/60 ring-offset-2 ring-offset-background shadow-xl",
+    !isSearchActive &&
+      isSearchMatch &&
+      "ring-2 ring-primary/30 ring-offset-2 ring-offset-background shadow-lg",
+  );
+
   return (
     <div
       ref={nodeRef}
@@ -99,6 +116,7 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
         selected && "ring-2 ring-primary ring-offset-2",
         isDisabled && "opacity-60",
         "h-16 w-16 rounded-xl cursor-pointer",
+        highlightClasses,
       )}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import WorkflowCanvas from "./workflow-canvas";
 
@@ -94,5 +94,43 @@ describe("WorkflowCanvas editing history", () => {
 
     expect(undoButtons[0]).toBeDisabled();
     expect(redoButtons[0]).toBeDisabled();
+  });
+
+  it("opens search overlay with keyboard shortcut", async () => {
+    renderCanvas();
+
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+
+    const searchInput = await screen.findByPlaceholderText("Search nodes...");
+    fireEvent.change(searchInput, { target: { value: "Initial" } });
+
+    expect(await screen.findByText(/1 of 1/i)).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: /close search/i });
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByPlaceholderText("Search nodes..."),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows collapsible inspector panel when a node is opened", async () => {
+    renderCanvas();
+
+    const nodeLabel = await screen.findByText("Initial Node");
+    fireEvent.doubleClick(nodeLabel);
+
+    const collapseButton = await screen.findByRole("button", {
+      name: /collapse inspector panel/i,
+    });
+    expect(collapseButton).toBeVisible();
+
+    fireEvent.click(collapseButton);
+
+    expect(
+      await screen.findByRole("button", { name: /expand inspector panel/i }),
+    ).toBeVisible();
   });
 });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ### Milestone 4 – Visual Designer Experience
 - [x] Migrate the legacy canvas app to connect to the new backend via React Flow foundation, restoring minimap, snapping, and chat affordances while preserving node compatibility.
-- [ ] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
+- [x] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
 - [ ] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
 - [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
 - [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.


### PR DESCRIPTION
## Summary
- add workflow canvas search overlay with keyboard shortcuts, highlighting, and toolbar entry
- refresh canvas layout styling and convert the node inspector into a collapsible side panel
- tighten workflow node visuals, update controls, and expand tests plus documentation roadmap status

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68f679ad253883279865172ae7a59c6d