### PR TITLE
Fix workflow execution state initialization

### DIFF
--- a/apps/canvas/src/config/orcheo-backend.ts
+++ b/apps/canvas/src/config/orcheo-backend.ts
@@ -1,0 +1,96 @@
+const DEFAULT_BACKEND_BASE_URL = "http://localhost:8000";
+
+type Maybe<T> = T | null | undefined;
+
+const ENV_BACKEND_URL_KEYS = [
+  "VITE_ORCHEO_BACKEND_BASE_URL",
+  "VITE_BACKEND_BASE_URL",
+  "VITE_API_BASE_URL",
+] as const;
+
+const stripTrailingSlash = (value: string): string => {
+  if (value.endsWith("/")) {
+    return value.slice(0, -1);
+  }
+  return value;
+};
+
+const resolveEnvBackendUrl = (): string | undefined => {
+  for (const key of ENV_BACKEND_URL_KEYS) {
+    const envValue = (import.meta.env as Record<string, Maybe<string>>)[key];
+    if (typeof envValue === "string" && envValue.trim().length > 0) {
+      return envValue.trim();
+    }
+  }
+  return undefined;
+};
+
+const resolveBrowserBase = (): string | undefined => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    const { protocol, host } = window.location;
+    if (protocol && host) {
+      return `${protocol}//${host}`;
+    }
+  } catch (error) {
+    console.warn("Failed to resolve browser origin", error);
+  }
+  return undefined;
+};
+
+const normaliseToUrl = (value: string): URL => {
+  try {
+    return new URL(value);
+  } catch {
+    if (typeof window !== "undefined") {
+      return new URL(value, window.location.origin);
+    }
+    return new URL(DEFAULT_BACKEND_BASE_URL);
+  }
+};
+
+export const getBackendBaseUrl = (): string => {
+  const envUrl = resolveEnvBackendUrl();
+  if (envUrl) {
+    return stripTrailingSlash(envUrl);
+  }
+  const browserUrl = resolveBrowserBase();
+  if (browserUrl) {
+    return stripTrailingSlash(browserUrl);
+  }
+  return DEFAULT_BACKEND_BASE_URL;
+};
+
+export const getHttpApiBaseUrl = (): string => {
+  const base = normaliseToUrl(getBackendBaseUrl());
+  const apiPath = stripTrailingSlash(base.pathname);
+  const resolvedPath = apiPath ? `${apiPath}/api` : "/api";
+  const apiUrl = new URL(base.toString());
+  apiUrl.pathname = resolvedPath;
+  return stripTrailingSlash(apiUrl.toString());
+};
+
+export const buildWorkflowWebSocketUrl = (workflowId: string): string => {
+  const trimmed = workflowId.trim();
+  if (!trimmed) {
+    throw new Error("workflowId is required to build a WebSocket URL");
+  }
+  const base = normaliseToUrl(getBackendBaseUrl());
+  const wsProtocol = base.protocol === "https:" ? "wss:" : "ws:";
+  const wsUrl = new URL(base.toString());
+  wsUrl.protocol = wsProtocol;
+  wsUrl.pathname = `${stripTrailingSlash(wsUrl.pathname)}/ws/workflow/${encodeURIComponent(trimmed)}`;
+  wsUrl.search = "";
+  wsUrl.hash = "";
+  return wsUrl.toString();
+};
+
+export const toApiUrl = (path: string): string => {
+  const normalisedPath = path.startsWith("/") ? path : `/${path}`;
+  const apiBase = getHttpApiBaseUrl();
+  const apiUrl = new URL(apiBase);
+  apiUrl.pathname = `${stripTrailingSlash(apiUrl.pathname)}${normalisedPath}`;
+  return apiUrl.toString();
+};

