### PR TITLE
Add canvas resources tab with credential and sub-workflow tooling

### DIFF
--- a/apps/canvas/src/features/workflow/components/canvas/connection-validator.tsx
+++ b/apps/canvas/src/features/workflow/components/canvas/connection-validator.tsx
@@ -12,6 +12,7 @@ export interface ValidationError {
   sourceId?: string;
   targetId?: string;
   nodeName?: string;
+  nodeId?: string;
 }
 
 interface ConnectionValidatorProps {
@@ -191,14 +192,17 @@ export function validateNodeCredentials(
 ): ValidationError | null {
   // Example validation for credentials
   if (
-    (node.data.type === "api" || node.data.type === "database") &&
+    (node.data.type === "api" ||
+      node.data.type === "database" ||
+      node.data.type === "ai") &&
     (!node.data.credentials || !node.data.credentials.id)
   ) {
     return {
-      id: `cred-${node.id}-${Date.now()}`,
+      id: `cred-${node.id}`,
       type: "credential",
       message: `${node.data.label} requires credentials to be configured`,
       nodeName: node.data.label,
+      nodeId: node.id,
     };
   }
 

--- a/apps/canvas/src/features/workflow/components/panels/credential-assignment-table.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/credential-assignment-table.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/design-system/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/design-system/ui/select";
+import { Badge } from "@/design-system/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface CredentialSummary {
+  id: string;
+  name: string;
+  type: string;
+  access: "private" | "shared" | "public";
+}
+
+interface NodeCredentialState {
+  id: string;
+  label: string;
+  type?: string;
+  credentialId?: string | null;
+  credentialName?: string;
+}
+
+interface CredentialAssignmentTableProps {
+  nodes: NodeCredentialState[];
+  credentials: CredentialSummary[];
+  onAssign: (nodeId: string, credentialId: string | null) => void;
+  className?: string;
+}
+
+const requiresCredential = (type?: string) =>
+  type === "api" || type === "database" || type === "ai";
+
+export default function CredentialAssignmentTable({
+  nodes,
+  credentials,
+  onAssign,
+  className,
+}: CredentialAssignmentTableProps) {
+  const nodesNeedingCredentials = useMemo(
+    () => nodes.filter((node) => requiresCredential(node.type)),
+    [nodes],
+  );
+
+  if (nodesNeedingCredentials.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-lg border border-dashed border-border bg-muted/20 p-6 text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        All nodes are configured with the credentials they require.
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[35%]">Node</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Assigned Credential</TableHead>
+            <TableHead className="w-[30%]">Select Credential</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {nodesNeedingCredentials.map((node) => {
+            const selectedValue = node.credentialId ?? "__none__";
+
+            return (
+              <TableRow key={node.id}>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="font-medium">{node.label}</span>
+                    <span className="text-xs text-muted-foreground">
+                      ID: {node.id}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="capitalize">
+                    {node.type ?? "unknown"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {node.credentialName ? (
+                    <div className="flex flex-col">
+                      <span className="font-medium">{node.credentialName}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {credentials.find(
+                          (credential) => credential.id === node.credentialId,
+                        )?.type ?? "Custom"}
+                      </span>
+                    </div>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">
+                      No credential assigned
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Select
+                    value={selectedValue}
+                    onValueChange={(value) =>
+                      onAssign(node.id, value === "__none__" ? null : value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select credential" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">Unassigned</SelectItem>
+                      {credentials.map((credential) => (
+                        <SelectItem key={credential.id} value={credential.id}>
+                          <div className="flex flex-col">
+                            <span className="font-medium">
+                              {credential.name}
+                            </span>
+                            <span className="text-xs text-muted-foreground capitalize">
+                              {credential.type} · {credential.access}
+                            </span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/canvas/src/features/workflow/components/panels/sub-workflow-library.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/sub-workflow-library.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/design-system/ui/card";
+import { Badge } from "@/design-system/ui/badge";
+import { Button } from "@/design-system/ui/button";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/design-system/ui/tabs";
+import { ScrollArea } from "@/design-system/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+interface SubWorkflowSummary {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  tags: string[];
+  nodeCount: number;
+  edgeCount: number;
+}
+
+interface SubWorkflowLibraryProps {
+  subWorkflows: SubWorkflowSummary[];
+  onInsert?: (workflowId: string) => void;
+  className?: string;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  all: "All",
+  automation: "Automation",
+  ai: "AI",
+  data: "Data",
+  communication: "Communication",
+};
+
+export default function SubWorkflowLibrary({
+  subWorkflows,
+  onInsert,
+  className,
+}: SubWorkflowLibraryProps) {
+  const [activeCategory, setActiveCategory] = useState<string>("all");
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>(["all"]);
+    for (const workflow of subWorkflows) {
+      unique.add(workflow.category);
+    }
+    return Array.from(unique);
+  }, [subWorkflows]);
+
+  const filtered = useMemo(() => {
+    if (activeCategory === "all") {
+      return subWorkflows;
+    }
+    return subWorkflows.filter(
+      (workflow) => workflow.category === activeCategory,
+    );
+  }, [activeCategory, subWorkflows]);
+
+  if (subWorkflows.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-lg border border-dashed border-border bg-muted/20 p-6 text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        No reusable sub-workflows are available yet. Create a workflow and save
+        it to reuse it here.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <Tabs value={activeCategory} onValueChange={setActiveCategory}>
+        <TabsList className="w-full justify-start overflow-x-auto">
+          {categories.map((category) => (
+            <TabsTrigger key={category} value={category} className="capitalize">
+              {CATEGORY_LABELS[category] ?? category}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        <TabsContent value={activeCategory} className="m-0">
+          <ScrollArea className="max-h-[420px] pr-2">
+            <div className="grid gap-4 md:grid-cols-2">
+              {filtered.map((workflow) => (
+                <Card key={workflow.id} className="border-border/70">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-between text-base">
+                      <span>{workflow.name}</span>
+                      <Badge variant="secondary" className="capitalize">
+                        {CATEGORY_LABELS[workflow.category] ??
+                          workflow.category}
+                      </Badge>
+                    </CardTitle>
+                    <CardDescription>{workflow.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                      <span>{workflow.nodeCount} nodes</span>
+                      <span aria-hidden="true">•</span>
+                      <span>{workflow.edgeCount} connections</span>
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {workflow.tags.map((tag) => (
+                        <Badge
+                          key={`${workflow.id}-${tag}`}
+                          variant="outline"
+                          className="text-xs capitalize"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </CardContent>
+                  <CardFooter>
+                    <Button
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => onInsert?.(workflow.id)}
+                    >
+                      Insert into canvas
+                    </Button>
+                  </CardFooter>
+                </Card>
+              ))}
+            </div>
+          </ScrollArea>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/canvas/src/features/workflow/components/panels/workflow-tabs.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/workflow-tabs.tsx
@@ -6,12 +6,14 @@ interface WorkflowTabsProps {
   activeTab: string;
   onTabChange: (value: string) => void;
   executionCount?: number;
+  resourceCount?: number;
 }
 
 export default function WorkflowTabs({
   activeTab,
   onTabChange,
   executionCount = 0,
+  resourceCount = 0,
 }: WorkflowTabsProps) {
   return (
     <div className="border-b border-border">
@@ -25,6 +27,14 @@ export default function WorkflowTabs({
             {executionCount > 0 && (
               <Badge variant="secondary" className="ml-1">
                 {executionCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="resources" className="gap-2">
+            Resources
+            {resourceCount > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {resourceCount}
               </Badge>
             )}
           </TabsTrigger>

--- a/apps/canvas/src/features/workflow/data/sub-workflows.ts
+++ b/apps/canvas/src/features/workflow/data/sub-workflows.ts
@@ -1,0 +1,132 @@
+import type { WorkflowEdge, WorkflowNode } from "./workflow-data";
+
+export interface ReusableSubWorkflow {
+  id: string;
+  name: string;
+  description: string;
+  category: "automation" | "ai" | "data" | "communication";
+  tags: string[];
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+}
+
+const createNode = (
+  id: string,
+  type: WorkflowNode["type"],
+  x: number,
+  y: number,
+  data: WorkflowNode["data"],
+): WorkflowNode => ({
+  id,
+  type,
+  position: { x, y },
+  data,
+});
+
+export const REUSABLE_SUB_WORKFLOWS: ReusableSubWorkflow[] = [
+  {
+    id: "sub-qualify-lead",
+    name: "Qualify lead and sync to CRM",
+    description:
+      "Enrich an inbound lead, score it with AI, and update the CRM when ready for sales.",
+    category: "automation",
+    tags: ["leads", "crm", "routing"],
+    nodes: [
+      createNode("node-1", "trigger", 0, 0, {
+        label: "Inbound Lead",
+        type: "trigger",
+        description: "Triggered when a new lead submits the form",
+      }),
+      createNode("node-2", "api", 260, 0, {
+        label: "Enrich Profile",
+        type: "api",
+        description: "Fetch company and persona data",
+      }),
+      createNode("node-3", "ai", 520, 0, {
+        label: "Score Lead",
+        type: "ai",
+        description: "Use GPT to score buying intent",
+      }),
+      createNode("node-4", "api", 780, 0, {
+        label: "Update CRM",
+        type: "api",
+        description: "Create or update opportunity in CRM",
+      }),
+    ],
+    edges: [
+      { id: "edge-1", source: "node-1", target: "node-2" },
+      { id: "edge-2", source: "node-2", target: "node-3" },
+      { id: "edge-3", source: "node-3", target: "node-4" },
+    ],
+  },
+  {
+    id: "sub-meeting-summary",
+    name: "Meeting insights summary",
+    description:
+      "Transcribe a call, extract action items, and send a summary to stakeholders.",
+    category: "communication",
+    tags: ["meetings", "summaries", "notifications"],
+    nodes: [
+      createNode("node-1", "trigger", 0, 0, {
+        label: "New Recording",
+        type: "trigger",
+        description: "Triggered when a call recording is available",
+      }),
+      createNode("node-2", "ai", 260, 0, {
+        label: "Transcribe Audio",
+        type: "ai",
+        description: "Convert call audio into text",
+      }),
+      createNode("node-3", "function", 520, 0, {
+        label: "Extract Actions",
+        type: "function",
+        description: "Identify owners and due dates",
+      }),
+      createNode("node-4", "api", 780, 0, {
+        label: "Send Recap",
+        type: "api",
+        description: "Email summary to attendees",
+      }),
+    ],
+    edges: [
+      { id: "edge-1", source: "node-1", target: "node-2" },
+      { id: "edge-2", source: "node-2", target: "node-3" },
+      { id: "edge-3", source: "node-3", target: "node-4" },
+    ],
+  },
+  {
+    id: "sub-sync-warehouse",
+    name: "Sync metrics to warehouse",
+    description:
+      "Pull metrics from analytics API, transform them, and load into the warehouse.",
+    category: "data",
+    tags: ["analytics", "warehouse", "etl"],
+    nodes: [
+      createNode("node-1", "trigger", 0, 0, {
+        label: "Nightly Schedule",
+        type: "trigger",
+        description: "Run every night at midnight",
+      }),
+      createNode("node-2", "api", 260, 0, {
+        label: "Fetch Metrics",
+        type: "api",
+        description: "Call analytics API",
+      }),
+      createNode("node-3", "data", 520, 0, {
+        label: "Normalize Dataset",
+        type: "data",
+        description: "Clean and normalize records",
+      }),
+      createNode("node-4", "api", 780, 0, {
+        label: "Load to Warehouse",
+        type: "api",
+        description: "Insert rows into warehouse",
+      }),
+    ],
+    edges: [
+      { id: "edge-1", source: "node-1", target: "node-2" },
+      { id: "edge-2", source: "node-2", target: "node-3" },
+      { id: "edge-3", source: "node-3", target: "node-4" },
+    ],
+  },
+];

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -32,6 +32,7 @@ import "@xyflow/react/dist/style.css";
 import { Button } from "@/design-system/ui/button";
 import { Tabs, TabsContent } from "@/design-system/ui/tabs";
 import { Separator } from "@/design-system/ui/separator";
+import { ScrollArea } from "@/design-system/ui/scroll-area";
 
 import TopNavigation from "@features/shared/components/top-navigation";
 import SidebarPanel from "@features/workflow/components/panels/sidebar-panel";
@@ -2595,48 +2596,53 @@ export default function WorkflowCanvas({
 
           <TabsContent
             value="resources"
-            className="flex-1 m-0 p-4 overflow-auto min-h-0"
+            className="flex-1 m-0 overflow-hidden min-h-0"
           >
-            <div className="max-w-5xl mx-auto space-y-10">
-              <section className="space-y-4">
-                <div>
-                  <h2 className="text-xl font-bold">Credential management</h2>
-                  <p className="text-sm text-muted-foreground">
-                    Manage reusable credentials and attach them to workflow
-                    nodes before publishing.
-                  </p>
-                </div>
+            <ScrollArea className="h-full">
+              <div className="max-w-5xl mx-auto space-y-10 p-4 pb-10">
+                <section className="space-y-4">
+                  <div>
+                    <h2 className="text-xl font-bold">Credential management</h2>
+                    <p className="text-sm text-muted-foreground">
+                      Manage reusable credentials and attach them to workflow
+                      nodes before publishing.
+                    </p>
+                  </div>
 
-                <CredentialsVault
-                  credentials={credentials}
-                  onAddCredential={handleAddCredential}
-                  onDeleteCredential={handleDeleteCredential}
-                />
+                  <CredentialsVault
+                    credentials={credentials}
+                    onAddCredential={handleAddCredential}
+                    onDeleteCredential={handleDeleteCredential}
+                  />
 
-                <CredentialAssignmentTable
-                  nodes={credentialAssignmentNodes}
-                  credentials={credentials}
-                  onAssign={handleAssignCredential}
-                  className="mt-6"
-                />
-              </section>
+                  <CredentialAssignmentTable
+                    nodes={credentialAssignmentNodes}
+                    credentials={credentials}
+                    onAssign={handleAssignCredential}
+                    className="mt-6"
+                  />
+                </section>
 
-              <Separator />
+                <Separator />
 
-              <section className="space-y-4">
-                <div>
-                  <h2 className="text-xl font-bold">Reusable sub-workflows</h2>
-                  <p className="text-sm text-muted-foreground">
-                    Insert pre-built automations to accelerate canvas authoring.
-                  </p>
-                </div>
+                <section className="space-y-4">
+                  <div>
+                    <h2 className="text-xl font-bold">
+                      Reusable sub-workflows
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      Insert pre-built automations to accelerate canvas
+                      authoring.
+                    </p>
+                  </div>
 
-                <SubWorkflowLibrary
-                  subWorkflows={subWorkflowSummaries}
-                  onInsert={handleInsertSubWorkflow}
-                />
-              </section>
-            </div>
+                  <SubWorkflowLibrary
+                    subWorkflows={subWorkflowSummaries}
+                    onInsert={handleInsertSubWorkflow}
+                  />
+                </section>
+              </div>
+            </ScrollArea>
           </TabsContent>
 
           <TabsContent value="settings" className="m-0 p-4 overflow-auto">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Migrate the legacy canvas app to connect to the new backend via React Flow foundation, restoring minimap, snapping, and chat affordances while preserving node compatibility.
 - [x] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
 - [x] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
-- [ ] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
+- [x] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
 - [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
 - [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 - [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.


### PR DESCRIPTION
## Summary
- add publish-time validation hooks and resource state management to the workflow canvas, including credential-aware validation before saving or running flows
- introduce reusable credential assignment and sub-workflow library panels backed by sample data to accelerate canvas authoring
- mark the milestone roadmap item for credential management integration as complete

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68f6bc7daa8883278554670bf79266ea