### PR TITLE
Enhance workflow canvas search and tooling

### DIFF
--- a/apps/canvas/src/features/workflow/components/canvas/workflow-search.tsx
+++ b/apps/canvas/src/features/workflow/components/canvas/workflow-search.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/design-system/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface WorkflowSearchProps {
+  query: string;
   onSearch: (query: string) => void;
   onHighlightNext: () => void;
   onHighlightPrevious: () => void;
@@ -17,6 +18,7 @@ interface WorkflowSearchProps {
 }
 
 export default function WorkflowSearch({
+  query,
   onSearch,
   onHighlightNext,
   onHighlightPrevious,
@@ -26,7 +28,7 @@ export default function WorkflowSearch({
   isOpen,
   className,
 }: WorkflowSearchProps) {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(query);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -36,11 +38,17 @@ export default function WorkflowSearch({
   }, [isOpen]);
 
   useEffect(() => {
+    setSearchQuery(query);
+  }, [query]);
+
+  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === "f") {
+      if (e.ctrlKey && e.key.toLowerCase() === "f") {
         e.preventDefault();
         if (!isOpen) {
-          onSearch("");
+          onSearch(query);
+        } else {
+          inputRef.current?.focus();
         }
       } else if (e.key === "Escape" && isOpen) {
         e.preventDefault();
@@ -56,7 +64,7 @@ export default function WorkflowSearch({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onSearch, onClose, onHighlightNext, onHighlightPrevious]);
+  }, [isOpen, onSearch, onClose, onHighlightNext, onHighlightPrevious, query]);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const query = e.target.value;
@@ -81,6 +89,7 @@ export default function WorkflowSearch({
           value={searchQuery}
           onChange={handleSearchChange}
           placeholder="Search nodes..."
+          aria-label="Search workflow nodes"
           className="pl-8 pr-16 h-9 focus-visible:ring-1"
         />
 
@@ -93,6 +102,7 @@ export default function WorkflowSearch({
               setSearchQuery("");
               onSearch("");
             }}
+            aria-label="Clear search"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -118,6 +128,7 @@ export default function WorkflowSearch({
           className="h-7 w-7"
           onClick={onHighlightPrevious}
           disabled={matchCount === 0}
+          aria-label="Previous match"
         >
           <ArrowUp className="h-4 w-4" />
         </Button>
@@ -127,6 +138,7 @@ export default function WorkflowSearch({
           className="h-7 w-7"
           onClick={onHighlightNext}
           disabled={matchCount === 0}
+          aria-label="Next match"
         >
           <ArrowDown className="h-4 w-4" />
         </Button>
@@ -135,6 +147,7 @@ export default function WorkflowSearch({
           size="icon"
           className="h-7 w-7 ml-1"
           onClick={onClose}
+          aria-label="Close search"
         >
           <X className="h-4 w-4" />
         </Button>

--- a/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
+++ b/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
@@ -28,6 +28,8 @@ export type WorkflowNodeData = {
   isDisabled?: boolean;
   onLabelChange?: (id: string, newLabel: string) => void;
   onNodeInspect?: (id: string) => void;
+  isSearchMatch?: boolean;
+  isActiveSearchMatch?: boolean;
   [key: string]: unknown;
 };
 
@@ -37,7 +39,15 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
   const controlsRef = useRef<HTMLDivElement>(null);
   const nodeRef = useRef<HTMLDivElement>(null);
 
-  const { label, icon, status = "idle" as const, type, isDisabled } = nodeData;
+  const {
+    label,
+    icon,
+    status = "idle" as const,
+    type,
+    isDisabled,
+    isSearchMatch,
+    isActiveSearchMatch,
+  } = nodeData;
 
   // Handle clicks outside the controls to hide them
   useEffect(() => {
@@ -90,16 +100,26 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
     setControlsVisible(false);
   };
 
+  const highlightClassName = selected
+    ? "ring-2 ring-primary ring-offset-2"
+    : isActiveSearchMatch
+      ? "ring-2 ring-primary ring-offset-2 animate-pulse"
+      : isSearchMatch
+        ? "ring-2 ring-sky-400/60 ring-offset-2"
+        : undefined;
+
   return (
     <div
       ref={nodeRef}
       className={cn(
         "group relative border shadow-sm transition-all duration-200",
         nodeColor,
-        selected && "ring-2 ring-primary ring-offset-2",
+        highlightClassName,
         isDisabled && "opacity-60",
         "h-16 w-16 rounded-xl cursor-pointer",
       )}
+      data-search-match={isSearchMatch ? "true" : undefined}
+      data-active-search-match={isActiveSearchMatch ? "true" : undefined}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       tabIndex={0}

--- a/apps/canvas/src/features/workflow/components/panels/node-inspector.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/node-inspector.tsx
@@ -19,7 +19,12 @@ import {
 import { Switch } from "@/design-system/ui/switch";
 import { ScrollArea } from "@/design-system/ui/scroll-area";
 import { Badge } from "@/design-system/ui/badge";
-import { Separator } from "@/design-system/ui/separator";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/design-system/ui/accordion";
 import {
   X,
   Code,
@@ -225,15 +230,16 @@ export default function NodeInspector({
     </div>
   );
 
-  const renderConfigContent = () => (
-    <ScrollArea className="h-full">
-      <div
-        className="p-6 space-y-6"
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={handleDrop}
-      >
-        <div className="space-y-4">
-          <h3 className="text-lg font-medium">Basic Settings</h3>
+  const renderConfigContent = () => {
+    const sections: {
+      value: string;
+      title: string;
+      content: React.ReactNode;
+    }[] = [
+      {
+        value: "basic-settings",
+        title: "Basic Settings",
+        content: (
           <div className="grid gap-4">
             <div className="grid gap-2">
               <Label htmlFor="node-name">Node Name</Label>
@@ -255,185 +261,221 @@ export default function NodeInspector({
               />
             </div>
           </div>
-        </div>
+        ),
+      },
+    ];
 
-        <Separator />
-
-        {node.type === "HTTP Request" && (
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">HTTP Settings</h3>
-            <div className="grid gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="request-method">Method</Label>
-                <Select defaultValue="GET">
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select method" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="GET">GET</SelectItem>
-                    <SelectItem value="POST">POST</SelectItem>
-                    <SelectItem value="PUT">PUT</SelectItem>
-                    <SelectItem value="DELETE">DELETE</SelectItem>
-                    <SelectItem value="PATCH">PATCH</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="request-url">URL</Label>
-                <Input
-                  id="request-url"
-                  defaultValue="https://api.example.com/data"
-                  placeholder="Enter URL"
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="request-headers">Headers</Label>
-                  <Button variant="ghost" size="sm" className="h-8 px-2">
-                    <Plus className="h-3 w-3 mr-1" />
-                    Add Header
-                  </Button>
-                </div>
-                <div className="space-y-2">
-                  <div className="grid grid-cols-2 gap-2">
-                    <Input placeholder="Key" defaultValue="Content-Type" />
-
-                    <Input
-                      placeholder="Value"
-                      defaultValue="application/json"
-                    />
-                  </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <Input placeholder="Key" defaultValue="Authorization" />
-
-                    <Input
-                      placeholder="Value"
-                      defaultValue="Bearer {{auth.token}}"
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="request-body">Request Body</Label>
-                <div className="relative">
-                  <Textarea
-                    id="request-body"
-                    defaultValue='{\n  "query": "example",\n  "limit": 10\n}'
-                    className="font-mono min-h-[150px]"
-                  />
-
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="absolute top-2 right-2 h-6 w-6 bg-background/80"
-                  >
-                    <Code className="h-3 w-3" />
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {node.type === "Transform Data" && (
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">Transformation Settings</h3>
-            <div className="grid gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="transform-mode">Mode</Label>
-                <Select defaultValue="jmespath">
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select mode" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="jmespath">JMESPath</SelectItem>
-                    <SelectItem value="jsonata">JSONata</SelectItem>
-                    <SelectItem value="custom">Custom Code</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="transform-expression">Expression</Label>
-                <div className="relative">
-                  <Textarea
-                    id="transform-expression"
-                    defaultValue="data.items[?value > `100`]"
-                    className="font-mono min-h-[150px]"
-                  />
-
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="absolute top-2 right-2 h-6 w-6 bg-background/80"
-                  >
-                    <Code className="h-3 w-3" />
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {node.type === "Python" && (
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">Python Code</h3>
-            <div className="grid gap-2">
-              <Label htmlFor="python-code">Code</Label>
-              <div className="border rounded-md overflow-hidden h-[300px]">
-                {typeof window !== "undefined" && (
-                  <Editor
-                    height="100%"
-                    defaultLanguage="python"
-                    value={pythonCode}
-                    onChange={(value) => setPythonCode(value || "")}
-                    options={{
-                      minimap: { enabled: false },
-                      scrollBeyondLastLine: false,
-                      fontSize: 14,
-                      lineNumbers: "on",
-                    }}
-                    theme="vs-dark"
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        <Separator />
-
-        <div className="space-y-4">
-          <h3 className="text-lg font-medium">Advanced Options</h3>
+    if (node.type === "HTTP Request") {
+      sections.push({
+        value: "http-settings",
+        title: "HTTP Settings",
+        content: (
           <div className="grid gap-4">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="retry-failed">Retry on failure</Label>
-              <Switch id="retry-failed" />
-            </div>
-
-            <div className="flex items-center justify-between">
-              <Label htmlFor="continue-on-fail">Continue on failure</Label>
-              <Switch id="continue-on-fail" />
+            <div className="grid gap-2">
+              <Label htmlFor="request-method">Method</Label>
+              <Select defaultValue="GET">
+                <SelectTrigger>
+                  <SelectValue placeholder="Select method" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="GET">GET</SelectItem>
+                  <SelectItem value="POST">POST</SelectItem>
+                  <SelectItem value="PUT">PUT</SelectItem>
+                  <SelectItem value="DELETE">DELETE</SelectItem>
+                  <SelectItem value="PATCH">PATCH</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="grid gap-2">
-              <Label htmlFor="timeout">Timeout (seconds)</Label>
+              <Label htmlFor="request-url">URL</Label>
               <Input
-                id="timeout"
-                type="number"
-                defaultValue="30"
-                min="1"
-                max="300"
+                id="request-url"
+                defaultValue="https://api.example.com/data"
+                placeholder="Enter URL"
               />
             </div>
+
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="request-headers">Headers</Label>
+                <Button variant="ghost" size="sm" className="h-8 px-2">
+                  <Plus className="h-3 w-3 mr-1" />
+                  Add Header
+                </Button>
+              </div>
+              <div className="space-y-2">
+                <div className="grid grid-cols-2 gap-2">
+                  <Input placeholder="Key" defaultValue="Content-Type" />
+
+                  <Input placeholder="Value" defaultValue="application/json" />
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Input placeholder="Key" defaultValue="Authorization" />
+
+                  <Input
+                    placeholder="Value"
+                    defaultValue="Bearer {{auth.token}}"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="request-body">Request Body</Label>
+              <div className="relative">
+                <Textarea
+                  id="request-body"
+                  defaultValue='{\n  "query": "example",\n  "limit": 10\n}'
+                  className="font-mono min-h-[150px]"
+                />
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute top-2 right-2 h-6 w-6 bg-background/80"
+                >
+                  <Code className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        ),
+      });
+    }
+
+    if (node.type === "Transform Data") {
+      sections.push({
+        value: "transform-settings",
+        title: "Transformation Settings",
+        content: (
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="transform-mode">Mode</Label>
+              <Select defaultValue="jmespath">
+                <SelectTrigger>
+                  <SelectValue placeholder="Select mode" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="jmespath">JMESPath</SelectItem>
+                  <SelectItem value="jsonata">JSONata</SelectItem>
+                  <SelectItem value="custom">Custom Code</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="transform-expression">Expression</Label>
+              <div className="relative">
+                <Textarea
+                  id="transform-expression"
+                  defaultValue="data.items[?value > `100`]"
+                  className="font-mono min-h-[150px]"
+                />
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute top-2 right-2 h-6 w-6 bg-background/80"
+                >
+                  <Code className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        ),
+      });
+    }
+
+    if (node.type === "Python") {
+      sections.push({
+        value: "python-settings",
+        title: "Python Code",
+        content: (
+          <div className="grid gap-2">
+            <Label htmlFor="python-code">Code</Label>
+            <div className="border rounded-md overflow-hidden h-[300px]">
+              {typeof window !== "undefined" && (
+                <Editor
+                  height="100%"
+                  defaultLanguage="python"
+                  value={pythonCode}
+                  onChange={(value) => setPythonCode(value || "")}
+                  options={{
+                    minimap: { enabled: false },
+                    scrollBeyondLastLine: false,
+                    fontSize: 14,
+                    lineNumbers: "on",
+                  }}
+                  theme="vs-dark"
+                />
+              )}
+            </div>
+          </div>
+        ),
+      });
+    }
+
+    sections.push({
+      value: "advanced-options",
+      title: "Advanced Options",
+      content: (
+        <div className="grid gap-4">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="retry-failed">Retry on failure</Label>
+            <Switch id="retry-failed" />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="continue-on-fail">Continue on failure</Label>
+            <Switch id="continue-on-fail" />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="timeout">Timeout (seconds)</Label>
+            <Input
+              id="timeout"
+              type="number"
+              defaultValue="30"
+              min="1"
+              max="300"
+            />
           </div>
         </div>
-      </div>
-    </ScrollArea>
-  );
+      ),
+    });
+
+    return (
+      <ScrollArea className="h-full">
+        <div
+          className="p-6"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={handleDrop}
+        >
+          <Accordion
+            type="multiple"
+            defaultValue={sections.map((section) => section.value)}
+            className="space-y-4"
+          >
+            {sections.map((section) => (
+              <AccordionItem
+                key={section.value}
+                value={section.value}
+                className="border border-border rounded-md"
+              >
+                <AccordionTrigger className="px-4 py-2 text-left text-sm font-semibold hover:no-underline">
+                  {section.title}
+                </AccordionTrigger>
+                <AccordionContent className="px-4 pb-4 pt-0">
+                  {section.content}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </ScrollArea>
+    );
+  };
 
   const renderOutputContent = () => (
     <div className="flex h-full flex-col">

--- a/apps/canvas/src/features/workflow/components/panels/sidebar-panel.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/sidebar-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Input } from "@/design-system/ui/input";
 import { Button } from "@/design-system/ui/button";
 import { ScrollArea } from "@/design-system/ui/scroll-area";
@@ -67,6 +67,8 @@ interface SidebarPanelProps {
   onAddNode?: (node: SidebarNode) => void;
   className?: string;
   position?: "left" | "canvas";
+  searchQuery?: string;
+  onSearchQueryChange?: (value: string) => void;
 }
 
 export default function SidebarPanel({
@@ -75,9 +77,9 @@ export default function SidebarPanel({
   onAddNode,
   className,
   position = "left",
+  searchQuery = "",
+  onSearchQueryChange,
 }: SidebarPanelProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-
   const nodeCategories: NodeCategory[] = [
     {
       id: "special",
@@ -572,16 +574,20 @@ export default function SidebarPanel({
     },
   ];
 
+  const normalizedQuery = searchQuery.toLowerCase();
+
   const filteredCategories = nodeCategories
     .map((category) => ({
       ...category,
       nodes: category.nodes.filter(
         (node) =>
-          node.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          node.description.toLowerCase().includes(searchQuery.toLowerCase()),
+          node.name.toLowerCase().includes(normalizedQuery) ||
+          node.description.toLowerCase().includes(normalizedQuery),
       ),
     }))
-    .filter((category) => category.nodes.length > 0);
+    .filter(
+      (category) => category.nodes.length > 0 || normalizedQuery.length === 0,
+    );
 
   const handleNodeClick = (node: SidebarNode) => {
     onAddNode?.(node);
@@ -663,7 +669,8 @@ export default function SidebarPanel({
                 placeholder="Search nodes..."
                 className="pl-8"
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => onSearchQueryChange?.(e.target.value)}
+                aria-label="Filter node catalog"
               />
             </div>
           </div>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 
 ### Milestone 4 – Visual Designer Experience
 - [x] Migrate the legacy canvas app to connect to the new backend via React Flow foundation, restoring minimap, snapping, and chat affordances while preserving node compatibility.
-- [ ] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
+- [x] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
 - [ ] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
 - [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
 - [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.


### PR DESCRIPTION
## Summary
- wire the workflow canvas to a shared search state with the toolbar, sidebar, and new WorkflowSearch overlay, including node highlighting and focus helpers
- update sidebar and node rendering to reflect search matches and add share/version placeholder actions while keeping duplication/export/import behaviour stable
- refactor the node inspector configuration pane into collapsible accordion sections and expand canvas tests for history/lookup coverage while marking the roadmap task complete

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing even after npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68f679ad253883279865172ae7a59c6d