--- a/apps/canvas/src/features/workflow/api/executions.ts
+++ b/apps/canvas/src/features/workflow/api/executions.ts
@@ -1,0 +1,68 @@
+import { toApiUrl } from "@/config/orcheo-backend";
+
+interface FetchOptions {
+  signal?: AbortSignal;
+}
+
+const parseJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const text = await response.text();
+    const error = new Error(
+      `Request failed with status ${response.status}: ${text || response.statusText}`,
+    );
+    throw error;
+  }
+  return (await response.json()) as T;
+};
+
+export interface RunHistoryStepResponse {
+  index: number;
+  at: string;
+  payload: Record<string, unknown>;
+}
+
+export interface RunHistoryResponse {
+  execution_id: string;
+  workflow_id: string;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+  error: string | null;
+  inputs: Record<string, unknown>;
+  steps: RunHistoryStepResponse[];
+}
+
+export const fetchExecutionHistory = async (
+  executionId: string,
+  options?: FetchOptions,
+): Promise<RunHistoryResponse> => {
+  const url = toApiUrl(
+    `/executions/${encodeURIComponent(executionId)}/history`,
+  );
+  const response = await fetch(url, {
+    method: "GET",
+    signal: options?.signal,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+  return parseJson<RunHistoryResponse>(response);
+};
+
+export const replayExecution = async (
+  executionId: string,
+  fromStep = 0,
+  options?: FetchOptions,
+): Promise<RunHistoryResponse> => {
+  const url = toApiUrl(`/executions/${encodeURIComponent(executionId)}/replay`);
+  const response = await fetch(url, {
+    method: "POST",
+    signal: options?.signal,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ from_step: fromStep }),
+  });
+  return parseJson<RunHistoryResponse>(response);
+};

--- a/apps/canvas/src/features/workflow/components/panels/workflow-execution-history.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/workflow-execution-history.tsx
@@ -60,6 +60,12 @@ export interface WorkflowExecution {
     level: "INFO" | "DEBUG" | "ERROR" | "WARNING";
     message: string;
   }[];
