### PR TITLE
Integrate credential tooling into canvas settings

### DIFF
--- a/apps/canvas/src/features/shared/components/chatkit/chatkit-interface.tsx
+++ b/apps/canvas/src/features/shared/components/chatkit/chatkit-interface.tsx
@@ -1,0 +1,533 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { Badge } from "@/design-system/ui/badge";
+import { Button } from "@/design-system/ui/button";
+import { Checkbox } from "@/design-system/ui/checkbox";
+import { Dialog, DialogContent } from "@/design-system/ui/dialog";
+import { Input } from "@/design-system/ui/input";
+import { ScrollArea } from "@/design-system/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/design-system/ui/select";
+import { Separator } from "@/design-system/ui/separator";
+import { ToggleGroup, ToggleGroupItem } from "@/design-system/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/design-system/ui/tooltip";
+import { cn } from "@/lib/utils";
+import ChatMessage from "@features/shared/components/chat-message";
+import ChatInput, {
+  type Attachment,
+} from "@features/shared/components/chat-input";
+import type { ExecutionStatus } from "@features/workflow/hooks/use-workflow-execution";
+import {
+  type ChatEnvironment,
+  type ChatKitChecklistItem,
+  type ChatKitMetrics,
+  type ChatKitSession,
+} from "@features/shared/components/chatkit/types";
+import {
+  ArrowUpRight,
+  CheckCircle2,
+  CircleDashed,
+  MessageSquareIcon,
+  PinIcon,
+  SearchIcon,
+  Share2Icon,
+  SparklesIcon,
+  XIcon,
+} from "lucide-react";
+
+interface ChatKitInterfaceProps {
+  open: boolean;
+  onClose: () => void;
+  workflowName: string;
+  environment: ChatEnvironment;
+  onEnvironmentChange: (environment: ChatEnvironment) => void;
+  sessions: ChatKitSession[];
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onSendMessage: (
+    sessionId: string,
+    message: string,
+    attachments: Attachment[],
+  ) => void;
+  onQuickPrompt?: (sessionId: string, prompt: string) => void;
+  onToggleChecklistItem?: (
+    sessionId: string,
+    itemId: string,
+    completed: boolean,
+  ) => void;
+  metrics?: ChatKitMetrics;
+  executionStatus?: ExecutionStatus;
+  view: "assist" | "handoff";
+  onViewChange: (view: "assist" | "handoff") => void;
+}
+
+const statusBadgeVariants: Record<string, string> = {
+  idle: "secondary",
+  connecting: "secondary",
+  running: "default",
+  completed: "outline",
+  error: "destructive",
+  cancelled: "secondary",
+  handoff: "default",
+  "handoff-ready": "success",
+  qa: "secondary",
+};
+
+const statusLabels: Record<string, string> = {
+  idle: "Idle",
+  connecting: "Connecting",
+  running: "Running",
+  completed: "Completed",
+  error: "Error",
+  cancelled: "Cancelled",
+  handoff: "Handoff",
+  "handoff-ready": "Ready for handoff",
+  qa: "QA review",
+};
+
+const getStatusBadgeVariant = (status?: ChatKitSession["status"]) => {
+  if (!status) return "secondary" as const;
+  return (statusBadgeVariants[status] ?? "secondary") as const;
+};
+
+const getStatusLabel = (
+  status?: ChatKitSession["status"],
+  fallback?: string,
+) => {
+  if (!status) return fallback ?? "Idle";
+  return statusLabels[status] ?? fallback ?? status;
+};
+
+const ChecklistItem = ({
+  item,
+  onToggle,
+}: {
+  item: ChatKitChecklistItem;
+  onToggle?: (next: boolean) => void;
+}) => {
+  return (
+    <label
+      className={cn(
+        "flex items-start gap-3 rounded-lg border border-border/60 bg-background/40 p-3 transition-all",
+        item.completed && "bg-primary/5 border-primary/40",
+      )}
+    >
+      <Checkbox
+        checked={item.completed}
+        onCheckedChange={(checked) => onToggle?.(Boolean(checked))}
+        className="mt-0.5"
+      />
+      <div className="space-y-1">
+        <p className="text-sm font-medium leading-none">{item.label}</p>
+        {(item.owner || item.dueDate) && (
+          <p className="text-xs text-muted-foreground">
+            {item.owner && <span>Owner: {item.owner}</span>}
+            {item.owner && item.dueDate && <span className="mx-1">•</span>}
+            {item.dueDate && <span>Due {item.dueDate}</span>}
+          </p>
+        )}
+      </div>
+    </label>
+  );
+};
+
+const ConversationList = ({
+  sessions,
+  activeSessionId,
+  onSelectSession,
+}: {
+  sessions: ChatKitSession[];
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+}) => {
+  const [search, setSearch] = useState("");
+
+  const filteredSessions = useMemo(() => {
+    if (!search.trim()) return sessions;
+    const value = search.toLowerCase();
+    return sessions.filter((session) => {
+      const haystack = [
+        session.title,
+        session.subtitle,
+        session.description,
+        ...(session.tags ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(value);
+    });
+  }, [sessions, search]);
+
+  return (
+    <div className="flex h-full w-72 flex-col border-r bg-muted/40">
+      <div className="p-4">
+        <h3 className="text-sm font-semibold text-muted-foreground">
+          Conversations
+        </h3>
+        <div className="mt-3 flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm">
+          <SearchIcon className="h-4 w-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search"
+            className="h-auto border-0 p-0 shadow-none focus-visible:ring-0"
+          />
+        </div>
+      </div>
+      <Separator />
+      <ScrollArea className="flex-1">
+        <div className="space-y-1 p-2">
+          {filteredSessions.map((session) => {
+            const isActive = session.id === activeSessionId;
+            const status = getStatusLabel(session.status);
+            const updatedAtLabel = formatDistanceToNow(
+              new Date(session.updatedAt),
+              { addSuffix: true },
+            );
+
+            return (
+              <button
+                key={session.id}
+                type="button"
+                onClick={() => onSelectSession(session.id)}
+                className={cn(
+                  "group flex w-full flex-col gap-2 rounded-lg border border-transparent px-3 py-2 text-left transition",
+                  isActive
+                    ? "bg-background shadow-sm border-border"
+                    : "hover:bg-background/60",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  {session.pinned && (
+                    <PinIcon className="h-3.5 w-3.5 text-primary" />
+                  )}
+                  <span className="text-sm font-medium truncate">
+                    {session.title}
+                  </span>
+                </div>
+                {session.subtitle && (
+                  <p className="truncate text-xs text-muted-foreground">
+                    {session.subtitle}
+                  </p>
+                )}
+                <div className="flex flex-wrap items-center gap-1">
+                  <Badge variant="outline" className="text-[10px] uppercase">
+                    {session.environment}
+                  </Badge>
+                  <Badge
+                    variant={getStatusBadgeVariant(session.status)}
+                    className="text-[10px]"
+                  >
+                    {status}
+                  </Badge>
+                  <span className="text-[11px] text-muted-foreground">
+                    {updatedAtLabel}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+          {filteredSessions.length === 0 && (
+            <div className="p-4 text-sm text-muted-foreground">
+              No conversations found.
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+      <Separator />
+      <div className="p-4 text-xs text-muted-foreground">
+        Conversations auto-sync with your workflow runs.
+      </div>
+    </div>
+  );
+};
+
+const MetricCard = ({
+  title,
+  value,
+  description,
+  icon: Icon,
+}: {
+  title: string;
+  value: React.ReactNode;
+  description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}) => {
+  return (
+    <div className="rounded-lg border bg-background p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase text-muted-foreground">
+          {title}
+        </p>
+        {Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
+      </div>
+      <div className="mt-3 text-2xl font-semibold tracking-tight">{value}</div>
+      {description && (
+        <p className="mt-2 text-xs text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+};
+
+const ChatKitInterface = ({
+  open,
+  onClose,
+  workflowName,
+  environment,
+  onEnvironmentChange,
+  sessions,
+  activeSessionId,
+  onSelectSession,
+  onSendMessage,
+  onQuickPrompt,
+  onToggleChecklistItem,
+  metrics,
+  executionStatus,
+  view,
+  onViewChange,
+}: ChatKitInterfaceProps) => {
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => {
+      if (a.pinned && !b.pinned) return -1;
+      if (!a.pinned && b.pinned) return 1;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+  }, [sessions]);
+
+  const activeSession = useMemo(() => {
+    if (activeSessionId) {
+      const match = sortedSessions.find(
+        (session) => session.id === activeSessionId,
+      );
+      if (match) {
+        return match;
+      }
+    }
+    return sortedSessions[0] ?? null;
+  }, [activeSessionId, sortedSessions]);
+
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [activeSession?.messages]);
+
+  const handleSendMessage = (message: string, attachments: Attachment[]) => {
+    if (!activeSession) return;
+    onSendMessage(activeSession.id, message, attachments);
+  };
+
+  const handleQuickPrompt = (prompt: string) => {
+    if (!activeSession) return;
+    if (onQuickPrompt) {
+      onQuickPrompt(activeSession.id, prompt);
+    } else {
+      onSendMessage(activeSession.id, prompt, []);
+    }
+  };
+
+  const handleChecklistToggle = (itemId: string, completed: boolean) => {
+    if (!activeSession || !onToggleChecklistItem) return;
+    onToggleChecklistItem(activeSession.id, itemId, completed);
+  };
+
+  const tokenStats = metrics?.tokens ?? activeSession?.tokenEstimate;
+  const statusLabel = getStatusLabel(
+    activeSession?.status ?? executionStatus,
+    executionStatus ? getStatusLabel(executionStatus) : undefined,
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(value) => !value && onClose()}>
+      <DialogContent className="max-w-6xl w-[92vw] h-[90vh] overflow-hidden p-0">
+        <div className="flex h-full">
+          <ConversationList
+            sessions={sortedSessions}
+            activeSessionId={activeSession?.id ?? null}
+            onSelectSession={onSelectSession}
+          />
+          <div className="flex flex-1 flex-col bg-background">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/30 px-6 py-4">
+              <div className="min-w-0">
+                <p className="text-xs uppercase text-muted-foreground">
+                  {workflowName}
+                </p>
+                <h2 className="text-xl font-semibold leading-tight">
+                  {activeSession?.title ?? "Chat"}
+                </h2>
+                {activeSession?.subtitle && (
+                  <p className="truncate text-sm text-muted-foreground">
+                    {activeSession.subtitle}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <ToggleGroup
+                  type="single"
+                  value={view}
+                  onValueChange={(next) =>
+                    next && onViewChange(next as "assist" | "handoff")
+                  }
+                  className="rounded-lg border bg-background"
+                >
+                  <ToggleGroupItem value="assist" className="px-3 py-1 text-sm">
+                    Assist
+                  </ToggleGroupItem>
+                  <ToggleGroupItem
+                    value="handoff"
+                    className="px-3 py-1 text-sm"
+                  >
+                    Handoff
+                  </ToggleGroupItem>
+                </ToggleGroup>
+                <Select
+                  value={environment}
+                  onValueChange={(value) =>
+                    onEnvironmentChange(value as ChatEnvironment)
+                  }
+                >
+                  <SelectTrigger className="w-[140px]">
+                    <SelectValue placeholder="Select env" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="draft">Draft</SelectItem>
+                    <SelectItem value="production">Production</SelectItem>
+                  </SelectContent>
+                </Select>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="outline" size="icon">
+                        <Share2Icon className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Share session</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <Button variant="ghost" size="icon" onClick={onClose}>
+                  <XIcon className="h-5 w-5" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="border-b bg-muted/40 px-6 py-4">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                <MetricCard
+                  title="Session status"
+                  value={statusLabel}
+                  description="Tracks the latest workflow execution state"
+                  icon={CircleDashed}
+                />
+                <MetricCard
+                  title="Token usage"
+                  value={
+                    tokenStats
+                      ? `${tokenStats.total.toLocaleString()} tokens`
+                      : "—"
+                  }
+                  description={
+                    tokenStats
+                      ? `Prompt ${tokenStats.prompt.toLocaleString()} • Completion ${tokenStats.completion.toLocaleString()}`
+                      : "Live tokens will appear after a run"
+                  }
+                  icon={SparklesIcon}
+                />
+                <MetricCard
+                  title="Updated"
+                  value={
+                    activeSession
+                      ? formatDistanceToNow(new Date(activeSession.updatedAt), {
+                          addSuffix: true,
+                        })
+                      : "—"
+                  }
+                  description="Sessions auto-refresh with run history"
+                  icon={ArrowUpRight}
+                />
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-hidden">
+              <div className="flex h-full flex-col">
+                <ScrollArea className="flex-1 px-6 py-4">
+                  <div className="space-y-3">
+                    {activeSession?.messages?.length ? (
+                      activeSession.messages.map((message) => (
+                        <ChatMessage key={message.id} {...message} />
+                      ))
+                    ) : (
+                      <div className="flex h-full flex-col items-center justify-center rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+                        <MessageSquareIcon className="mb-2 h-8 w-8" />
+                        <p>No messages yet</p>
+                        <p className="text-sm">
+                          Start the conversation to trigger this workflow.
+                        </p>
+                      </div>
+                    )}
+                    <div ref={messagesEndRef} />
+                  </div>
+                </ScrollArea>
+
+                <div className="border-t bg-muted/30">
+                  <div className="flex flex-wrap items-center gap-2 px-6 py-3">
+                    {activeSession?.quickPrompts?.map((prompt) => (
+                      <Button
+                        key={prompt}
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full"
+                        onClick={() => handleQuickPrompt(prompt)}
+                      >
+                        <SparklesIcon className="mr-1 h-3.5 w-3.5" />
+                        {prompt}
+                      </Button>
+                    ))}
+                  </div>
+                  <ChatInput
+                    onSendMessage={handleSendMessage}
+                    placeholder="Ask the workflow to test, debug, or hand off"
+                    className="border-t bg-background"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {view === "handoff" && activeSession?.handoffChecklist && (
+              <div className="border-t bg-muted/30 px-6 py-4">
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-primary" />
+                  <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+                    Handoff checklist
+                  </h3>
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  {activeSession.handoffChecklist.map((item) => (
+                    <ChecklistItem
+                      key={item.id}
+                      item={item}
+                      onToggle={(next) => handleChecklistToggle(item.id, next)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ChatKitInterface;

--- a/apps/canvas/src/features/shared/components/chatkit/types.ts
+++ b/apps/canvas/src/features/shared/components/chatkit/types.ts
@@ -1,0 +1,71 @@
+import type { ChatMessageProps } from "@features/shared/components/chat-message";
+import type { ExecutionStatus } from "@features/workflow/hooks/use-workflow-execution";
+
+export type ChatEnvironment = "draft" | "production";
+
+export interface ChatKitParticipant {
+  id: string;
+  name: string;
+  avatar?: string;
+  role?: "user" | "ai" | "observer" | "reviewer";
+  status?: "online" | "offline" | "away";
+}
+
+export interface ChatKitChecklistItem {
+  id: string;
+  label: string;
+  completed: boolean;
+  owner?: string;
+  dueDate?: string;
+}
+
+export interface ChatKitRunSummary {
+  id: string;
+  status: ExecutionStatus;
+  environment: ChatEnvironment;
+  startedAt: string;
+  durationMs?: number;
+  triggeredBy?: string;
+  tokens?: {
+    prompt: number;
+    completion: number;
+    total: number;
+  };
+  notes?: string;
+}
+
+export interface ChatKitSession {
+  id: string;
+  nodeId?: string;
+  title: string;
+  subtitle?: string;
+  description?: string;
+  environment: ChatEnvironment;
+  status?: ExecutionStatus | "handoff" | "handoff-ready" | "qa";
+  pinned?: boolean;
+  updatedAt: string;
+  messages: ChatMessageProps[];
+  participants: ChatKitParticipant[];
+  quickPrompts?: string[];
+  handoffChecklist?: ChatKitChecklistItem[];
+  runSummaries?: ChatKitRunSummary[];
+  tags?: string[];
+  unreadCount?: number;
+  tokenEstimate?: {
+    prompt: number;
+    completion: number;
+    total: number;
+  };
+}
+
+export interface ChatKitMetrics {
+  tokens?: {
+    total: number;
+    prompt: number;
+    completion: number;
+  };
+  averageLatencyMs?: number;
+  runsToday?: number;
+  lastExecutionStatus?: ExecutionStatus;
+  lastExecutionStartedAt?: string | null;
+}

--- a/apps/canvas/src/features/workflow/components/canvas/connection-validator.tsx
+++ b/apps/canvas/src/features/workflow/components/canvas/connection-validator.tsx
@@ -21,7 +21,7 @@ interface ConnectionValidatorProps {
   className?: string;
 }
 
-interface ValidatorNodeData {
+export interface ValidatorNodeData {
   type?: string;
   label?: string;
   credentials?: {
@@ -128,7 +128,7 @@ export function validateConnection(
 
   if (!sourceNode || !targetNode) {
     return {
-      id: `conn-${Date.now()}`,
+      id: `conn-${connection.source}-${connection.target}-missing`,
       type: "connection",
       message: "Source or target node not found",
       sourceId: connection.source,
@@ -144,7 +144,7 @@ export function validateConnection(
 
   if (connectionExists) {
     return {
-      id: `conn-${Date.now()}`,
+      id: `conn-${connection.source}-${connection.target}-duplicate`,
       type: "connection",
       message: "Connection already exists between these nodes",
       sourceId: connection.source,
@@ -158,7 +158,7 @@ export function validateConnection(
     targetNode.data.type === "trigger"
   ) {
     return {
-      id: `conn-${Date.now()}`,
+      id: `conn-${connection.source}-${connection.target}-trigger-chain`,
       type: "connection",
       message: "Cannot connect a trigger node to another trigger node",
       sourceId: connection.source,
@@ -174,7 +174,7 @@ export function validateConnection(
   );
   if (wouldCreateCycle) {
     return {
-      id: `conn-${Date.now()}`,
+      id: `conn-${connection.source}-${connection.target}-cycle`,
       type: "connection",
       message: "This connection would create a circular reference",
       sourceId: connection.source,
@@ -195,9 +195,10 @@ export function validateNodeCredentials(
     (!node.data.credentials || !node.data.credentials.id)
   ) {
     return {
-      id: `cred-${node.id}-${Date.now()}`,
+      id: `cred-${node.id}`,
       type: "credential",
       message: `${node.data.label} requires credentials to be configured`,
+      sourceId: node.id,
       nodeName: node.data.label,
     };
   }

--- a/apps/canvas/src/features/workflow/components/panels/reusable-subworkflows.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/reusable-subworkflows.tsx
@@ -1,0 +1,131 @@
+import React, { useMemo } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/design-system/ui/card";
+import { Badge } from "@/design-system/ui/badge";
+import { Button } from "@/design-system/ui/button";
+import { Separator } from "@/design-system/ui/separator";
+import { Clock3, Link2, Plus } from "lucide-react";
+
+import type { ReusableSubWorkflow } from "@features/workflow/data/workflow-data";
+
+interface ReusableSubworkflowLibraryProps {
+  subworkflows: ReusableSubWorkflow[];
+  linkedSubworkflows: string[];
+  onInsert: (subworkflowId: string) => void;
+  onToggleLinked: (subworkflowId: string, linked: boolean) => void;
+}
+
+export default function ReusableSubworkflowLibrary({
+  subworkflows,
+  linkedSubworkflows,
+  onInsert,
+  onToggleLinked,
+}: ReusableSubworkflowLibraryProps) {
+  const linkedSet = useMemo(
+    () => new Set(linkedSubworkflows),
+    [linkedSubworkflows],
+  );
+
+  if (subworkflows.length === 0) {
+    return (
+      <Card className="border-dashed border-border/70 bg-muted/40">
+        <CardHeader>
+          <CardTitle className="text-base">
+            No reusable sub-workflows yet
+          </CardTitle>
+          <CardDescription>
+            Start by publishing a workflow segment to make it available as a
+            reusable building block.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {subworkflows.map((subworkflow) => {
+        const isLinked = linkedSet.has(subworkflow.id);
+
+        return (
+          <Card key={subworkflow.id} className="border-border/70">
+            <CardHeader className="space-y-3">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="text-lg">{subworkflow.name}</CardTitle>
+                  <CardDescription className="mt-1">
+                    {subworkflow.description}
+                  </CardDescription>
+                </div>
+                {isLinked && (
+                  <Badge variant="secondary" className="shrink-0">
+                    Linked
+                  </Badge>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-2 text-xs">
+                <Badge variant="outline" className="capitalize">
+                  {subworkflow.category}
+                </Badge>
+                {subworkflow.tags.map((tag) => (
+                  <Badge key={`${subworkflow.id}-${tag}`} variant="outline">
+                    #{tag}
+                  </Badge>
+                ))}
+              </div>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-1">
+                  <Clock3 className="h-3.5 w-3.5" />
+                  {subworkflow.estimatedDurationMinutes}-minute run time
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <Link2 className="h-3.5 w-3.5" />
+                  Updated{" "}
+                  {new Date(subworkflow.lastUpdated).toLocaleDateString()}
+                </span>
+              </div>
+
+              <Separator />
+
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="text-sm text-muted-foreground">
+                  {isLinked
+                    ? "This workflow will be included when the canvas is published."
+                    : "Link this reusable flow to include it at publish time."}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant={isLinked ? "secondary" : "outline"}
+                    onClick={() => onToggleLinked(subworkflow.id, !isLinked)}
+                  >
+                    {isLinked ? "Remove link" : "Mark as linked"}
+                  </Button>
+
+                  <Button
+                    size="sm"
+                    onClick={() => onInsert(subworkflow.id)}
+                    variant="default"
+                  >
+                    <Plus className="mr-1.5 h-4 w-4" />
+                    Insert on canvas
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/canvas/src/features/workflow/components/panels/workflow-execution-history.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/workflow-execution-history.tsx
@@ -94,6 +94,26 @@ export default function WorkflowExecutionHistory({
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
 
+  useEffect(() => {
+    if (defaultSelectedExecution) {
+      setSelectedExecution(defaultSelectedExecution);
+      return;
+    }
+    if (executions.length === 0) {
+      setSelectedExecution(null);
+      return;
+    }
+    setSelectedExecution((current) => {
+      if (
+        current &&
+        executions.some((execution) => execution.id === current.id)
+      ) {
+        return current;
+      }
+      return executions[0];
+    });
+  }, [defaultSelectedExecution, executions]);
+
   const handleSelectExecution = (execution: WorkflowExecution) => {
     setSelectedExecution(execution);
   };

--- a/apps/canvas/src/features/workflow/data/chat-samples.ts
+++ b/apps/canvas/src/features/workflow/data/chat-samples.ts
@@ -1,0 +1,204 @@
+import type { ChatKitSession } from "@features/shared/components/chatkit/types";
+
+const isoMinutesAgo = (minutesAgo: number) =>
+  new Date(Date.now() - minutesAgo * 60_000).toISOString();
+
+const baseAssistant = {
+  id: "assistant-default",
+  name: "Workflow Copilot",
+  avatar: "https://avatar.vercel.sh/workflow-copilot",
+  isAI: true,
+} as const;
+
+const baseUser = {
+  id: "workflow-owner",
+  name: "Workflow Owner",
+  avatar: "https://avatar.vercel.sh/workflow-owner",
+};
+
+export const SAMPLE_CHAT_SESSIONS: ChatKitSession[] = [
+  {
+    id: "handoff-production",
+    nodeId: "chat-trigger-production",
+    title: "Launch campaign handoff",
+    subtitle: "Marketing automation • Production",
+    description:
+      "Production chat room for the marketing launch workflow hand-off.",
+    environment: "production",
+    status: "handoff-ready",
+    pinned: true,
+    updatedAt: isoMinutesAgo(5),
+    participants: [
+      {
+        id: baseUser.id,
+        name: baseUser.name,
+        avatar: baseUser.avatar,
+        role: "user",
+      },
+      {
+        id: baseAssistant.id,
+        name: baseAssistant.name,
+        avatar: baseAssistant.avatar,
+        role: "ai",
+      },
+      {
+        id: "qa-lead",
+        name: "Morgan Patel",
+        avatar: "https://avatar.vercel.sh/morgan",
+        role: "reviewer",
+      },
+    ],
+    quickPrompts: [
+      "Summarize the last production run",
+      "List launch blockers",
+      "Generate customer-ready status update",
+    ],
+    handoffChecklist: [
+      {
+        id: "handoff-copy-review",
+        label: "Final content reviewed and approved",
+        completed: true,
+        owner: "Morgan Patel",
+      },
+      {
+        id: "handoff-credentials",
+        label: "Credential scope validated for production use",
+        completed: true,
+        owner: "Workflow Owner",
+      },
+      {
+        id: "handoff-monitoring",
+        label: "Monitoring alerts configured for launch window",
+        completed: false,
+        owner: "SRE Rotation",
+        dueDate: "Today",
+      },
+    ],
+    runSummaries: [
+      {
+        id: "prod-run-42",
+        status: "completed",
+        environment: "production",
+        startedAt: isoMinutesAgo(32),
+        durationMs: 4820,
+        triggeredBy: "Workflow Owner",
+        tokens: { prompt: 612, completion: 318, total: 930 },
+        notes: "Validated launch assets and distributed Slack announcement.",
+      },
+    ],
+    tokenEstimate: { prompt: 640, completion: 340, total: 980 },
+    messages: [
+      {
+        id: "handoff-1",
+        content:
+          "Production run completed successfully. All launch emails queued and approvals stored in the audit log.",
+        sender: baseAssistant,
+        timestamp: isoMinutesAgo(40),
+      },
+      {
+        id: "handoff-2",
+        content:
+          "Great — can you surface any remaining blockers before we flip the switch?",
+        sender: baseUser,
+        timestamp: isoMinutesAgo(38),
+        isUserMessage: true,
+      },
+      {
+        id: "handoff-3",
+        content:
+          "Only pending item is confirming the monitoring webhook is active. Once that's done I'll mark the hand-off as complete.",
+        sender: baseAssistant,
+        timestamp: isoMinutesAgo(36),
+      },
+      {
+        id: "handoff-4",
+        content:
+          "Monitoring alert is now configured. Ready for final approval.",
+        sender: baseUser,
+        timestamp: isoMinutesAgo(6),
+        isUserMessage: true,
+      },
+    ],
+  },
+  {
+    id: "draft-playground",
+    nodeId: "chat-trigger-draft",
+    title: "Workflow playground",
+    subtitle: "Draft environment",
+    description:
+      "Sandbox chat for iterating on prompts and flows before publish.",
+    environment: "draft",
+    status: "running",
+    pinned: false,
+    updatedAt: isoMinutesAgo(1),
+    participants: [
+      {
+        id: baseUser.id,
+        name: baseUser.name,
+        avatar: baseUser.avatar,
+        role: "user",
+      },
+      {
+        id: baseAssistant.id,
+        name: baseAssistant.name,
+        avatar: baseAssistant.avatar,
+        role: "ai",
+      },
+    ],
+    quickPrompts: [
+      "Trigger a draft run",
+      "Show me token usage",
+      "What changed since the last iteration?",
+    ],
+    handoffChecklist: [
+      {
+        id: "draft-validation",
+        label: "Validate credential assignment for chat trigger",
+        completed: false,
+        owner: "Workflow Owner",
+      },
+      {
+        id: "draft-copy",
+        label: "QA welcome prompt copy",
+        completed: false,
+        owner: "Content Team",
+      },
+    ],
+    runSummaries: [
+      {
+        id: "draft-run-13",
+        status: "running",
+        environment: "draft",
+        startedAt: isoMinutesAgo(2),
+        triggeredBy: "Workflow Owner",
+        tokens: { prompt: 280, completion: 144, total: 424 },
+        notes: "Testing new prompt variations for onboarding flow.",
+      },
+    ],
+    tokenEstimate: { prompt: 300, completion: 150, total: 450 },
+    messages: [
+      {
+        id: "draft-1",
+        content:
+          "Draft run kicked off. I'll post token stats once the loop completes.",
+        sender: baseAssistant,
+        timestamp: isoMinutesAgo(3),
+      },
+      {
+        id: "draft-2",
+        content:
+          "Log the latest prompt deltas and check whether we need additional approvals before publish.",
+        sender: baseUser,
+        timestamp: isoMinutesAgo(2),
+        isUserMessage: true,
+      },
+      {
+        id: "draft-3",
+        content:
+          "Documented the prompt changes. Credential scope is limited to sandbox tokens; no extra approval required yet.",
+        sender: baseAssistant,
+        timestamp: isoMinutesAgo(1),
+      },
+    ],
+  },
+];

--- a/apps/canvas/src/features/workflow/hooks/use-workflow-execution.ts
+++ b/apps/canvas/src/features/workflow/hooks/use-workflow-execution.ts
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type BackendExecutionMessage,
+  DEFAULT_LANGGRAPH_GRAPH_CONFIG,
+  type ExecutionMessage,
+  type ExecutionMetrics,
+  type ExecutionTokens,
+  getWorkflowWebSocketUrl,
+} from "@features/workflow/lib/execution-client";
+
+export type ExecutionStatus =
+  | "idle"
+  | "connecting"
+  | "running"
+  | "completed"
+  | "error"
+  | "cancelled";
+
+export interface ExecutionLogEntry {
+  timestamp: string;
+  level: "INFO" | "DEBUG" | "ERROR" | "WARNING";
+  message: string;
+}
+
+export interface TokenMetrics {
+  prompt: number;
+  completion: number;
+  total: number;
+}
+
+interface StartExecutionOverrides {
+  inputs?: Record<string, unknown>;
+  graphConfig?: Record<string, unknown>;
+  executionId?: string;
+}
+
+interface UseWorkflowExecutionOptions {
+  workflowId: string | null;
+  graphConfig?: Record<string, unknown>;
+  inputs?: Record<string, unknown>;
+}
+
+const INITIAL_TOKENS: TokenMetrics = { prompt: 0, completion: 0, total: 0 };
+
+const normaliseStatus = (status: string | undefined): ExecutionStatus => {
+  if (!status) {
+    return "running";
+  }
+
+  const value = status.toLowerCase();
+  if (value === "completed" || value === "success") {
+    return "completed";
+  }
+  if (value === "error" || value === "failed") {
+    return "error";
+  }
+  if (value === "cancelled") {
+    return "cancelled";
+  }
+  if (value === "running") {
+    return "running";
+  }
+  return "running";
+};
+
+const parseTokens = (
+  metrics: ExecutionMetrics | undefined,
+): ExecutionTokens | null => {
+  if (!metrics || !metrics.tokens) {
+    return null;
+  }
+
+  const { prompt = 0, completion = 0, total } = metrics.tokens;
+  return {
+    prompt,
+    completion,
+    total: typeof total === "number" ? total : prompt + completion,
+  };
+};
+
+const nowIso = () => new Date().toISOString();
+
+export const useWorkflowExecution = (options: UseWorkflowExecutionOptions) => {
+  const { workflowId, graphConfig, inputs } = options;
+
+  const [status, setStatus] = useState<ExecutionStatus>("idle");
+  const [executionId, setExecutionId] = useState<string | null>(null);
+  const [logs, setLogs] = useState<ExecutionLogEntry[]>([]);
+  const [tokenMetrics, setTokenMetrics] =
+    useState<TokenMetrics>(INITIAL_TOKENS);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const socketRef = useRef<WebSocket | null>(null);
+  const statusRef = useRef<ExecutionStatus>("idle");
+  const payloadRef = useRef({
+    graphConfig: graphConfig ?? DEFAULT_LANGGRAPH_GRAPH_CONFIG,
+    inputs: inputs ?? {},
+  });
+
+  useEffect(() => {
+    payloadRef.current = {
+      graphConfig: graphConfig ?? DEFAULT_LANGGRAPH_GRAPH_CONFIG,
+      inputs: inputs ?? {},
+    };
+  }, [graphConfig, inputs]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const appendLog = useCallback((entry: ExecutionLogEntry) => {
+    setLogs((previous) => {
+      const next = [...previous, entry];
+      if (next.length > 200) {
+        return next.slice(next.length - 200);
+      }
+      return next;
+    });
+  }, []);
+
+  const closeSocket = useCallback(() => {
+    const socket = socketRef.current;
+    if (socket) {
+      try {
+        socket.close();
+      } catch (error) {
+        console.warn("Failed to close execution socket", error);
+      }
+    }
+    socketRef.current = null;
+  }, []);
+
+  const resetState = useCallback(() => {
+    setLogs([]);
+    setTokenMetrics(INITIAL_TOKENS);
+    setExecutionId(null);
+    setLastError(null);
+    setStatus("idle");
+  }, []);
+
+  useEffect(() => () => closeSocket(), [closeSocket]);
+
+  const startExecution = useCallback(
+    async (overrides?: StartExecutionOverrides): Promise<string | null> => {
+      if (!workflowId) {
+        setLastError("Backend workflow ID is not configured for execution.");
+        setStatus("error");
+        return null;
+      }
+
+      if (typeof window === "undefined" || typeof WebSocket === "undefined") {
+        setLastError(
+          "WebSocket streaming is not available in this environment.",
+        );
+        setStatus("error");
+        return null;
+      }
+
+      closeSocket();
+      setLogs([]);
+      setTokenMetrics(INITIAL_TOKENS);
+      setLastError(null);
+
+      const executionIdentifier =
+        overrides?.executionId ??
+        globalThis.crypto?.randomUUID?.() ??
+        `execution-${Math.random().toString(36).slice(2)}`;
+
+      setExecutionId(executionIdentifier);
+      setStatus("connecting");
+
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(getWorkflowWebSocketUrl(workflowId));
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to initialise WebSocket connection.";
+        setLastError(message);
+        setStatus("error");
+        return null;
+      }
+
+      const resolvedPayload = {
+        type: "run_workflow",
+        graph_config: overrides?.graphConfig ?? payloadRef.current.graphConfig,
+        inputs: overrides?.inputs ?? payloadRef.current.inputs,
+        execution_id: executionIdentifier,
+      } satisfies Record<string, unknown>;
+
+      socket.addEventListener("open", () => {
+        try {
+          socket.send(JSON.stringify(resolvedPayload));
+          appendLog({
+            timestamp: nowIso(),
+            level: "INFO",
+            message: "Started backend execution stream.",
+          });
+          setStatus("running");
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to send execution payload.";
+          setLastError(message);
+          appendLog({ timestamp: nowIso(), level: "ERROR", message });
+          setStatus("error");
+        }
+      });
+
+      socket.addEventListener("message", (event) => {
+        const timestamp = nowIso();
+
+        let payload: ExecutionMessage | BackendExecutionMessage | null = null;
+        try {
+          payload = JSON.parse(event.data);
+        } catch {
+          appendLog({
+            timestamp,
+            level: "ERROR",
+            message: "Received non-JSON execution payload.",
+          });
+          return;
+        }
+
+        if (!payload || typeof payload !== "object") {
+          return;
+        }
+
+        const metrics =
+          payload.metrics ??
+          (typeof payload.payload === "object"
+            ? payload.payload?.metrics
+            : undefined);
+        const tokens = parseTokens(metrics as ExecutionMetrics | undefined);
+        if (tokens) {
+          setTokenMetrics(tokens);
+        }
+
+        if (payload.status) {
+          const nextStatus = normaliseStatus(payload.status);
+          appendLog({
+            timestamp,
+            level: nextStatus === "error" ? "ERROR" : "INFO",
+            message: `Status update: ${payload.status}`,
+          });
+          setStatus(nextStatus);
+          return;
+        }
+
+        if (payload.node || payload.event) {
+          appendLog({
+            timestamp,
+            level: "DEBUG",
+            message: `[${payload.event ?? "update"}] ${payload.node ?? "node"}`,
+          });
+          return;
+        }
+
+        appendLog({
+          timestamp,
+          level: "INFO",
+          message: `Update: ${JSON.stringify(payload)}`,
+        });
+      });
+
+      socket.addEventListener("error", (event) => {
+        console.error("Workflow execution socket error", event);
+        setLastError("Encountered an error while streaming execution updates.");
+        setStatus("error");
+      });
+
+      socket.addEventListener("close", () => {
+        if (!socketRef.current || statusRef.current === "idle") {
+          return;
+        }
+        setStatus((previous) => {
+          if (
+            previous === "completed" ||
+            previous === "error" ||
+            previous === "cancelled"
+          ) {
+            return previous;
+          }
+          appendLog({
+            timestamp: nowIso(),
+            level: "WARNING",
+            message: "Execution stream closed by remote host.",
+          });
+          return "idle";
+        });
+      });
+
+      socketRef.current = socket;
+      return executionIdentifier;
+    },
+    [appendLog, closeSocket, workflowId],
+  );
+
+  const stopExecution = useCallback(() => {
+    closeSocket();
+    setStatus("idle");
+  }, [closeSocket]);
+
+  return useMemo(
+    () => ({
+      status,
+      executionId,
+      logs,
+      tokenMetrics,
+      lastError,
+      startExecution,
+      stopExecution,
+      reset: resetState,
+    }),
+    [
+      executionId,
+      lastError,
+      logs,
+      resetState,
+      startExecution,
+      status,
+      stopExecution,
+      tokenMetrics,
+    ],
+  );
+};
+
+export type { ExecutionMessage };

--- a/apps/canvas/src/features/workflow/lib/execution-client.ts
+++ b/apps/canvas/src/features/workflow/lib/execution-client.ts
@@ -1,6 +1,18 @@
 const DEFAULT_API_BASE = "http://localhost:8000/api";
 const LANGGRAPH_SCRIPT_FORMAT = "langgraph_script";
 
+export class HttpRequestError extends Error {
+  public readonly status: number;
+  public readonly body: string;
+
+  constructor(status: number, body: string) {
+    super(`Request failed with status ${status}${body ? `: ${body}` : ""}`);
+    this.name = "HttpRequestError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 const normaliseUrl = (value: string): string => value.replace(/\/+$/, "");
 
 const resolveApiBase = () => {
@@ -126,9 +138,7 @@ export const getBackendWorkflowId = (): string | null => {
 const handleResponse = async <T>(response: Response): Promise<T> => {
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(
-      `Request failed with status ${response.status}${text ? `: ${text}` : ""}`,
-    );
+    throw new HttpRequestError(response.status, text);
   }
   return response.json() as Promise<T>;
 };

--- a/apps/canvas/src/features/workflow/lib/execution-client.ts
+++ b/apps/canvas/src/features/workflow/lib/execution-client.ts
@@ -1,0 +1,182 @@
+const DEFAULT_API_BASE = "http://localhost:8000/api";
+const LANGGRAPH_SCRIPT_FORMAT = "langgraph_script";
+
+const normaliseUrl = (value: string): string => value.replace(/\/+$/, "");
+
+const resolveApiBase = () => {
+  const envBase = import.meta.env.VITE_ORCHEO_API_BASE_URL;
+  if (typeof envBase === "string" && envBase.trim().length > 0) {
+    return normaliseUrl(envBase.trim());
+  }
+  return DEFAULT_API_BASE;
+};
+
+const resolveHttpHost = (apiBase: string): string => {
+  const trimmed = normaliseUrl(apiBase);
+  if (trimmed.endsWith("/api")) {
+    return trimmed.slice(0, -4);
+  }
+  return trimmed;
+};
+
+const deriveWebSocketBase = (apiBase: string): string => {
+  const envWs = import.meta.env.VITE_ORCHEO_WS_BASE_URL;
+  if (typeof envWs === "string" && envWs.trim().length > 0) {
+    return normaliseUrl(envWs.trim());
+  }
+
+  try {
+    const httpHost = resolveHttpHost(apiBase);
+    const url = new URL(httpHost);
+    const protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    return `${protocol}//${url.host}/ws/workflow`;
+  } catch (error) {
+    console.warn("Failed to derive WebSocket base from API base", error);
+    return "ws://localhost:8000/ws/workflow";
+  }
+};
+
+export const API_BASE_URL = resolveApiBase();
+export const WS_BASE_URL = deriveWebSocketBase(API_BASE_URL);
+
+export const DEFAULT_LANGGRAPH_SOURCE = `from langgraph.graph import StateGraph
+
+
+def greet_user(state):
+    """Generate a greeting message based on the name in state."""
+    name = state.get("name", "there")
+    return {"greeting": f"Hello {name}!"}
+
+
+def format_message(state):
+    """Convert greeting message to uppercase."""
+    greeting = state.get("greeting", "")
+    return {"shout": greeting.upper()}
+
+
+def build_graph():
+    """Build and return the LangGraph workflow."""
+    graph = StateGraph(dict)
+    graph.add_node("greet_user", greet_user)
+    graph.add_node("format_message", format_message)
+    graph.add_edge("greet_user", "format_message")
+    graph.set_entry_point("greet_user")
+    graph.set_finish_point("format_message")
+    return graph`.trim();
+
+export const DEFAULT_LANGGRAPH_GRAPH_CONFIG = {
+  format: LANGGRAPH_SCRIPT_FORMAT,
+  source: DEFAULT_LANGGRAPH_SOURCE,
+  entrypoint: "build_graph",
+} satisfies Record<string, unknown>;
+
+export interface ExecutionTokens {
+  prompt: number;
+  completion: number;
+  total: number;
+}
+
+export interface ExecutionMetrics {
+  tokens?: ExecutionTokens;
+  [key: string]: unknown;
+}
+
+export interface ExecutionMessage {
+  status?: string;
+  node?: string;
+  event?: string;
+  payload?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+  metrics?: ExecutionMetrics;
+  [key: string]: unknown;
+}
+
+export interface RunHistoryStepResponse {
+  index: number;
+  at: string;
+  payload: Record<string, unknown>;
+}
+
+export interface RunHistoryResponse {
+  execution_id: string;
+  workflow_id: string;
+  status: string;
+  started_at: string;
+  completed_at?: string | null;
+  error?: string | null;
+  inputs: Record<string, unknown>;
+  steps: RunHistoryStepResponse[];
+}
+
+const buildApiUrl = (path: string): string => `${API_BASE_URL}${path}`;
+
+export const getWorkflowWebSocketUrl = (workflowId: string): string => {
+  const sanitized = encodeURIComponent(workflowId.trim());
+  return `${WS_BASE_URL}/${sanitized}`;
+};
+
+export const getBackendWorkflowId = (): string | null => {
+  const value = import.meta.env.VITE_ORCHEO_BACKEND_WORKFLOW_ID;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return null;
+};
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Request failed with status ${response.status}${text ? `: ${text}` : ""}`,
+    );
+  }
+  return response.json() as Promise<T>;
+};
+
+export const fetchExecutionHistory = async (
+  executionId: string,
+): Promise<RunHistoryResponse> => {
+  if (!executionId.trim()) {
+    throw new Error("Execution ID is required to fetch history.");
+  }
+
+  if (typeof fetch === "undefined") {
+    throw new Error("Fetch API is not available in this environment.");
+  }
+
+  const url = buildApiUrl(
+    `/executions/${encodeURIComponent(executionId)}/history`,
+  );
+  const response = await fetch(url, { method: "GET" });
+  return handleResponse<RunHistoryResponse>(response);
+};
+
+interface RunReplayRequestPayload {
+  from_step: number;
+}
+
+export const replayExecution = async (
+  executionId: string,
+  fromStep: number,
+): Promise<RunHistoryResponse> => {
+  if (!executionId.trim()) {
+    throw new Error("Execution ID is required to replay history.");
+  }
+
+  if (typeof fetch === "undefined") {
+    throw new Error("Fetch API is not available in this environment.");
+  }
+
+  const payload: RunReplayRequestPayload = { from_step: fromStep };
+  const response = await fetch(
+    buildApiUrl(`/executions/${encodeURIComponent(executionId)}/replay`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
+  return handleResponse<RunHistoryResponse>(response);
+};
+
+export type { ExecutionMessage as BackendExecutionMessage };

--- a/apps/canvas/src/features/workflow/lib/workflow-diff.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-diff.ts
@@ -1,6 +1,7 @@
 import type {
   WorkflowNode,
   WorkflowEdge,
+  WorkflowCredential,
 } from "@features/workflow/data/workflow-data";
 
 export type WorkflowDiffType = "added" | "removed" | "modified";
@@ -11,6 +12,8 @@ export interface WorkflowSnapshot {
   description?: string;
   nodes: WorkflowNode[];
   edges: WorkflowEdge[];
+  credentials?: WorkflowCredential[];
+  linkedSubworkflowIds?: string[];
 }
 
 export interface WorkflowDiffEntry {

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.ts
@@ -1,6 +1,7 @@
 import {
   SAMPLE_WORKFLOWS,
   type Workflow,
+  type WorkflowCredential,
   type WorkflowEdge,
   type WorkflowNode,
 } from "@features/workflow/data/workflow-data";
@@ -41,6 +42,8 @@ interface SaveWorkflowInput {
   tags?: string[];
   nodes: WorkflowNode[];
   edges: WorkflowEdge[];
+  credentials?: WorkflowCredential[];
+  linkedSubworkflowIds?: string[];
 }
 
 interface SaveWorkflowOptions {
@@ -53,6 +56,8 @@ interface CreateWorkflowInput {
   tags?: string[];
   nodes?: WorkflowNode[];
   edges?: WorkflowEdge[];
+  credentials?: WorkflowCredential[];
+  linkedSubworkflowIds?: string[];
 }
 
 const getStorage = () => {
@@ -92,6 +97,8 @@ const readStorage = (): StoredWorkflow[] => {
       versions: workflow.versions ?? [],
       nodes: workflow.nodes ?? [],
       edges: workflow.edges ?? [],
+      credentials: workflow.credentials ?? [],
+      linkedSubworkflowIds: workflow.linkedSubworkflowIds ?? [],
     }));
   } catch (error) {
     console.warn("Failed to read workflow storage", error);
@@ -168,6 +175,8 @@ export const createWorkflow = (input: CreateWorkflowInput): StoredWorkflow => {
     tags: input.tags ?? ["draft"],
     nodes: input.nodes ?? [],
     edges: input.edges ?? [],
+    credentials: input.credentials ?? [],
+    linkedSubworkflowIds: input.linkedSubworkflowIds ?? [],
     versions: [],
   };
 
@@ -208,6 +217,8 @@ export const saveWorkflow = (
     description: workflow.description,
     nodes: workflow.nodes ?? [],
     edges: workflow.edges ?? [],
+    credentials: workflow.credentials ?? [],
+    linkedSubworkflowIds: workflow.linkedSubworkflowIds ?? [],
   };
 
   workflow.name = input.name;
@@ -215,6 +226,9 @@ export const saveWorkflow = (
   workflow.tags = input.tags ?? workflow.tags ?? [];
   workflow.nodes = input.nodes;
   workflow.edges = input.edges;
+  workflow.credentials = input.credentials ?? workflow.credentials ?? [];
+  workflow.linkedSubworkflowIds =
+    input.linkedSubworkflowIds ?? workflow.linkedSubworkflowIds ?? [];
   workflow.updatedAt = now;
 
   const snapshot: WorkflowSnapshot = {
@@ -222,6 +236,8 @@ export const saveWorkflow = (
     description: workflow.description,
     nodes: workflow.nodes,
     edges: workflow.edges,
+    credentials: workflow.credentials,
+    linkedSubworkflowIds: workflow.linkedSubworkflowIds,
   };
 
   const diff = computeWorkflowDiff(previousSnapshot, snapshot);

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -32,6 +32,15 @@ import "@xyflow/react/dist/style.css";
 import { Button } from "@/design-system/ui/button";
 import { Tabs, TabsContent } from "@/design-system/ui/tabs";
 import { Separator } from "@/design-system/ui/separator";
+import { Badge } from "@/design-system/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/design-system/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/design-system/ui/select";
 
 import TopNavigation from "@features/shared/components/top-navigation";
 import SidebarPanel from "@features/workflow/components/panels/sidebar-panel";
@@ -40,8 +49,14 @@ import WorkflowControls from "@features/workflow/components/canvas/workflow-cont
 import WorkflowSearch from "@features/workflow/components/canvas/workflow-search";
 import NodeInspector from "@features/workflow/components/panels/node-inspector";
 import ChatTriggerNode from "@features/workflow/components/nodes/chat-trigger-node";
-import ChatInterface from "@features/shared/components/chat-interface";
+import ChatKitInterface from "@features/shared/components/chatkit/chatkit-interface";
+import {
+  type ChatEnvironment,
+  type ChatKitMetrics,
+  type ChatKitSession,
+} from "@features/shared/components/chatkit/types";
 import type { Attachment } from "@features/shared/components/chat-input";
+import type { ChatMessageProps } from "@features/shared/components/chat-message";
 import WorkflowExecutionHistory, {
   type WorkflowExecution as HistoryWorkflowExecution,
 } from "@features/workflow/components/panels/workflow-execution-history";
@@ -49,10 +64,14 @@ import WorkflowTabs from "@features/workflow/components/panels/workflow-tabs";
 import WorkflowHistory from "@features/workflow/components/panels/workflow-history";
 import StartEndNode from "@features/workflow/components/nodes/start-end-node";
 import {
+  SAMPLE_CREDENTIALS,
+  SAMPLE_SUBWORKFLOWS,
   SAMPLE_WORKFLOWS,
+  type WorkflowCredential,
   type WorkflowEdge as PersistedWorkflowEdge,
   type WorkflowNode as PersistedWorkflowNode,
 } from "@features/workflow/data/workflow-data";
+import { SAMPLE_CHAT_SESSIONS } from "@features/workflow/data/chat-samples";
 import {
   getVersionSnapshot,
   getWorkflowById,
@@ -60,7 +79,25 @@ import {
   type StoredWorkflow,
   WORKFLOW_STORAGE_EVENT,
 } from "@features/workflow/lib/workflow-storage";
+import {
+  DEFAULT_LANGGRAPH_GRAPH_CONFIG,
+  fetchExecutionHistory,
+  getBackendWorkflowId,
+} from "@features/workflow/lib/execution-client";
+import {
+  useWorkflowExecution,
+  type ExecutionLogEntry,
+  type ExecutionStatus,
+} from "@features/workflow/hooks/use-workflow-execution";
 import { toast } from "@/hooks/use-toast";
+import CredentialsVault from "@features/workflow/components/dialogs/credentials-vault";
+import ReusableSubworkflowLibrary from "@features/workflow/components/panels/reusable-subworkflows";
+import ConnectionValidator, {
+  type ValidationError,
+  type ValidatorNodeData,
+  validateConnection,
+  validateNodeCredentials,
+} from "@features/workflow/components/canvas/connection-validator";
 
 // Define custom node types
 const nodeTypes = {
@@ -77,6 +114,65 @@ const defaultNodeStyle = {
   borderRadius: 0,
   width: "auto",
   boxShadow: "none",
+};
+
+const EXECUTION_STATUS_LABELS: Record<ExecutionStatus, string> = {
+  idle: "Idle",
+  connecting: "Connecting",
+  running: "Running",
+  completed: "Completed",
+  error: "Error",
+  cancelled: "Cancelled",
+};
+
+const isFinalExecutionStatus = (status: ExecutionStatus) =>
+  status === "completed" || status === "error" || status === "cancelled";
+
+const mapBackendStatusToHistory = (
+  status: ExecutionStatus,
+): HistoryWorkflowExecution["status"] => {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "error":
+      return "failed";
+    case "cancelled":
+      return "partial";
+    case "running":
+    case "connecting":
+    case "idle":
+    default:
+      return "running";
+  }
+};
+
+const normaliseHistoryStatus = (status: string): ExecutionStatus => {
+  const value = status.toLowerCase();
+  if (value === "completed" || value === "success") {
+    return "completed";
+  }
+  if (value === "error" || value === "failed") {
+    return "error";
+  }
+  if (value === "cancelled") {
+    return "cancelled";
+  }
+  if (value === "running") {
+    return "running";
+  }
+  return "running";
+};
+
+const computeDurationMs = (start?: string | null, end?: string | null) => {
+  if (!start || !end) {
+    return 0;
+  }
+  const startMs = new Date(start).getTime();
+  const endMs = new Date(end).getTime();
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+    return 0;
+  }
+  return Math.max(0, endMs - startMs);
 };
 
 const generateNodeId = () => {
@@ -101,11 +197,19 @@ interface NodeData {
   icon?: React.ReactNode;
   onOpenChat?: () => void;
   isDisabled?: boolean;
+  credentials?: {
+    id?: string;
+  } | null;
   [key: string]: unknown;
 }
 
 type CanvasNode = Node<NodeData>;
 type CanvasEdge = Edge<Record<string, unknown>>;
+
+type CredentialFormInput = Partial<
+  Omit<WorkflowCredential, "id" | "createdAt" | "updatedAt">
+> &
+  Pick<WorkflowCredential, "name" | "type" | "access" | "secrets">;
 
 const PERSISTED_NODE_FIELDS = new Set([
   "label",
@@ -274,35 +378,7 @@ const cloneEdge = (edge: CanvasEdge): CanvasEdge => ({
   data: edge.data ? { ...edge.data } : edge.data,
 });
 
-// Update the WorkflowExecution interface to match the component's expectations
-type WorkflowExecutionStatus = "running" | "success" | "failed" | "partial";
 type NodeStatus = "idle" | "running" | "success" | "error" | "warning";
-
-interface WorkflowExecutionNode {
-  id: string;
-  type: string;
-  name: string;
-  position: { x: number; y: number };
-  status: NodeStatus;
-  details?: Record<string, unknown>;
-}
-
-interface WorkflowExecution {
-  id: string;
-  runId: string;
-  status: WorkflowExecutionStatus;
-  startTime: string;
-  endTime?: string;
-  duration: number;
-  issues: number;
-  nodes: WorkflowExecutionNode[];
-  edges: WorkflowEdge[];
-  logs: {
-    timestamp: string;
-    level: "INFO" | "DEBUG" | "ERROR" | "WARNING";
-    message: string;
-  }[];
-}
 
 interface SidebarNodeDefinition {
   id?: string;
@@ -386,6 +462,19 @@ export default function WorkflowCanvas({
     StoredWorkflow["versions"]
   >([]);
   const [workflowTags, setWorkflowTags] = useState<string[]>(["draft"]);
+  const [credentials, setCredentials] = useState<WorkflowCredential[]>(() =>
+    SAMPLE_CREDENTIALS.map((credential) => ({
+      ...credential,
+      secrets: { ...credential.secrets },
+    })),
+  );
+  const [linkedSubworkflows, setLinkedSubworkflows] = useState<string[]>([]);
+  const [nodeCredentialAssignments, setNodeCredentialAssignments] = useState<
+    Record<string, string>
+  >({});
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>(
+    [],
+  );
 
   // State for UI controls
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -400,8 +489,64 @@ export default function WorkflowCanvas({
 
   // Chat interface state
   const [isChatOpen, setIsChatOpen] = useState(false);
-  const [activeChatNodeId, setActiveChatNodeId] = useState<string | null>(null);
-  const [chatTitle, setChatTitle] = useState("Chat");
+  const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(
+    SAMPLE_CHAT_SESSIONS[0]?.id ?? null,
+  );
+  const [chatEnvironment, setChatEnvironment] = useState<ChatEnvironment>(
+    SAMPLE_CHAT_SESSIONS[0]?.environment ?? "draft",
+  );
+  const [chatSessions, setChatSessions] = useState<
+    Record<string, ChatKitSession>
+  >(() => {
+    const initial: Record<string, ChatKitSession> = {};
+    SAMPLE_CHAT_SESSIONS.forEach((session) => {
+      initial[session.id] = session;
+    });
+    return initial;
+  });
+  const [chatView, setChatView] = useState<"assist" | "handoff">("assist");
+
+  const backendWorkflowId = getBackendWorkflowId();
+  const executionInputs = useMemo(
+    () => ({ name: workflowName.trim() || "Canvas User" }),
+    [workflowName],
+  );
+  const chatUserProfile = useMemo(
+    () => ({
+      id: "workflow-owner",
+      name: "Workflow Owner",
+      avatar: "https://avatar.vercel.sh/workflow-owner",
+    }),
+    [],
+  );
+  const chatAssistantProfile = useMemo(
+    () => ({
+      id: "assistant-default",
+      name: "Workflow Copilot",
+      avatar: "https://avatar.vercel.sh/workflow-copilot",
+      isAI: true,
+    }),
+    [],
+  );
+  const {
+    status: backendExecutionStatus,
+    executionId: backendExecutionId,
+    logs: backendExecutionLogs,
+    tokenMetrics,
+    lastError: backendExecutionError,
+    startExecution,
+    stopExecution,
+  } = useWorkflowExecution({
+    workflowId: backendWorkflowId,
+    graphConfig: DEFAULT_LANGGRAPH_GRAPH_CONFIG,
+    inputs: executionInputs,
+  });
+  const [liveExecution, setLiveExecution] =
+    useState<HistoryWorkflowExecution | null>(null);
+  const [liveExecutionLogs, setLiveExecutionLogs] = useState<
+    ExecutionLogEntry[]
+  >([]);
+  const executionStartRef = useRef<string | null>(null);
 
   const undoStackRef = useRef<WorkflowSnapshot[]>([]);
   const redoStackRef = useRef<WorkflowSnapshot[]>([]);
@@ -409,14 +554,126 @@ export default function WorkflowCanvas({
   const nodesRef = useRef<CanvasNode[]>(nodes);
   const edgesRef = useRef<CanvasEdge[]>(edges);
 
-  const handleOpenChat = useCallback((nodeId: string) => {
-    const chatNode = nodesRef.current.find((node) => node.id === nodeId);
-    if (chatNode) {
-      setChatTitle(chatNode.data.label || "Chat");
-      setActiveChatNodeId(nodeId);
-      setIsChatOpen(true);
-    }
+  const ensureCredentialsState = useCallback((items?: WorkflowCredential[]) => {
+    const source = items && items.length > 0 ? items : SAMPLE_CREDENTIALS;
+    setCredentials(
+      source.map((credential) => ({
+        ...credential,
+        secrets: { ...credential.secrets },
+      })),
+    );
   }, []);
+
+  const ensureLinkedSubworkflows = useCallback((ids?: string[]) => {
+    setLinkedSubworkflows([...(ids ?? [])]);
+  }, []);
+
+  const rehydrateCredentialAssignments = useCallback(
+    (canvasNodes: CanvasNode[]) => {
+      const mapping: Record<string, string> = {};
+      canvasNodes.forEach((node) => {
+        const credentials =
+          (node.data as NodeData & { credentials?: { id?: string } })
+            .credentials ?? null;
+        if (credentials?.id) {
+          mapping[node.id] = credentials.id;
+        }
+      });
+      setNodeCredentialAssignments(mapping);
+    },
+    [],
+  );
+
+  const handleOpenChat = useCallback(
+    (nodeId: string) => {
+      const chatNode = nodesRef.current.find((node) => node.id === nodeId);
+      if (!chatNode) {
+        return;
+      }
+
+      let resolvedEnvironment: ChatEnvironment | null = null;
+
+      setChatSessions((prev) => {
+        const existing = prev[nodeId];
+        if (existing) {
+          resolvedEnvironment = existing.environment;
+          return {
+            ...prev,
+            [nodeId]: {
+              ...existing,
+              title: chatNode.data.label || existing.title,
+              subtitle:
+                typeof chatNode.data?.description === "string"
+                  ? chatNode.data.description
+                  : existing.subtitle,
+              updatedAt: new Date().toISOString(),
+            },
+          };
+        }
+
+        const nowIso = new Date().toISOString();
+        const session: ChatKitSession = {
+          id: nodeId,
+          nodeId,
+          title: chatNode.data.label || "Chat trigger",
+          subtitle:
+            typeof chatNode.data?.description === "string"
+              ? chatNode.data.description
+              : "Chat-triggered workflow",
+          environment: chatEnvironment,
+          status: "idle",
+          updatedAt: nowIso,
+          participants: [
+            { ...chatUserProfile, role: "user" },
+            { ...chatAssistantProfile, role: "ai" },
+          ],
+          quickPrompts: [
+            "Trigger this workflow",
+            "Show me the last run summary",
+            "List required credentials",
+          ],
+          handoffChecklist: [
+            {
+              id: `${nodeId}-qa`,
+              label: "QA prompt output for chat trigger",
+              completed: false,
+              owner: "Workflow Owner",
+            },
+            {
+              id: `${nodeId}-credentials`,
+              label: "Verify credential scope for chat usage",
+              completed: false,
+              owner: "Security Reviewer",
+            },
+          ],
+          messages: [
+            {
+              id: `welcome-${nodeId}`,
+              content: `You're connected to ${
+                chatNode.data.label || "this chat trigger"
+              }. Ask me to run the workflow or inspect recent runs.`,
+              sender: chatAssistantProfile,
+              timestamp: nowIso,
+            },
+          ],
+        };
+
+        resolvedEnvironment = session.environment;
+
+        return {
+          ...prev,
+          [nodeId]: session,
+        };
+      });
+
+      setActiveChatSessionId(nodeId);
+      if (resolvedEnvironment) {
+        setChatEnvironment(resolvedEnvironment);
+      }
+      setIsChatOpen(true);
+    },
+    [chatAssistantProfile, chatEnvironment, chatUserProfile],
+  );
 
   const convertPersistedNodesToCanvas = useCallback(
     (persistedNodes: PersistedWorkflowNode[]) =>
@@ -482,12 +739,120 @@ export default function WorkflowCanvas({
     });
   }, [currentSearchIndex, isSearchOpen, nodes, searchMatchSet, searchMatches]);
 
+  const credentialEligibleNodes = useMemo(
+    () =>
+      nodes.filter((node) => {
+        const candidateType =
+          typeof node.data?.type === "string"
+            ? node.data.type
+            : typeof node.type === "string"
+              ? node.type
+              : "";
+        return ["api", "data", "database"].includes(candidateType);
+      }),
+    [nodes],
+  );
+
+  const credentialOptions = useMemo(
+    () =>
+      credentials.map((credential) => ({
+        id: credential.id,
+        label: credential.name,
+      })),
+    [credentials],
+  );
+
+  const credentialIssueCount = validationErrors.filter(
+    (error) => error.type === "credential",
+  ).length;
+  const totalValidationIssues = validationErrors.length;
+
   const createSnapshot = useCallback(
     (): WorkflowSnapshot => ({
       nodes: nodesRef.current.map(cloneNode),
       edges: edgesRef.current.map(cloneEdge),
     }),
     [],
+  );
+
+  const appendValidationError = useCallback((error: ValidationError) => {
+    setValidationErrors((previous) => {
+      if (previous.some((item) => item.id === error.id)) {
+        return previous;
+      }
+      return [...previous, error];
+    });
+  }, []);
+
+  const mergeCredentialErrors = useCallback((errors: ValidationError[]) => {
+    setValidationErrors((previous) => {
+      const retained = previous.filter((item) => item.type !== "credential");
+      const merged = new Map<string, ValidationError>();
+      retained.forEach((item) => merged.set(item.id, item));
+      errors.forEach((item) => merged.set(item.id, item));
+      return Array.from(merged.values());
+    });
+  }, []);
+
+  const runPublishValidation = useCallback(() => {
+    const snapshot = createSnapshot();
+    const credentialErrors = snapshot.nodes
+      .map((node) =>
+        validateNodeCredentials(node as unknown as Node<ValidatorNodeData>),
+      )
+      .filter((error): error is ValidationError => Boolean(error));
+
+    mergeCredentialErrors(credentialErrors);
+    return credentialErrors;
+  }, [createSnapshot, mergeCredentialErrors]);
+
+  const handleManualValidation = useCallback(() => {
+    const newCredentialIssues = runPublishValidation();
+    const existingConnectionIssues = validationErrors.filter(
+      (error) => error.type === "connection",
+    ).length;
+    const totalIssues = newCredentialIssues.length + existingConnectionIssues;
+
+    if (totalIssues === 0) {
+      toast({
+        title: "Workflow ready to publish",
+        description: "No blocking credential or connection issues detected.",
+      });
+    } else {
+      toast({
+        title: "Resolve blocking issues",
+        description: `${totalIssues} ${
+          totalIssues === 1 ? "issue" : "issues"
+        } must be fixed before publishing.`,
+        variant: "destructive",
+      });
+    }
+  }, [runPublishValidation, validationErrors]);
+
+  const handleDismissValidationError = useCallback((id: string) => {
+    setValidationErrors((previous) =>
+      previous.filter((error) => error.id !== id),
+    );
+  }, []);
+
+  const handleFixValidationError = useCallback(
+    (error: ValidationError) => {
+      if (error.type === "credential" && error.sourceId) {
+        const targetNode = nodesRef.current.find(
+          (node) => node.id === error.sourceId,
+        );
+        if (targetNode) {
+          setActiveTab("settings");
+          setSelectedNode(targetNode);
+        }
+        return;
+      }
+
+      if (error.type === "connection") {
+        setActiveTab("canvas");
+      }
+    },
+    [setActiveTab, setSelectedNode],
   );
 
   const recordSnapshot = useCallback(
@@ -509,6 +874,7 @@ export default function WorkflowCanvas({
   const applySnapshot = useCallback(
     (snapshot: WorkflowSnapshot, { resetHistory = false } = {}) => {
       isRestoringRef.current = true;
+      rehydrateCredentialAssignments(snapshot.nodes);
       setNodesState(snapshot.nodes);
       setEdgesState(snapshot.edges);
       if (resetHistory) {
@@ -518,7 +884,13 @@ export default function WorkflowCanvas({
         setCanRedo(false);
       }
     },
-    [setCanRedo, setCanUndo, setEdgesState, setNodesState],
+    [
+      rehydrateCredentialAssignments,
+      setCanRedo,
+      setCanUndo,
+      setEdgesState,
+      setNodesState,
+    ],
   );
 
   useLayoutEffect(() => {
@@ -534,6 +906,13 @@ export default function WorkflowCanvas({
   useEffect(() => {
     edgesRef.current = edges;
   }, [edges]);
+
+  useEffect(() => {
+    if (nodesRef.current.length === 0) {
+      return;
+    }
+    runPublishValidation();
+  }, [nodeCredentialAssignments, runPublishValidation]);
 
   const setNodes = useCallback(
     (updater: React.SetStateAction<CanvasNode[]>) => {
@@ -593,354 +972,608 @@ export default function WorkflowCanvas({
   );
 
   // Sample executions for the WorkflowExecutionHistory component
-  const mockExecutions: WorkflowExecution[] = [
-    {
-      id: "1",
-      runId: "842",
-      status: "success",
-      startTime: new Date().toISOString(),
-      duration: 45200,
+  const mockExecutions = useMemo<HistoryWorkflowExecution[]>(
+    () => [
+      {
+        id: "1",
+        runId: "842",
+        status: "success",
+        startTime: new Date().toISOString(),
+        duration: 45200,
+        issues: 0,
+        nodes: [
+          {
+            id: "node-1",
+            type: "webhook",
+            name: "New Customer Webhook",
+            position: { x: 100, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-2",
+            type: "http",
+            name: "Fetch Customer Details",
+            position: { x: 400, y: 100 },
+            status: "success",
+            details: {
+              method: "GET",
+              url: "https://api.example.com/customers/123",
+              items: 1,
+            },
+          },
+          {
+            id: "node-3",
+            type: "function",
+            name: "Format Customer Data",
+            position: { x: 700, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-4",
+            type: "api",
+            name: "Create Account",
+            position: { x: 400, y: 250 },
+            status: "success",
+          },
+          {
+            id: "node-5",
+            type: "api",
+            name: "Send Welcome Email",
+            position: { x: 700, y: 250 },
+            status: "success",
+            details: {
+              message: "Welcome to our platform!",
+            },
+          },
+        ],
+        edges: [
+          { id: "edge-1", source: "node-1", target: "node-2", type: "default" },
+          { id: "edge-2", source: "node-2", target: "node-3" },
+          { id: "edge-3", source: "node-3", target: "node-4" },
+          { id: "edge-4", source: "node-4", target: "node-5" },
+        ],
+        logs: [
+          {
+            timestamp: "10:23:15",
+            level: "INFO",
+            message: "Workflow execution started",
+          },
+          {
+            timestamp: "10:23:16",
+            level: "DEBUG",
+            message: 'Executing node "New Customer Webhook"',
+          },
+          {
+            timestamp: "10:23:17",
+            level: "INFO",
+            message: 'Node "New Customer Webhook" completed successfully',
+          },
+          {
+            timestamp: "10:23:18",
+            level: "DEBUG",
+            message: 'Executing node "Fetch Customer Details"',
+          },
+          {
+            timestamp: "10:23:20",
+            level: "INFO",
+            message: 'Node "Fetch Customer Details" completed successfully',
+          },
+          {
+            timestamp: "10:23:21",
+            level: "DEBUG",
+            message: 'Executing node "Format Customer Data"',
+          },
+          {
+            timestamp: "10:23:23",
+            level: "INFO",
+            message: 'Node "Format Customer Data" completed successfully',
+          },
+          {
+            timestamp: "10:23:24",
+            level: "DEBUG",
+            message: 'Executing node "Create Account"',
+          },
+          {
+            timestamp: "10:23:40",
+            level: "INFO",
+            message: 'Node "Create Account" completed successfully',
+          },
+          {
+            timestamp: "10:23:41",
+            level: "DEBUG",
+            message: 'Executing node "Send Welcome Email"',
+          },
+          {
+            timestamp: "10:23:45",
+            level: "INFO",
+            message: 'Node "Send Welcome Email" completed successfully',
+          },
+          {
+            timestamp: "10:23:45",
+            level: "INFO",
+            message: "Workflow execution completed successfully",
+          },
+        ],
+      },
+      {
+        id: "2",
+        runId: "841",
+        status: "failed",
+        startTime: new Date(Date.now() - 86400000).toISOString(), // yesterday
+        duration: 134700,
+        issues: 3,
+        nodes: [
+          {
+            id: "node-1",
+            type: "webhook",
+            name: "New Customer Webhook",
+            position: { x: 100, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-2",
+            type: "http",
+            name: "Fetch Customer Details",
+            position: { x: 400, y: 100 },
+            status: "success",
+            details: {
+              method: "GET",
+              url: "https://api.example.com/customers/456",
+              items: 1,
+            },
+          },
+          {
+            id: "node-3",
+            type: "function",
+            name: "Format Customer Data",
+            position: { x: 700, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-4",
+            type: "api",
+            name: "Create Account",
+            position: { x: 400, y: 250 },
+            status: "error",
+            details: {
+              message: "Email already exists",
+            },
+          },
+          {
+            id: "node-5",
+            type: "api",
+            name: "Send Welcome Email",
+            position: { x: 700, y: 250 },
+            status: "idle",
+          },
+        ],
+        edges: [
+          { id: "edge-1", source: "node-1", target: "node-2" },
+          { id: "edge-2", source: "node-2", target: "node-3" },
+          { id: "edge-3", source: "node-3", target: "node-4" },
+          { id: "edge-4", source: "node-4", target: "node-5" },
+        ],
+        logs: [
+          {
+            timestamp: "15:45:10",
+            level: "INFO",
+            message: "Workflow execution started",
+          },
+          {
+            timestamp: "15:45:11",
+            level: "DEBUG",
+            message: 'Executing node "New Customer Webhook"',
+          },
+          {
+            timestamp: "15:45:12",
+            level: "INFO",
+            message: 'Node "New Customer Webhook" completed successfully',
+          },
+          {
+            timestamp: "15:45:13",
+            level: "DEBUG",
+            message: 'Executing node "Fetch Customer Details"',
+          },
+          {
+            timestamp: "15:45:15",
+            level: "INFO",
+            message: 'Node "Fetch Customer Details" completed successfully',
+          },
+          {
+            timestamp: "15:45:16",
+            level: "DEBUG",
+            message: 'Executing node "Format Customer Data"',
+          },
+          {
+            timestamp: "15:45:18",
+            level: "INFO",
+            message: 'Node "Format Customer Data" completed successfully',
+          },
+          {
+            timestamp: "15:45:19",
+            level: "DEBUG",
+            message: 'Executing node "Create Account"',
+          },
+          {
+            timestamp: "15:45:30",
+            level: "ERROR",
+            message: 'Error in node "Create Account": Email already exists',
+          },
+          {
+            timestamp: "15:45:30",
+            level: "INFO",
+            message: "Workflow execution failed",
+          },
+        ],
+      },
+      {
+        id: "3",
+        runId: "840",
+        status: "partial",
+        startTime: new Date("2023-11-03T09:12:00").toISOString(),
+        duration: 67300,
+        issues: 1,
+        nodes: [
+          {
+            id: "node-1",
+            type: "webhook",
+            name: "New Customer Webhook",
+            position: { x: 100, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-2",
+            type: "http",
+            name: "Fetch Customer Details",
+            position: { x: 400, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-3",
+            type: "function",
+            name: "Format Customer Data",
+            position: { x: 700, y: 100 },
+            status: "success",
+          },
+          {
+            id: "node-4",
+            type: "api",
+            name: "Create Account",
+            position: { x: 400, y: 250 },
+            status: "success",
+          },
+          {
+            id: "node-5",
+            type: "api",
+            name: "Send Welcome Email",
+            position: { x: 700, y: 250 },
+            status: "success",
+          },
+        ],
+        edges: [
+          { id: "edge-1", source: "node-1", target: "node-2" },
+          { id: "edge-2", source: "node-2", target: "node-3" },
+          { id: "edge-3", source: "node-3", target: "node-4" },
+          { id: "edge-4", source: "node-4", target: "node-5" },
+        ],
+        logs: [
+          {
+            timestamp: "09:12:00",
+            level: "INFO",
+            message: "Workflow execution started",
+          },
+          {
+            timestamp: "09:12:01",
+            level: "DEBUG",
+            message: 'Executing node "Daily Report Trigger"',
+          },
+          {
+            timestamp: "09:12:02",
+            level: "INFO",
+            message: 'Node "Daily Report Trigger" completed successfully',
+          },
+          {
+            timestamp: "09:12:03",
+            level: "DEBUG",
+            message: 'Executing node "Fetch Sales Data"',
+          },
+          {
+            timestamp: "09:12:10",
+            level: "INFO",
+            message: 'Node "Fetch Sales Data" completed successfully',
+          },
+          {
+            timestamp: "09:12:11",
+            level: "DEBUG",
+            message: 'Executing node "Generate Report"',
+          },
+          {
+            timestamp: "09:12:30",
+            level: "INFO",
+            message: 'Node "Generate Report" completed successfully',
+          },
+          {
+            timestamp: "09:12:31",
+            level: "DEBUG",
+            message: 'Executing node "Email Report"',
+          },
+          {
+            timestamp: "09:12:40",
+            level: "INFO",
+            message: 'Node "Email Report" completed successfully',
+          },
+          {
+            timestamp: "09:12:41",
+            level: "DEBUG",
+            message: 'Executing node "Slack Notification"',
+          },
+          {
+            timestamp: "09:12:45",
+            level: "WARNING",
+            message:
+              'Node "Slack Notification" completed with warnings: Channel not found',
+          },
+          {
+            timestamp: "09:12:45",
+            level: "INFO",
+            message: "Workflow execution completed with warnings",
+          },
+        ],
+      },
+    ],
+    [],
+  );
+
+  const buildExecutionFromSnapshot = useCallback(
+    (snapshot: WorkflowSnapshot, executionId: string, startTime: string) => ({
+      id: executionId,
+      runId: executionId,
+      status: "running" as HistoryWorkflowExecution["status"],
+      startTime,
+      duration: 0,
       issues: 0,
-      nodes: [
-        {
-          id: "node-1",
-          type: "webhook",
-          name: "New Customer Webhook",
-          position: { x: 100, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-2",
-          type: "http",
-          name: "Fetch Customer Details",
-          position: { x: 400, y: 100 },
-          status: "success",
-          details: {
-            method: "GET",
-            url: "https://api.example.com/customers/123",
-            items: 1,
-          },
-        },
-        {
-          id: "node-3",
-          type: "function",
-          name: "Format Customer Data",
-          position: { x: 700, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-4",
-          type: "api",
-          name: "Create Account",
-          position: { x: 400, y: 250 },
-          status: "success",
-        },
-        {
-          id: "node-5",
-          type: "api",
-          name: "Send Welcome Email",
-          position: { x: 700, y: 250 },
-          status: "success",
-          details: {
-            message: "Welcome to our platform!",
-          },
-        },
-      ],
-      edges: [
-        { id: "edge-1", source: "node-1", target: "node-2", type: "default" },
-        { id: "edge-2", source: "node-2", target: "node-3" },
-        { id: "edge-3", source: "node-3", target: "node-4" },
-        { id: "edge-4", source: "node-4", target: "node-5" },
-      ],
-      logs: [
-        {
-          timestamp: "10:23:15",
-          level: "INFO",
-          message: "Workflow execution started",
-        },
-        {
-          timestamp: "10:23:16",
-          level: "DEBUG",
-          message: 'Executing node "New Customer Webhook"',
-        },
-        {
-          timestamp: "10:23:17",
-          level: "INFO",
-          message: 'Node "New Customer Webhook" completed successfully',
-        },
-        {
-          timestamp: "10:23:18",
-          level: "DEBUG",
-          message: 'Executing node "Fetch Customer Details"',
-        },
-        {
-          timestamp: "10:23:20",
-          level: "INFO",
-          message: 'Node "Fetch Customer Details" completed successfully',
-        },
-        {
-          timestamp: "10:23:21",
-          level: "DEBUG",
-          message: 'Executing node "Format Customer Data"',
-        },
-        {
-          timestamp: "10:23:23",
-          level: "INFO",
-          message: 'Node "Format Customer Data" completed successfully',
-        },
-        {
-          timestamp: "10:23:24",
-          level: "DEBUG",
-          message: 'Executing node "Create Account"',
-        },
-        {
-          timestamp: "10:23:40",
-          level: "INFO",
-          message: 'Node "Create Account" completed successfully',
-        },
-        {
-          timestamp: "10:23:41",
-          level: "DEBUG",
-          message: 'Executing node "Send Welcome Email"',
-        },
-        {
-          timestamp: "10:23:45",
-          level: "INFO",
-          message: 'Node "Send Welcome Email" completed successfully',
-        },
-        {
-          timestamp: "10:23:45",
-          level: "INFO",
-          message: "Workflow execution completed successfully",
-        },
-      ],
-    },
-    {
-      id: "2",
-      runId: "841",
-      status: "failed",
-      startTime: new Date(Date.now() - 86400000).toISOString(), // yesterday
-      duration: 134700,
-      issues: 3,
-      nodes: [
-        {
-          id: "node-1",
-          type: "webhook",
-          name: "New Customer Webhook",
-          position: { x: 100, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-2",
-          type: "http",
-          name: "Fetch Customer Details",
-          position: { x: 400, y: 100 },
-          status: "success",
-          details: {
-            method: "GET",
-            url: "https://api.example.com/customers/456",
-            items: 1,
-          },
-        },
-        {
-          id: "node-3",
-          type: "function",
-          name: "Format Customer Data",
-          position: { x: 700, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-4",
-          type: "api",
-          name: "Create Account",
-          position: { x: 400, y: 250 },
-          status: "error",
-          details: {
-            message: "Email already exists",
-          },
-        },
-        {
-          id: "node-5",
-          type: "api",
-          name: "Send Welcome Email",
-          position: { x: 700, y: 250 },
-          status: "idle",
-        },
-      ],
-      edges: [
-        { id: "edge-1", source: "node-1", target: "node-2" },
-        { id: "edge-2", source: "node-2", target: "node-3" },
-        { id: "edge-3", source: "node-3", target: "node-4" },
-        { id: "edge-4", source: "node-4", target: "node-5" },
-      ],
-      logs: [
-        {
-          timestamp: "15:45:10",
-          level: "INFO",
-          message: "Workflow execution started",
-        },
-        {
-          timestamp: "15:45:11",
-          level: "DEBUG",
-          message: 'Executing node "New Customer Webhook"',
-        },
-        {
-          timestamp: "15:45:12",
-          level: "INFO",
-          message: 'Node "New Customer Webhook" completed successfully',
-        },
-        {
-          timestamp: "15:45:13",
-          level: "DEBUG",
-          message: 'Executing node "Fetch Customer Details"',
-        },
-        {
-          timestamp: "15:45:15",
-          level: "INFO",
-          message: 'Node "Fetch Customer Details" completed successfully',
-        },
-        {
-          timestamp: "15:45:16",
-          level: "DEBUG",
-          message: 'Executing node "Format Customer Data"',
-        },
-        {
-          timestamp: "15:45:18",
-          level: "INFO",
-          message: 'Node "Format Customer Data" completed successfully',
-        },
-        {
-          timestamp: "15:45:19",
-          level: "DEBUG",
-          message: 'Executing node "Create Account"',
-        },
-        {
-          timestamp: "15:45:30",
-          level: "ERROR",
-          message: 'Error in node "Create Account": Email already exists',
-        },
-        {
-          timestamp: "15:45:30",
-          level: "INFO",
-          message: "Workflow execution failed",
-        },
-      ],
-    },
-    {
-      id: "3",
-      runId: "840",
-      status: "partial",
-      startTime: new Date("2023-11-03T09:12:00").toISOString(),
-      duration: 67300,
-      issues: 1,
-      nodes: [
-        {
-          id: "node-1",
-          type: "webhook",
-          name: "New Customer Webhook",
-          position: { x: 100, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-2",
-          type: "http",
-          name: "Fetch Customer Details",
-          position: { x: 400, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-3",
-          type: "function",
-          name: "Format Customer Data",
-          position: { x: 700, y: 100 },
-          status: "success",
-        },
-        {
-          id: "node-4",
-          type: "api",
-          name: "Create Account",
-          position: { x: 400, y: 250 },
-          status: "success",
-        },
-        {
-          id: "node-5",
-          type: "api",
-          name: "Send Welcome Email",
-          position: { x: 700, y: 250 },
-          status: "success",
-        },
-      ],
-      edges: [
-        { id: "edge-1", source: "node-1", target: "node-2" },
-        { id: "edge-2", source: "node-2", target: "node-3" },
-        { id: "edge-3", source: "node-3", target: "node-4" },
-        { id: "edge-4", source: "node-4", target: "node-5" },
-      ],
-      logs: [
-        {
-          timestamp: "09:12:00",
-          level: "INFO",
-          message: "Workflow execution started",
-        },
-        {
-          timestamp: "09:12:01",
-          level: "DEBUG",
-          message: 'Executing node "Daily Report Trigger"',
-        },
-        {
-          timestamp: "09:12:02",
-          level: "INFO",
-          message: 'Node "Daily Report Trigger" completed successfully',
-        },
-        {
-          timestamp: "09:12:03",
-          level: "DEBUG",
-          message: 'Executing node "Fetch Sales Data"',
-        },
-        {
-          timestamp: "09:12:10",
-          level: "INFO",
-          message: 'Node "Fetch Sales Data" completed successfully',
-        },
-        {
-          timestamp: "09:12:11",
-          level: "DEBUG",
-          message: 'Executing node "Generate Report"',
-        },
-        {
-          timestamp: "09:12:30",
-          level: "INFO",
-          message: 'Node "Generate Report" completed successfully',
-        },
-        {
-          timestamp: "09:12:31",
-          level: "DEBUG",
-          message: 'Executing node "Email Report"',
-        },
-        {
-          timestamp: "09:12:40",
-          level: "INFO",
-          message: 'Node "Email Report" completed successfully',
-        },
-        {
-          timestamp: "09:12:41",
-          level: "DEBUG",
-          message: 'Executing node "Slack Notification"',
-        },
-        {
-          timestamp: "09:12:45",
-          level: "WARNING",
-          message:
-            'Node "Slack Notification" completed with warnings: Channel not found',
-        },
-        {
-          timestamp: "09:12:45",
-          level: "INFO",
-          message: "Workflow execution completed with warnings",
-        },
-      ],
-    },
-  ];
+      nodes: snapshot.nodes.map((node) => ({
+        id: node.id,
+        type:
+          typeof node.data?.type === "string"
+            ? node.data.type
+            : typeof node.type === "string"
+              ? node.type
+              : "default",
+        name: typeof node.data?.label === "string" ? node.data.label : node.id,
+        position: node.position ?? { x: 0, y: 0 },
+        status: "running" as NodeStatus,
+      })),
+      edges: snapshot.edges.map((edge) => ({
+        id: edge.id ?? `${edge.source}-${edge.target}`,
+        source: edge.source,
+        target: edge.target,
+      })),
+      logs: [],
+    }),
+    [],
+  );
+
+  const toHistoryLogs = useCallback(
+    (entries: ExecutionLogEntry[]): HistoryWorkflowExecution["logs"] =>
+      entries.map((entry) => ({
+        timestamp: entry.timestamp,
+        level: entry.level,
+        message: entry.message,
+      })),
+    [],
+  );
+
+  const executionsForHistory = useMemo(() => {
+    const normalise = (execution: HistoryWorkflowExecution) => ({
+      ...execution,
+      nodes: execution.nodes.map((node) => ({
+        ...node,
+        status: (node.status ?? "idle") as NodeStatus,
+      })),
+    });
+
+    if (!liveExecution) {
+      return mockExecutions.map(normalise);
+    }
+    const filtered = mockExecutions
+      .filter((execution) => execution.id !== liveExecution.id)
+      .map(normalise);
+    return [normalise(liveExecution), ...filtered];
+  }, [liveExecution, mockExecutions]);
+
+  useEffect(() => {
+    if (!backendWorkflowId) {
+      return;
+    }
+    if (
+      backendExecutionStatus === "running" ||
+      backendExecutionStatus === "connecting"
+    ) {
+      setLiveExecutionLogs(backendExecutionLogs);
+    }
+  }, [backendExecutionLogs, backendExecutionStatus, backendWorkflowId]);
+
+  useEffect(() => {
+    setLiveExecution((current) =>
+      current
+        ? {
+            ...current,
+            logs: toHistoryLogs(liveExecutionLogs),
+          }
+        : current,
+    );
+  }, [liveExecutionLogs, toHistoryLogs]);
+
+  const loadExecutionHistory = useCallback(async (executionId: string) => {
+    try {
+      const history = await fetchExecutionHistory(executionId);
+      const normalisedStatus = normaliseHistoryStatus(history.status);
+      const logs = history.steps.map((step) => {
+        const payload = step.payload ?? {};
+        const statusValue =
+          typeof payload.status === "string"
+            ? payload.status.toLowerCase()
+            : "";
+        let level: HistoryWorkflowExecution["logs"][number]["level"] = "INFO";
+        if (statusValue === "error") {
+          level = "ERROR";
+        } else if (statusValue === "cancelled") {
+          level = "WARNING";
+        } else if (typeof payload.event === "string") {
+          level = "DEBUG";
+        }
+
+        let message: string;
+        if (typeof payload.message === "string" && payload.message.trim()) {
+          message = payload.message;
+        } else if (
+          typeof payload.node === "string" &&
+          typeof payload.event === "string"
+        ) {
+          message = `[${payload.event}] ${payload.node}`;
+        } else if (typeof payload.status === "string") {
+          message = `Status: ${payload.status}`;
+        } else {
+          message = JSON.stringify(payload);
+        }
+
+        return {
+          timestamp: new Date(step.at).toISOString(),
+          level,
+          message,
+        };
+      });
+
+      setLiveExecutionLogs(
+        logs.map((entry) => ({
+          timestamp: entry.timestamp,
+          level: entry.level,
+          message: entry.message,
+        })),
+      );
+
+      const duration = computeDurationMs(
+        history.started_at,
+        history.completed_at ?? new Date().toISOString(),
+      );
+
+      setLiveExecution((current) =>
+        current && current.id === executionId
+          ? {
+              ...current,
+              status: mapBackendStatusToHistory(normalisedStatus),
+              startTime: history.started_at,
+              endTime: history.completed_at ?? current.endTime,
+              duration,
+              issues: normalisedStatus === "error" ? 1 : current.issues,
+            }
+          : current,
+      );
+    } catch (error) {
+      console.error("Failed to fetch execution history", error);
+      toast({
+        title: "Execution history unavailable",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Unable to retrieve execution history from the backend.",
+        variant: "destructive",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!backendWorkflowId) {
+      return;
+    }
+
+    if (
+      backendExecutionStatus === "running" ||
+      backendExecutionStatus === "connecting"
+    ) {
+      executionStartRef.current ??= new Date().toISOString();
+      setIsRunning(true);
+      setLiveExecution((current) =>
+        current
+          ? {
+              ...current,
+              status: mapBackendStatusToHistory(backendExecutionStatus),
+            }
+          : current,
+      );
+      return;
+    }
+
+    if (backendExecutionStatus === "idle") {
+      setIsRunning(false);
+      return;
+    }
+
+    if (isFinalExecutionStatus(backendExecutionStatus)) {
+      setIsRunning(false);
+      if (!backendExecutionId) {
+        return;
+      }
+      const finishedAt = new Date().toISOString();
+      const startedAt = executionStartRef.current ?? finishedAt;
+      const duration = computeDurationMs(startedAt, finishedAt);
+      executionStartRef.current = null;
+      setLiveExecution((current) =>
+        current && current.id === backendExecutionId
+          ? {
+              ...current,
+              status: mapBackendStatusToHistory(backendExecutionStatus),
+              endTime: finishedAt,
+              duration,
+              issues:
+                backendExecutionStatus === "error"
+                  ? current.issues === 0
+                    ? 1
+                    : current.issues
+                  : current.issues,
+            }
+          : current,
+      );
+      void loadExecutionHistory(backendExecutionId);
+    }
+  }, [
+    backendExecutionId,
+    backendExecutionStatus,
+    backendWorkflowId,
+    loadExecutionHistory,
+  ]);
+
+  const startBackendExecution = useCallback(async () => {
+    try {
+      const snapshot = createSnapshot();
+      const startTime = new Date().toISOString();
+      const executionIdentifier = await startExecution();
+      if (!executionIdentifier) {
+        return null;
+      }
+      executionStartRef.current = startTime;
+      const executionRecord = buildExecutionFromSnapshot(
+        snapshot,
+        executionIdentifier,
+        startTime,
+      );
+      setLiveExecution(executionRecord);
+      setLiveExecutionLogs([]);
+      return executionIdentifier;
+    } catch (error) {
+      console.error("Failed to start backend execution", error);
+      toast({
+        title: "Unable to start execution",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Unexpected error while starting the backend execution.",
+        variant: "destructive",
+      });
+      return null;
+    }
+  }, [buildExecutionFromSnapshot, createSnapshot, startExecution]);
 
   const highlightMatch = useCallback(
     (index: number) => {
@@ -1143,6 +1776,11 @@ export default function WorkflowCanvas({
         description: workflowDescription,
         nodes: snapshot.nodes.map(toPersistedNode),
         edges: snapshot.edges.map(toPersistedEdge),
+        credentials: credentials.map((credential) => ({
+          ...credential,
+          secrets: { ...credential.secrets },
+        })),
+        linkedSubworkflowIds: [...linkedSubworkflows],
       };
       const serialized = JSON.stringify(workflowData, null, 2);
       const blob = new Blob([serialized], { type: "application/json" });
@@ -1166,7 +1804,13 @@ export default function WorkflowCanvas({
         variant: "destructive",
       });
     }
-  }, [createSnapshot, workflowDescription, workflowName]);
+  }, [
+    createSnapshot,
+    credentials,
+    linkedSubworkflows,
+    workflowDescription,
+    workflowName,
+  ]);
 
   const handleImportWorkflow = useCallback(() => {
     fileInputRef.current?.click();
@@ -1224,6 +1868,17 @@ export default function WorkflowCanvas({
             setCurrentWorkflowId(null);
             setWorkflowVersions([]);
             setWorkflowTags(["draft"]);
+            ensureCredentialsState(
+              Array.isArray(parsed.credentials)
+                ? (parsed.credentials as WorkflowCredential[])
+                : undefined,
+            );
+            ensureLinkedSubworkflows(
+              Array.isArray(parsed.linkedSubworkflowIds)
+                ? (parsed.linkedSubworkflowIds as string[])
+                : undefined,
+            );
+            rehydrateCredentialAssignments(importedNodes);
           } catch (error) {
             isRestoringRef.current = false;
             throw error;
@@ -1258,7 +1913,10 @@ export default function WorkflowCanvas({
     },
     [
       convertPersistedNodesToCanvas,
+      ensureCredentialsState,
+      ensureLinkedSubworkflows,
       recordSnapshot,
+      rehydrateCredentialAssignments,
       setEdgesState,
       setNodesState,
       setWorkflowDescription,
@@ -1266,7 +1924,249 @@ export default function WorkflowCanvas({
     ],
   );
 
+  const handleAddCredential = useCallback((input: CredentialFormInput) => {
+    const timestamp = new Date().toISOString();
+    const randomId =
+      typeof globalThis.crypto !== "undefined" &&
+      typeof globalThis.crypto.randomUUID === "function"
+        ? `cred-${globalThis.crypto.randomUUID()}`
+        : `cred-${Date.now().toString(36)}-${Math.random()
+            .toString(36)
+            .slice(2, 8)}`;
+
+    const credential: WorkflowCredential = {
+      id: randomId,
+      name: input.name,
+      type: input.type,
+      access: input.access,
+      secrets: { ...input.secrets },
+      owner: input.owner ?? "Workflow Owner",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      description: input.description,
+    };
+
+    setCredentials((previous) => [...previous, credential]);
+    toast({
+      title: "Credential added",
+      description: `${input.name} is now available for workflow nodes.`,
+    });
+  }, []);
+
+  const handleDeleteCredential = useCallback(
+    (credentialId: string) => {
+      setCredentials((previous) =>
+        previous.filter((credential) => credential.id !== credentialId),
+      );
+
+      setNodeCredentialAssignments((previous) => {
+        const nextAssignments: Record<string, string> = { ...previous };
+        let shouldUpdateNodes = false;
+        Object.entries(previous).forEach(([nodeId, value]) => {
+          if (value === credentialId) {
+            delete nextAssignments[nodeId];
+            shouldUpdateNodes = true;
+          }
+        });
+
+        if (shouldUpdateNodes) {
+          setNodes((current) =>
+            current.map((node) => {
+              const assigned = (
+                node.data as NodeData & { credentials?: { id?: string } }
+              ).credentials?.id;
+              if (assigned === credentialId) {
+                return {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    credentials: null,
+                  },
+                };
+              }
+              return node;
+            }),
+          );
+        }
+
+        return nextAssignments;
+      });
+
+      toast({
+        title: "Credential removed",
+        description:
+          "Nodes that referenced this credential will need a new assignment.",
+        variant: "destructive",
+      });
+    },
+    [setNodes],
+  );
+
+  const handleCredentialAssignmentChange = useCallback(
+    (nodeId: string, credentialId: string | null) => {
+      setNodeCredentialAssignments((previous) => {
+        const next = { ...previous };
+        if (!credentialId || credentialId === "__none__") {
+          delete next[nodeId];
+        } else {
+          next[nodeId] = credentialId;
+        }
+        return next;
+      });
+
+      setNodes((current) =>
+        current.map((node) => {
+          if (node.id !== nodeId) {
+            return node;
+          }
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              credentials:
+                credentialId && credentialId !== "__none__"
+                  ? { id: credentialId }
+                  : null,
+            },
+          };
+        }),
+      );
+
+      setValidationErrors((previous) =>
+        previous.filter(
+          (error) =>
+            !(
+              error.type === "credential" &&
+              error.sourceId === nodeId &&
+              credentialId &&
+              credentialId !== "__none__"
+            ),
+        ),
+      );
+    },
+    [setNodes],
+  );
+
+  const handleToggleLinkedSubworkflow = useCallback(
+    (subworkflowId: string, linked: boolean) => {
+      setLinkedSubworkflows((previous) => {
+        if (linked) {
+          if (previous.includes(subworkflowId)) {
+            return previous;
+          }
+          return [...previous, subworkflowId];
+        }
+        return previous.filter((item) => item !== subworkflowId);
+      });
+    },
+    [],
+  );
+
+  const handleInsertSubworkflow = useCallback(
+    (subworkflowId: string) => {
+      const template = SAMPLE_SUBWORKFLOWS.find(
+        (item) => item.id === subworkflowId,
+      );
+      if (!template) {
+        toast({
+          title: "Sub-workflow unavailable",
+          description:
+            "We couldn't locate that reusable sub-workflow template.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const baseOffsetX = Math.random() * 160 + 120;
+      const baseOffsetY = Math.random() * 120 + 120;
+      const timestamp = Date.now().toString(36);
+
+      const convertedNodes = convertPersistedNodesToCanvas(template.nodes);
+      const idMap = new Map<string, string>();
+
+      const newNodes = convertedNodes.map((node, index) => {
+        const newId = `${subworkflowId}-${timestamp}-node-${index}`;
+        idMap.set(node.id, newId);
+        const cloned = cloneNode(node);
+        return {
+          ...cloned,
+          id: newId,
+          position: {
+            x: (cloned.position?.x ?? 0) + baseOffsetX,
+            y: (cloned.position?.y ?? 0) + baseOffsetY,
+          },
+          data: {
+            ...cloned.data,
+            credentials:
+              (cloned.data as NodeData & { credentials?: { id?: string } })
+                .credentials ?? null,
+          },
+        } as CanvasNode;
+      });
+
+      const newEdges = template.edges.map((edge, index) => {
+        const canvasEdge = toCanvasEdge(edge);
+        return {
+          ...canvasEdge,
+          id: `${subworkflowId}-${timestamp}-edge-${index}`,
+          source: idMap.get(canvasEdge.source) ?? canvasEdge.source,
+          target: idMap.get(canvasEdge.target) ?? canvasEdge.target,
+        } as CanvasEdge;
+      });
+
+      const credentialAssignments: Record<string, string> = {};
+      newNodes.forEach((node) => {
+        const credentialId = (
+          node.data as NodeData & { credentials?: { id?: string } }
+        ).credentials?.id;
+        if (credentialId) {
+          credentialAssignments[node.id] = credentialId;
+        }
+      });
+
+      setNodes((current) => [...current, ...newNodes]);
+      setEdges((current) => [...current, ...newEdges]);
+
+      if (Object.keys(credentialAssignments).length > 0) {
+        setNodeCredentialAssignments((previous) => ({
+          ...previous,
+          ...credentialAssignments,
+        }));
+      }
+
+      setLinkedSubworkflows((previous) => {
+        if (previous.includes(subworkflowId)) {
+          return previous;
+        }
+        return [...previous, subworkflowId];
+      });
+
+      toast({
+        title: "Sub-workflow inserted",
+        description: `${template.name} was added to the canvas.`,
+      });
+    },
+    [convertPersistedNodesToCanvas, setEdges, setNodes],
+  );
+
   const handleSaveWorkflow = useCallback(() => {
+    const credentialIssues = runPublishValidation();
+    const connectionIssues = validationErrors.filter(
+      (error) => error.type === "connection",
+    );
+    const totalIssues = credentialIssues.length + connectionIssues.length;
+
+    if (totalIssues > 0) {
+      toast({
+        title: "Resolve validation issues",
+        description:
+          "Fix credential and connection problems before publishing this workflow.",
+        variant: "destructive",
+      });
+      setActiveTab("settings");
+      return;
+    }
+
     const snapshot = createSnapshot();
     const persistedNodes = snapshot.nodes.map(toPersistedNode);
     const persistedEdges = snapshot.edges.map(toPersistedEdge);
@@ -1282,6 +2182,11 @@ export default function WorkflowCanvas({
         tags: tagsToPersist,
         nodes: persistedNodes,
         edges: persistedEdges,
+        credentials: credentials.map((credential) => ({
+          ...credential,
+          secrets: { ...credential.secrets },
+        })),
+        linkedSubworkflowIds: [...linkedSubworkflows],
       },
       { versionMessage: `Manual save (${timestampLabel})` },
     );
@@ -1291,6 +2196,8 @@ export default function WorkflowCanvas({
     setWorkflowDescription(saved.description ?? "");
     setWorkflowTags(saved.tags ?? tagsToPersist);
     setWorkflowVersions(saved.versions ?? []);
+    ensureCredentialsState(saved.credentials);
+    ensureLinkedSubworkflows(saved.linkedSubworkflowIds);
 
     toast({
       title: "Workflow saved",
@@ -1301,13 +2208,20 @@ export default function WorkflowCanvas({
       navigate(`/workflow-canvas/${saved.id}`, { replace: !!workflowId });
     }
   }, [
+    credentials,
     createSnapshot,
     currentWorkflowId,
+    ensureCredentialsState,
+    ensureLinkedSubworkflows,
+    linkedSubworkflows,
     navigate,
+    runPublishValidation,
+    setActiveTab,
     workflowDescription,
     workflowId,
     workflowName,
     workflowTags,
+    validationErrors,
   ]);
 
   const handleTagsChange = useCallback((value: string) => {
@@ -1358,6 +2272,21 @@ export default function WorkflowCanvas({
   // Handle new connections between nodes
   const onConnect = useCallback(
     (params: Connection) => {
+      const validationResult = validateConnection(
+        params,
+        nodesRef.current as unknown as Node<ValidatorNodeData>[],
+        edgesRef.current,
+      );
+      if (validationResult) {
+        appendValidationError(validationResult);
+        toast({
+          title: "Connection blocked",
+          description: validationResult.message,
+          variant: "destructive",
+        });
+        return;
+      }
+
       const edgeId = `edge-${params.source}-${params.target}`;
       const connectionExists = edges.some(
         (edge) =>
@@ -1384,7 +2313,7 @@ export default function WorkflowCanvas({
         );
       }
     },
-    [edges, setEdges],
+    [appendValidationError, edges, setEdges],
   );
 
   // Handle node selection
@@ -1515,76 +2444,383 @@ export default function WorkflowCanvas({
   );
 
   // Handle chat message sending
-  const handleSendChatMessage = (
-    message: string,
-    attachments: Attachment[],
-  ) => {
-    if (!activeChatNodeId) {
-      toast({
-        title: "Select a chat-enabled node",
-        description: "Open a node chat to send messages.",
+  const buildAssistantResponse = useCallback(
+    (
+      incoming: string,
+      session: ChatKitSession,
+      environment: ChatEnvironment,
+    ) => {
+      const text = incoming.toLowerCase();
+      const outstanding =
+        session.handoffChecklist?.filter((item) => !item.completed) ?? [];
+      const latestRun = session.runSummaries?.[0];
+      const tokenStats = session.tokenEstimate ?? latestRun?.tokens ?? null;
+
+      if (text.includes("blocker") || text.includes("checklist")) {
+        if (outstanding.length === 0) {
+          return "No outstanding blockers. The handoff checklist is complete and we're ready for launch.";
+        }
+        const items = outstanding
+          .map(
+            (item) =>
+              `• ${item.label}${item.owner ? ` (owner: ${item.owner})` : ""}`,
+          )
+          .join("\n");
+        return `Here are the remaining items before handoff:\n${items}`;
+      }
+
+      if (text.includes("token")) {
+        if (tokenStats) {
+          return `Latest token profile — total: ${tokenStats.total.toLocaleString()}, prompt: ${tokenStats.prompt.toLocaleString()}, completion: ${tokenStats.completion.toLocaleString()}.`;
+        }
+        return "I'll capture token usage once the next run finishes.";
+      }
+
+      if (text.includes("credential")) {
+        return "This chat trigger uses the credential assignments from the Settings tab. Make sure production-safe scopes are linked before publishing.";
+      }
+
+      if (text.includes("summary") || text.includes("run")) {
+        if (latestRun) {
+          const durationSeconds = latestRun.durationMs
+            ? Math.round(latestRun.durationMs / 1000)
+            : 0;
+          return `Last ${environment} run (${latestRun.id}) ${latestRun.status === "completed" ? "completed" : latestRun.status} in ${durationSeconds}s. Triggered by ${latestRun.triggeredBy ?? "automation"}.`;
+        }
+        return `No recorded runs yet. Trigger a ${environment} execution and I'll summarise the results here.`;
+      }
+
+      if (text.includes("handoff")) {
+        return `I'll package a production-ready summary once the outstanding checklist items are resolved. Let me know if you want a customer-facing recap.`;
+      }
+
+      return `Queued a ${environment} run for ${workflowName}. I'll post the telemetry as soon as it's ready.`;
+    },
+    [workflowName],
+  );
+
+  const handleSendChatMessage = useCallback(
+    (sessionId: string, message: string, attachments: Attachment[]) => {
+      if (!sessionId) {
+        toast({
+          title: "Select a chat-enabled node",
+          description: "Open a node chat to send messages.",
+        });
+        return;
+      }
+
+      if (!message.trim() && attachments.length === 0) {
+        return;
+      }
+
+      const formatFileSize = (bytes: number): string => {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+        if (bytes < 1024 * 1024 * 1024)
+          return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+      };
+
+      const messageId = `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+      const attachmentPayloads: NonNullable<ChatMessageProps["attachments"]> =
+        attachments.map((item) => ({
+          id: item.id,
+          type: item.type,
+          name: item.file.name,
+          url:
+            item.previewUrl ??
+            (typeof window !== "undefined"
+              ? URL.createObjectURL(item.file)
+              : undefined),
+          size: formatFileSize(item.file.size),
+        }));
+
+      let targetNodeId: string | null = null;
+      let toastSessionTitle = "workflow";
+
+      setChatSessions((prev) => {
+        const session = prev[sessionId];
+        if (!session) {
+          return prev;
+        }
+
+        targetNodeId = session.nodeId ?? sessionId;
+        toastSessionTitle = session.title;
+
+        const nowIso = new Date().toISOString();
+        const newMessage: ChatMessageProps = {
+          id: messageId,
+          content: message,
+          sender: chatUserProfile,
+          timestamp: nowIso,
+          isUserMessage: true,
+          status: "sending",
+          attachments: attachmentPayloads,
+        };
+
+        return {
+          ...prev,
+          [sessionId]: {
+            ...session,
+            status: "running",
+            messages: [...session.messages, newMessage],
+            updatedAt: nowIso,
+          },
+        };
       });
-      return;
-    }
 
-    const activeNode = nodes.find((node) => node.id === activeChatNodeId);
-    const attachmentSummary =
-      attachments.length === 0
-        ? ""
-        : attachments.length === 1
-          ? " with 1 attachment"
-          : ` with ${attachments.length} attachments`;
+      const attachmentSummary =
+        attachments.length === 0
+          ? ""
+          : attachments.length === 1
+            ? " with 1 attachment"
+            : ` with ${attachments.length} attachments`;
 
-    toast({
-      title: `Message sent to ${activeNode?.data?.label ?? "workflow"}`,
-      description: `"${message}"${attachmentSummary}`,
-    });
+      toast({
+        title: `Message sent to ${toastSessionTitle}`,
+        description: `"${message}"${attachmentSummary}`,
+      });
 
-    // Here you would typically process the message and trigger the workflow
-    // For now, we'll just update the node status to simulate activity
-    setNodes((nds) =>
-      nds.map((n) => {
-        if (n.id === activeChatNodeId) {
+      if (targetNodeId) {
+        setNodes((nds) =>
+          nds.map((node) => {
+            if (node.id === targetNodeId) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  status: "running" as NodeStatus,
+                },
+              };
+            }
+            return node;
+          }),
+        );
+      }
+
+      setTimeout(() => {
+        setChatSessions((prev) => {
+          const session = prev[sessionId];
+          if (!session) {
+            return prev;
+          }
+
           return {
-            ...n,
-            data: {
-              ...n.data,
-              status: "running" as NodeStatus,
+            ...prev,
+            [sessionId]: {
+              ...session,
+              messages: session.messages.map((chatMessage) =>
+                chatMessage.id === messageId
+                  ? { ...chatMessage, status: "sent" }
+                  : chatMessage,
+              ),
             },
           };
-        }
-        return n;
-      }),
-    );
+        });
+      }, 400);
 
-    // Simulate workflow execution
-    setTimeout(() => {
-      setNodes((nds) =>
-        nds.map((n) => {
-          if (n.id === activeChatNodeId) {
-            return {
-              ...n,
-              data: {
-                ...n.data,
-                status: "success" as NodeStatus,
-              },
-            };
+      setTimeout(() => {
+        setChatSessions((prev) => {
+          const session = prev[sessionId];
+          if (!session) {
+            return prev;
           }
-          return n;
-        }),
-      );
-    }, 2000);
-  };
+          const environment = session.environment ?? chatEnvironment;
+          const nowIso = new Date().toISOString();
+          const response: ChatMessageProps = {
+            id: `ai-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+            content: buildAssistantResponse(message, session, environment),
+            sender: chatAssistantProfile,
+            timestamp: nowIso,
+          };
+
+          const newSummary = {
+            id: `session-${Math.random().toString(36).substring(2, 7)}`,
+            status: "completed" as const,
+            environment,
+            startedAt: nowIso,
+            durationMs: 4800,
+            triggeredBy: chatUserProfile.name,
+            tokens: session.tokenEstimate ??
+              session.runSummaries?.[0]?.tokens ?? {
+                prompt: 320,
+                completion: 160,
+                total: 480,
+              },
+            notes: `Simulated ${environment} execution for ${workflowName}.`,
+          };
+
+          return {
+            ...prev,
+            [sessionId]: {
+              ...session,
+              status: "completed",
+              runSummaries: [
+                newSummary,
+                ...(session.runSummaries ?? []).slice(0, 4),
+              ],
+              messages: [...session.messages, response],
+              updatedAt: nowIso,
+            },
+          };
+        });
+
+        if (targetNodeId) {
+          setNodes((nds) =>
+            nds.map((node) =>
+              node.id === targetNodeId
+                ? {
+                    ...node,
+                    data: {
+                      ...node.data,
+                      status: "success" as NodeStatus,
+                    },
+                  }
+                : node,
+            ),
+          );
+        }
+      }, 1200);
+    },
+    [
+      buildAssistantResponse,
+      chatAssistantProfile,
+      chatEnvironment,
+      chatUserProfile,
+      setNodes,
+      workflowName,
+    ],
+  );
+
+  const handleChatEnvironmentChange = useCallback(
+    (environment: ChatEnvironment) => {
+      setChatEnvironment(environment);
+      if (!activeChatSessionId) {
+        return;
+      }
+      setChatSessions((prev) => {
+        const session = prev[activeChatSessionId];
+        if (!session) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [activeChatSessionId]: {
+            ...session,
+            environment,
+            updatedAt: new Date().toISOString(),
+          },
+        };
+      });
+    },
+    [activeChatSessionId],
+  );
+
+  const handleSelectChatSession = useCallback(
+    (sessionId: string) => {
+      setActiveChatSessionId(sessionId);
+      setIsChatOpen(true);
+      const session = chatSessions[sessionId];
+      if (session?.environment) {
+        setChatEnvironment(session.environment);
+      }
+    },
+    [chatSessions],
+  );
+
+  const handleToggleChecklistItem = useCallback(
+    (sessionId: string, itemId: string, completed: boolean) => {
+      setChatSessions((prev) => {
+        const session = prev[sessionId];
+        if (!session?.handoffChecklist) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [sessionId]: {
+            ...session,
+            updatedAt: new Date().toISOString(),
+            handoffChecklist: session.handoffChecklist.map((item) =>
+              item.id === itemId ? { ...item, completed } : item,
+            ),
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const handleSendQuickPrompt = useCallback(
+    (sessionId: string, prompt: string) => {
+      handleSendChatMessage(sessionId, prompt, []);
+    },
+    [handleSendChatMessage],
+  );
+
+  const chatSessionsList = useMemo(
+    () => Object.values(chatSessions),
+    [chatSessions],
+  );
+
+  const chatMetrics = useMemo<ChatKitMetrics>(() => {
+    const metrics: ChatKitMetrics = {
+      lastExecutionStatus: backendExecutionStatus,
+      lastExecutionStartedAt: liveExecution?.startedAt ?? null,
+    };
+    if (tokenMetrics) {
+      metrics.tokens = {
+        total: tokenMetrics.total,
+        prompt: tokenMetrics.prompt,
+        completion: tokenMetrics.completion,
+      };
+    }
+    return metrics;
+  }, [backendExecutionStatus, liveExecution, tokenMetrics]);
 
   // Handle workflow execution
   const handleRunWorkflow = useCallback(() => {
+    if (backendWorkflowId) {
+      setIsRunning(true);
+      startBackendExecution()
+        .then((executionIdentifier) => {
+          if (!executionIdentifier) {
+            setIsRunning(false);
+            toast({
+              title: "Unable to start execution",
+              description:
+                "The backend did not accept the execution request. Check server logs for more details.",
+              variant: "destructive",
+            });
+            return;
+          }
+          toast({
+            title: "Streaming workflow run",
+            description:
+              "Execution " +
+              executionIdentifier +
+              " is streaming from the backend.",
+          });
+        })
+        .catch((error) => {
+          console.error("Failed to initiate backend execution", error);
+          setIsRunning(false);
+          toast({
+            title: "Backend execution failed",
+            description:
+              error instanceof Error
+                ? error.message
+                : "Unexpected error while starting the backend execution.",
+            variant: "destructive",
+          });
+        });
+      return;
+    }
+
     setIsRunning(true);
 
-    // Simulate workflow execution by updating node statuses
     const nodeUpdates = [...nodes];
     let delay = 0;
 
-    // Update nodes sequentially to simulate execution flow
     nodeUpdates.forEach((node) => {
       setTimeout(() => {
         setNodes((nds) =>
@@ -1602,7 +2838,6 @@ export default function WorkflowCanvas({
           }),
         );
 
-        // After a delay, set the node to success
         setTimeout(() => {
           setNodes((nds) =>
             nds.map((n) => {
@@ -1614,7 +2849,7 @@ export default function WorkflowCanvas({
                     status:
                       Math.random() > 0.9
                         ? ("error" as NodeStatus)
-                        : ("success" as NodeStatus), // 10% chance of error
+                        : ("success" as NodeStatus),
                   },
                 };
               }
@@ -1622,19 +2857,37 @@ export default function WorkflowCanvas({
             }),
           );
 
-          // If this is the last node, set isRunning to false
           if (node.id === nodeUpdates[nodeUpdates.length - 1].id) {
             setIsRunning(false);
           }
         }, 1500);
       }, delay);
 
-      delay += 1000; // Stagger the execution
+      delay += 1000;
     });
-  }, [nodes, setNodes]);
+  }, [backendWorkflowId, nodes, setNodes, startBackendExecution]);
 
   // Handle workflow pause
   const handlePauseWorkflow = useCallback(() => {
+    if (backendWorkflowId) {
+      stopExecution();
+      executionStartRef.current = null;
+      setIsRunning(false);
+      setLiveExecution((current) =>
+        current
+          ? {
+              ...current,
+              status: "partial",
+            }
+          : current,
+      );
+      toast({
+        title: "Execution stream stopped",
+        description: "Closed the live WebSocket connection to the backend.",
+      });
+      return;
+    }
+
     setIsRunning(false);
 
     // Reset all running nodes to idle
@@ -1652,7 +2905,7 @@ export default function WorkflowCanvas({
         return n;
       }),
     );
-  }, [setNodes]);
+  }, [backendWorkflowId, setNodes, stopExecution]);
 
   const handleUndo = useCallback(() => {
     const previousSnapshot = undoStackRef.current.pop();
@@ -1777,6 +3030,19 @@ export default function WorkflowCanvas({
     [setNodes],
   );
 
+  const handleRefreshExecutions = useCallback(() => {
+    if (backendWorkflowId && backendExecutionId) {
+      void loadExecutionHistory(backendExecutionId);
+      return;
+    }
+    toast({
+      title: "Execution history refresh",
+      description: backendWorkflowId
+        ? "No backend execution is currently active."
+        : "Configure a backend workflow ID to enable live execution syncing.",
+    });
+  }, [backendExecutionId, backendWorkflowId, loadExecutionHistory]);
+
   // Load workflow data when workflowId changes
   useEffect(() => {
     const loadWorkflow = () => {
@@ -1786,6 +3052,9 @@ export default function WorkflowCanvas({
         setWorkflowDescription("");
         setWorkflowTags(["draft"]);
         setWorkflowVersions([]);
+        ensureCredentialsState();
+        ensureLinkedSubworkflows([]);
+        setNodeCredentialAssignments({});
         if (nodesRef.current.length === 0 && edgesRef.current.length === 0) {
           applySnapshot({ nodes: [], edges: [] }, { resetHistory: true });
         } else {
@@ -1814,6 +3083,9 @@ export default function WorkflowCanvas({
           { nodes: canvasNodes, edges: canvasEdges },
           { resetHistory: true },
         );
+        ensureCredentialsState(persisted.credentials);
+        ensureLinkedSubworkflows(persisted.linkedSubworkflowIds);
+        rehydrateCredentialAssignments(canvasNodes);
         return;
       }
 
@@ -1830,6 +3102,9 @@ export default function WorkflowCanvas({
           { nodes: canvasNodes, edges: canvasEdges },
           { resetHistory: true },
         );
+        ensureCredentialsState(template.credentials);
+        ensureLinkedSubworkflows(template.linkedSubworkflowIds);
+        rehydrateCredentialAssignments(canvasNodes);
         toast({
           title: "Template loaded",
           description: "Save to add this workflow to your workspace.",
@@ -1847,11 +3122,21 @@ export default function WorkflowCanvas({
       setWorkflowDescription("");
       setWorkflowTags(["draft"]);
       setWorkflowVersions([]);
+      ensureCredentialsState();
+      ensureLinkedSubworkflows([]);
+      setNodeCredentialAssignments({});
       applySnapshot({ nodes: [], edges: [] }, { resetHistory: true });
     };
 
     loadWorkflow();
-  }, [applySnapshot, convertPersistedNodesToCanvas, workflowId]);
+  }, [
+    applySnapshot,
+    convertPersistedNodesToCanvas,
+    ensureCredentialsState,
+    ensureLinkedSubworkflows,
+    rehydrateCredentialAssignments,
+    workflowId,
+  ]);
 
   useEffect(() => {
     if (!currentWorkflowId || typeof window === "undefined") {
@@ -1880,19 +3165,6 @@ export default function WorkflowCanvas({
       }
     }, 100);
   }, [nodes]);
-
-  // User and AI info for chat
-  const user = {
-    id: "user-1",
-    name: "Avery Chen",
-    avatar: "https://avatar.vercel.sh/avery",
-  };
-
-  const ai = {
-    id: "ai-1",
-    name: "Orcheo Canvas Assistant",
-    avatar: "https://avatar.vercel.sh/orcheo-canvas",
-  };
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -2030,35 +3302,99 @@ export default function WorkflowCanvas({
             value="execution"
             className="flex-1 m-0 p-0 overflow-hidden min-h-0"
           >
-            <WorkflowExecutionHistory
-              executions={mockExecutions.map((execution) => ({
-                ...execution,
-                nodes: execution.nodes.map((node) => ({
-                  ...node,
-                  status: node.status || ("idle" as NodeStatus),
-                })),
-              }))}
-              onViewDetails={handleViewExecutionDetails}
-              onRefresh={() =>
-                toast({
-                  title: "Execution history refresh",
-                  description:
-                    "Live execution syncing will be added once the backend is connected.",
-                })
-              }
-              onCopyToEditor={(execution) =>
-                toast({
-                  title: "Copied execution context",
-                  description: `Run ${execution.runId} will be available in the editor soon.`,
-                })
-              }
-              onDelete={(execution) =>
-                toast({
-                  title: "Execution deletion coming soon",
-                  description: `Run ${execution.runId} can be removed once persistence is implemented.`,
-                })
-              }
-            />
+            <div className="flex flex-col h-full">
+              <div className="border-b border-border p-4 space-y-2">
+                {backendWorkflowId ? (
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-4">
+                      <div>
+                        <h3 className="text-lg font-semibold">
+                          Live execution
+                        </h3>
+                        <p className="text-sm text-muted-foreground">
+                          Streaming updates from workflow
+                          <span className="ml-1 font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+                            {backendWorkflowId}
+                          </span>
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-6 text-sm">
+                        <div>
+                          <span className="block text-xs uppercase text-muted-foreground tracking-wide">
+                            Status
+                          </span>
+                          <span className="font-medium">
+                            {EXECUTION_STATUS_LABELS[backendExecutionStatus]}
+                          </span>
+                        </div>
+                        <div>
+                          <span className="block text-xs uppercase text-muted-foreground tracking-wide">
+                            Tokens
+                          </span>
+                          <span className="font-medium">
+                            {tokenMetrics.total.toLocaleString()} total
+                          </span>
+                          <span className="block text-xs text-muted-foreground">
+                            prompt {tokenMetrics.prompt.toLocaleString()} ·
+                            completion{" "}
+                            {tokenMetrics.completion.toLocaleString()}
+                          </span>
+                        </div>
+                        {backendExecutionId ? (
+                          <div>
+                            <span className="block text-xs uppercase text-muted-foreground tracking-wide">
+                              Execution ID
+                            </span>
+                            <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                              {backendExecutionId}
+                            </code>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                    {backendExecutionError ? (
+                      <Alert variant="destructive">
+                        <AlertTitle>Streaming error</AlertTitle>
+                        <AlertDescription>
+                          {backendExecutionError}
+                        </AlertDescription>
+                      </Alert>
+                    ) : null}
+                  </div>
+                ) : (
+                  <Alert>
+                    <AlertTitle>Backend streaming disabled</AlertTitle>
+                    <AlertDescription>
+                      Configure <code>VITE_ORCHEO_BACKEND_WORKFLOW_ID</code> to
+                      stream live executions from the Orcheo backend. Runs are
+                      currently simulated locally.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <WorkflowExecutionHistory
+                  executions={executionsForHistory}
+                  onViewDetails={handleViewExecutionDetails}
+                  onRefresh={handleRefreshExecutions}
+                  onCopyToEditor={(execution) =>
+                    toast({
+                      title: "Copied execution context",
+                      description: `Run ${execution.runId} will be available in the editor soon.`,
+                    })
+                  }
+                  onDelete={(execution) =>
+                    toast({
+                      title: "Execution deletion coming soon",
+                      description: `Run ${execution.runId} can be removed once persistence is implemented.`,
+                    })
+                  }
+                  defaultSelectedExecution={
+                    liveExecution ?? executionsForHistory[0] ?? undefined
+                  }
+                />
+              </div>
+            </div>
           </TabsContent>
 
           <TabsContent value="settings" className="m-0 p-4 overflow-auto">
@@ -2197,6 +3533,154 @@ export default function WorkflowCanvas({
 
               <Separator />
 
+              <div className="space-y-4">
+                <div>
+                  <h2 className="text-xl font-bold mb-2">
+                    Credential management
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    Store encrypted credentials and reuse them across workflow
+                    nodes.
+                  </p>
+                </div>
+                <CredentialsVault
+                  credentials={credentials}
+                  onAddCredential={(credential) =>
+                    handleAddCredential(credential)
+                  }
+                  onDeleteCredential={handleDeleteCredential}
+                  className="mt-2"
+                />
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-semibold">
+                      Node credential assignments
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Map each external call to a credential before you publish.
+                    </p>
+                  </div>
+                  <Badge
+                    variant={
+                      credentialIssueCount > 0 ? "destructive" : "secondary"
+                    }
+                  >
+                    {credentialIssueCount > 0
+                      ? `${credentialIssueCount} unassigned`
+                      : "All nodes covered"}
+                  </Badge>
+                </div>
+
+                {credentialEligibleNodes.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No nodes require credentials in this workflow yet.
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {credentialEligibleNodes.map((node) => {
+                      const assigned =
+                        nodeCredentialAssignments[node.id] ?? "__none__";
+                      const nodeType =
+                        typeof node.data?.type === "string"
+                          ? node.data.type
+                          : (node.type ?? "");
+                      return (
+                        <div
+                          key={node.id}
+                          className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/30 p-3"
+                        >
+                          <div>
+                            <p className="text-sm font-medium">
+                              {node.data?.label ?? node.id}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {node.id} • {nodeType}
+                            </p>
+                          </div>
+
+                          <Select
+                            value={assigned}
+                            onValueChange={(value) =>
+                              handleCredentialAssignmentChange(
+                                node.id,
+                                value === "__none__" ? null : value,
+                              )
+                            }
+                          >
+                            <SelectTrigger className="w-64">
+                              <SelectValue placeholder="Select credential" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="__none__">
+                                Unassigned
+                              </SelectItem>
+                              {credentialOptions.map((option) => (
+                                <SelectItem key={option.id} value={option.id}>
+                                  {option.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <Separator />
+
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-xl font-bold mb-1">
+                      Reusable sub-workflows
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      Insert curated workflow segments and control which ones
+                      publish with this automation.
+                    </p>
+                  </div>
+                </div>
+                <ReusableSubworkflowLibrary
+                  subworkflows={SAMPLE_SUBWORKFLOWS}
+                  linkedSubworkflows={linkedSubworkflows}
+                  onInsert={handleInsertSubworkflow}
+                  onToggleLinked={handleToggleLinkedSubworkflow}
+                />
+              </div>
+
+              <Separator />
+
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-bold mb-1">Publish validation</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Validation runs on save and highlights credential or
+                    connection issues.
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge
+                    variant={
+                      totalValidationIssues > 0 ? "destructive" : "secondary"
+                    }
+                  >
+                    {totalValidationIssues > 0
+                      ? `${totalValidationIssues} issues`
+                      : "No blocking issues"}
+                  </Badge>
+                  <Button variant="outline" onClick={handleManualValidation}>
+                    Run validation
+                  </Button>
+                </div>
+              </div>
+
+              <Separator />
+
               <WorkflowHistory
                 versions={workflowVersions}
                 currentVersion={workflowVersions.at(-1)?.version}
@@ -2225,28 +3709,29 @@ export default function WorkflowCanvas({
         />
       )}
 
-      {/* Chat Interface */}
-      {isChatOpen && (
-        <ChatInterface
-          title={chatTitle}
-          user={user}
-          ai={ai}
-          isClosable={true}
-          onSendMessage={handleSendChatMessage}
-          position="bottom-right"
-          initialMessages={[
-            {
-              id: "welcome-msg",
-              content: `Welcome to the ${chatTitle} interface. How can I help you today?`,
-              sender: {
-                ...ai,
-                isAI: true,
-              },
-              timestamp: new Date(),
-            },
-          ]}
-        />
-      )}
+      <ChatKitInterface
+        open={isChatOpen}
+        onClose={() => setIsChatOpen(false)}
+        workflowName={workflowName}
+        environment={chatEnvironment}
+        onEnvironmentChange={handleChatEnvironmentChange}
+        sessions={chatSessionsList}
+        activeSessionId={activeChatSessionId}
+        onSelectSession={handleSelectChatSession}
+        onSendMessage={handleSendChatMessage}
+        onQuickPrompt={handleSendQuickPrompt}
+        onToggleChecklistItem={handleToggleChecklistItem}
+        metrics={chatMetrics}
+        executionStatus={backendExecutionStatus}
+        view={chatView}
+        onViewChange={setChatView}
+      />
+
+      <ConnectionValidator
+        errors={validationErrors}
+        onDismiss={handleDismissValidationError}
+        onFix={handleFixValidationError}
+      />
     </div>
   );
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,9 +45,9 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Migrate the legacy canvas app to connect to the new backend via React Flow foundation, restoring minimap, snapping, and chat affordances while preserving node compatibility.
 - [x] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
 - [x] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
-- [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
-- [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
-- [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
+- [x] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
+- [x] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
+- [x] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 - [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.
 
 ### Milestone 5 – Node Ecosystem & Integrations


### PR DESCRIPTION
## Summary
- add credential sample data and persistence plumbing for workflows and templates
- wire credential vault UI, node assignments, reusable sub-workflows, and publish validation into the canvas settings experience
- ensure connection validation errors are deterministic and mark the roadmap task complete

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test *(fails: rollup optional dependency missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6bc7daa8883278554670bf79266ea