+  tokenMetrics?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    lastUpdatedAt?: string;
+  };
 }
 
 interface WorkflowExecutionHistoryProps {
@@ -93,6 +99,15 @@ export default function WorkflowExecutionHistory({
   const resizingRef = useRef(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
+
+  useEffect(() => {
+    if (
+      defaultSelectedExecution &&
+      defaultSelectedExecution.id !== selectedExecution?.id
+    ) {
+      setSelectedExecution(defaultSelectedExecution);
+    }
+  }, [defaultSelectedExecution, selectedExecution?.id]);
 
   const handleSelectExecution = (execution: WorkflowExecution) => {
     setSelectedExecution(execution);
@@ -367,6 +382,47 @@ export default function WorkflowExecutionHistory({
                   </Button>
                 </div>
               </div>
+
+              {selectedExecution.tokenMetrics ? (
+                <div className="grid grid-cols-3 gap-4 px-4 py-3 border-b border-border bg-muted/30 text-sm">
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">
+                      Input tokens
+                    </p>
+                    <p className="font-semibold">
+                      {selectedExecution.tokenMetrics.inputTokens.toLocaleString()}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">
+                      Output tokens
+                    </p>
+                    <p className="font-semibold">
+                      {selectedExecution.tokenMetrics.outputTokens.toLocaleString()}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">
+                      Total tokens
+                    </p>
+                    <p className="font-semibold">
+                      {selectedExecution.tokenMetrics.totalTokens.toLocaleString()}
+                      {selectedExecution.tokenMetrics.lastUpdatedAt ? (
+                        <span className="block text-[11px] font-normal text-muted-foreground">
+                          Updated{" "}
+                          {new Date(
+                            selectedExecution.tokenMetrics.lastUpdatedAt,
+                          ).toLocaleTimeString([], {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                            second: "2-digit",
+                          })}
+                        </span>
+                      ) : null}
+                    </p>
+                  </div>
+                </div>
+              ) : null}
 
               <div className="flex-1 flex flex-col overflow-hidden">
                 <div

--- a/apps/canvas/src/features/workflow/hooks/use-workflow-runner.ts
+++ b/apps/canvas/src/features/workflow/hooks/use-workflow-runner.ts
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { buildWorkflowWebSocketUrl } from "@/config/orcheo-backend";
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface WorkflowRunPayload {
+  graphConfig: Record<string, unknown>;
+  inputs: Record<string, unknown>;
+  executionId?: string;
+}
+
+export interface WorkflowStreamMessage {
+  status?: string;
+  node?: string;
+  event?: string;
+  tokens?: Record<string, number> | { input?: number; output?: number };
+  metrics?: {
+    tokens?: Record<string, number> | { input?: number; output?: number };
+  };
+  [key: string]: JsonValue;
+}
+
+export interface TokenMetrics {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  lastUpdatedAt?: string;
+}
+
+interface RunnerState {
+  status: "idle" | "connecting" | "streaming" | "completed" | "error";
+  executionId: string | null;
+  error: string | null;
+  messages: WorkflowStreamMessage[];
+  metrics: TokenMetrics;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface StreamContext {
+  executionId: string;
+}
+
+export interface WorkflowRunnerOptions {
+  onMessage?: (message: WorkflowStreamMessage, context: StreamContext) => void;
+  onError?: (error: Error, context: StreamContext | null) => void;
+  onComplete?: (context: StreamContext) => void;
+}
+
+const DEFAULT_METRICS: TokenMetrics = {
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+};
+
+const extractTokenCounts = (
+  message: WorkflowStreamMessage,
+): Partial<TokenMetrics> | null => {
+  const candidate = message.metrics?.tokens ?? message.tokens;
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+  const entries = Object.entries(candidate);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const normalised: Partial<TokenMetrics> = {};
+  for (const [key, value] of entries) {
+    if (typeof value !== "number") {
+      continue;
+    }
+    const lower = key.toLowerCase();
+    if (lower.includes("prompt") || lower.includes("input")) {
+      normalised.inputTokens = (normalised.inputTokens ?? 0) + value;
+    } else if (lower.includes("completion") || lower.includes("output")) {
+      normalised.outputTokens = (normalised.outputTokens ?? 0) + value;
+    } else if (lower.includes("total")) {
+      normalised.totalTokens = (normalised.totalTokens ?? 0) + value;
+    }
+  }
+
+  return Object.keys(normalised).length > 0 ? normalised : null;
+};
+
+const mergeTokenMetrics = (
+  previous: TokenMetrics,
+  incoming: Partial<TokenMetrics>,
+  timestamp: string,
+): TokenMetrics => {
+  const inputTokens = previous.inputTokens + (incoming.inputTokens ?? 0);
+  const outputTokens = previous.outputTokens + (incoming.outputTokens ?? 0);
+  const totalTokensCandidate = incoming.totalTokens ?? 0;
+  const totalTokens =
+    totalTokensCandidate > 0
+      ? totalTokensCandidate
+      : inputTokens + outputTokens;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    lastUpdatedAt: timestamp,
+  };
+};
+
+const createWebSocket = (url: string): WebSocket => {
+  if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is not supported in this environment");
+  }
+  return new WebSocket(url);
+};
+
+const generateExecutionId = (): string => {
+  if (
+    typeof crypto !== "undefined" &&
+    "randomUUID" in crypto &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `exec-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export const useWorkflowRunner = (
+  workflowId: string | null,
+  options?: WorkflowRunnerOptions,
+) => {
+  const websocketRef = useRef<WebSocket | null>(null);
+  const completionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const [state, setState] = useState<RunnerState>({
+    status: "idle",
+    executionId: null,
+    error: null,
+    messages: [],
+    metrics: DEFAULT_METRICS,
+    startedAt: null,
+    completedAt: null,
+  });
+
+  const clearCompletionTimer = useCallback(() => {
+    if (completionTimeoutRef.current !== null) {
+      clearTimeout(completionTimeoutRef.current);
+      completionTimeoutRef.current = null;
+    }
+  }, []);
+
+  const closeWebSocket = useCallback(() => {
+    clearCompletionTimer();
+    const websocket = websocketRef.current;
+    if (websocket && websocket.readyState === WebSocket.OPEN) {
+      websocket.close();
+    }
+    websocketRef.current = null;
+  }, [clearCompletionTimer]);
+
+  useEffect(() => closeWebSocket, [closeWebSocket]);
+
+  const runWorkflow = useCallback(
+    async ({ graphConfig, inputs, executionId }: WorkflowRunPayload) => {
+      if (!workflowId) {
+        throw new Error("Workflow identifier is required to run a workflow");
+      }
+
+      const runId = executionId ?? generateExecutionId();
+
+      setState({
+        status: "connecting",
+        executionId: runId,
+        error: null,
+        messages: [],
+        metrics: { ...DEFAULT_METRICS },
+        startedAt: null,
+        completedAt: null,
+      });
+
+      const websocketUrl = buildWorkflowWebSocketUrl(workflowId);
+      const ws = createWebSocket(websocketUrl);
+      websocketRef.current = ws;
+
+      return await new Promise<string>((resolve, reject) => {
+        const rejectWithError = (error: Error) => {
+          closeWebSocket();
+          const context: StreamContext | null = runId
+            ? { executionId: runId }
+            : null;
+          options?.onError?.(error, context);
+          setState((previous) => ({
+            ...previous,
+            status: "error",
+            error: error.message,
+            executionId: runId,
+          }));
+          reject(error);
+        };
+
+        ws.onopen = () => {
+          setState({
+            status: "streaming",
+            executionId: runId,
+            error: null,
+            messages: [],
+            metrics: { ...DEFAULT_METRICS },
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+          });
+
+          const payload = {
+            type: "run_workflow",
+            graph_config: graphConfig,
+            inputs,
+            execution_id: runId,
+          } satisfies Record<string, unknown>;
+
+          ws.send(JSON.stringify(payload));
+          resolve(runId);
+        };
+
+        ws.onerror = () => {
+          rejectWithError(new Error("WebSocket connection error"));
+        };
+
+        ws.onclose = (event) => {
+          if (event.code !== 1000) {
+            const reason = event.reason || "WebSocket closed unexpectedly";
+            rejectWithError(new Error(reason));
+            return;
+          }
+          clearCompletionTimer();
+          setState((previous) => {
+            if (previous.status === "completed") {
+              return previous;
+            }
+            return {
+              ...previous,
+              status: "completed",
+              completedAt: previous.completedAt ?? new Date().toISOString(),
+            };
+          });
+        };
+
+        ws.onmessage = (event: MessageEvent<string>) => {
+          try {
+            const data = JSON.parse(event.data) as WorkflowStreamMessage;
+            const timestamp = new Date().toISOString();
+            setState((previous) => {
+              const updatedMessages = [...previous.messages, data];
+              const tokenUpdate = extractTokenCounts(data);
+              const metrics = tokenUpdate
+                ? mergeTokenMetrics(previous.metrics, tokenUpdate, timestamp)
+                : previous.metrics;
+              let status: RunnerState["status"] = previous.status;
+              let completedAt = previous.completedAt;
+              if (typeof data.status === "string") {
+                const normalised = data.status.toLowerCase();
+                if (["completed", "success"].includes(normalised)) {
+                  status = "completed";
+                  completedAt = timestamp;
+                  completionTimeoutRef.current = setTimeout(() => {
+                    closeWebSocket();
+                    options?.onComplete?.({ executionId: runId });
+                  }, 100);
+                } else if (["error", "failed"].includes(normalised)) {
+                  status = "error";
+                  completedAt = timestamp;
+                }
+              }
+              return {
+                ...previous,
+                messages: updatedMessages,
+                metrics,
+                status,
+                completedAt,
+              };
+            });
+            options?.onMessage?.(data, { executionId: runId });
+          } catch (error) {
+            console.error("Failed to parse workflow stream message", error);
+          }
+        };
+      });
+    },
+    [clearCompletionTimer, closeWebSocket, options, workflowId],
+  );
+
+  const cancel = useCallback(() => {
+    closeWebSocket();
+    setState((previous) => ({
+      ...previous,
+      status: "idle",
+      completedAt: new Date().toISOString(),
+    }));
+  }, [closeWebSocket]);
+
+  return {
+    status: state.status,
+    executionId: state.executionId,
+    error: state.error,
+    messages: state.messages,
+    metrics: state.metrics,
+    startedAt: state.startedAt,
+    completedAt: state.completedAt,
+    runWorkflow,
+    cancel,
+  } as const;
+};

--- a/apps/canvas/src/features/workflow/hooks/use-workflow-runner.ts
+++ b/apps/canvas/src/features/workflow/hooks/use-workflow-runner.ts
@@ -155,8 +155,15 @@ export const useWorkflowRunner = (
   const closeWebSocket = useCallback(() => {
     clearCompletionTimer();
     const websocket = websocketRef.current;
-    if (websocket && websocket.readyState === WebSocket.OPEN) {
-      websocket.close();
+    if (websocket) {
+      const { readyState } = websocket;
+      if (
+        readyState === WebSocket.CONNECTING ||
+        readyState === WebSocket.OPEN ||
+        readyState === WebSocket.CLOSING
+      ) {
+        websocket.close();
+      }
     }
     websocketRef.current = null;
   }, [clearCompletionTimer]);
@@ -168,6 +175,8 @@ export const useWorkflowRunner = (
       if (!workflowId) {
         throw new Error("Workflow identifier is required to run a workflow");
       }
+
+      closeWebSocket();
 
       const runId = executionId ?? generateExecutionId();
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,8 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Finish React Flow canvas tooling: add undo/redo history, node duplication/export handlers, node search/filtering, styling updates, and collapsible configuration panels.
 - [x] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
 - [x] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
-- [ ] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
+- [x] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
+- [x] Stabilize execution history state initialization so the canvas runner and tests operate without ReferenceErrors.
 - [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 - [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.
 


### PR DESCRIPTION
## Summary
- add canvas backend configuration helpers and execution history REST utilities
- introduce a workflow runner hook and integrate it into the canvas page with stable execution state initialization
- extend the execution history panel and roadmap milestone to reflect the finished runner work

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68f739b178708327ba060665e66122f8