### PR TITLE
Integrate ChatKit into Orcheo chat experiences

### DIFF
--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -1410,9 +1410,24 @@ async def chatkit_entrypoint(request: Request, repository: RepositoryDep) -> Res
             detail="ChatKit request processing failed.",
         ) from exc
 
+    status_code = getattr(result, "status_code", status.HTTP_200_OK)
+    headers = getattr(result, "headers", None) or {}
+
     if StreamingResult is not None and isinstance(result, StreamingResult):
-        return StreamingResponse(result, media_type="text/event-stream")
-    return Response(content=result.json, media_type="application/json")
+        response = StreamingResponse(
+            result,
+            media_type="text/event-stream",
+            status_code=status_code,
+        )
+    else:
+        response = Response(
+            content=result.json,
+            media_type="application/json",
+            status_code=status_code,
+        )
+
+    response.headers.update(headers)
+    return response
 
 
 def create_app(

--- a/apps/backend/src/orcheo_backend/app/chatkit_runtime.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_runtime.py
@@ -1,0 +1,396 @@
+# ruff: noqa: D102, D107
+
+from __future__ import annotations
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from chatkit.server import (
+    ChatKitServer,
+    NonStreamingResult,
+    StreamingResult,
+    ThreadItemDoneEvent,
+)
+from chatkit.store import NotFoundError, Store
+from chatkit.types import (
+    AssistantMessageContent,
+    AssistantMessageItem,
+    Page,
+    Thread,
+    ThreadItem,
+    ThreadMetadata,
+    ThreadStreamEvent,
+    UserMessageItem,
+)
+from orcheo.models.workflow import Workflow, WorkflowRun
+from orcheo.triggers.manual import (
+    ManualDispatchItem,
+    ManualDispatchRequest,
+    ManualDispatchValidationError,
+)
+from orcheo.vault.oauth import CredentialHealthError
+from .repository import (
+    WorkflowRepository,
+    WorkflowVersionNotFoundError,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ChatRequestContext:
+    """Runtime context for ChatKit requests."""
+
+    repository: WorkflowRepository
+    workflow: Workflow
+    node_id: str | None
+    actor: str
+    chat_label: str | None
+
+
+@dataclass(slots=True)
+class _ThreadState:
+    thread: ThreadMetadata
+    items: list[ThreadItem]
+
+
+class InMemoryChatStore(Store[ChatRequestContext]):
+    """Simple in-memory store compatible with the ChatKit server interface."""
+
+    def __init__(self) -> None:
+        self._threads: dict[str, _ThreadState] = {}
+
+    @staticmethod
+    def _coerce_thread_metadata(thread: ThreadMetadata | Thread) -> ThreadMetadata:
+        has_items = isinstance(thread, Thread) or "items" in getattr(
+            thread,
+            "model_fields_set",
+            set(),
+        )
+        if not has_items:
+            return thread.model_copy(deep=True)
+
+        data = thread.model_dump()
+        data.pop("items", None)
+        return ThreadMetadata(**data).model_copy(deep=True)
+
+    async def load_thread(
+        self, thread_id: str, context: ChatRequestContext
+    ) -> ThreadMetadata:
+        state = self._threads.get(thread_id)
+        if not state:
+            raise NotFoundError(f"Thread {thread_id} not found")
+        return self._coerce_thread_metadata(state.thread)
+
+    async def save_thread(
+        self, thread: ThreadMetadata, context: ChatRequestContext
+    ) -> None:
+        metadata = self._coerce_thread_metadata(thread)
+        state = self._threads.get(thread.id)
+        if state:
+            state.thread = metadata
+        else:
+            self._threads[thread.id] = _ThreadState(thread=metadata, items=[])
+
+    async def load_threads(
+        self,
+        limit: int,
+        after: str | None,
+        order: str,
+        context: ChatRequestContext,
+    ) -> Page[ThreadMetadata]:
+        threads = sorted(
+            (
+                self._coerce_thread_metadata(state.thread)
+                for state in self._threads.values()
+            ),
+            key=lambda t: t.created_at or datetime.min,
+            reverse=(order == "desc"),
+        )
+
+        if after:
+            index_map = {thread.id: idx for idx, thread in enumerate(threads)}
+            start = index_map.get(after, -1) + 1
+        else:
+            start = 0
+
+        slice_threads = threads[start : start + limit + 1]
+        has_more = len(slice_threads) > limit
+        slice_threads = slice_threads[:limit]
+        next_after = slice_threads[-1].id if has_more and slice_threads else None
+        return Page(data=slice_threads, has_more=has_more, after=next_after)
+
+    async def delete_thread(self, thread_id: str, context: ChatRequestContext) -> None:
+        self._threads.pop(thread_id, None)
+
+    def _items(self, thread_id: str) -> list[ThreadItem]:
+        state = self._threads.get(thread_id)
+        if state is None:
+            state = _ThreadState(
+                thread=ThreadMetadata(id=thread_id, created_at=datetime.utcnow()),
+                items=[],
+            )
+            self._threads[thread_id] = state
+        return state.items
+
+    async def load_thread_items(
+        self,
+        thread_id: str,
+        after: str | None,
+        limit: int,
+        order: str,
+        context: ChatRequestContext,
+    ) -> Page[ThreadItem]:
+        items = [item.model_copy(deep=True) for item in self._items(thread_id)]
+        items.sort(
+            key=lambda item: getattr(item, "created_at", datetime.utcnow()),
+            reverse=(order == "desc"),
+        )
+
+        if after:
+            index_map = {item.id: idx for idx, item in enumerate(items)}
+            start = index_map.get(after, -1) + 1
+        else:
+            start = 0
+
+        slice_items = items[start : start + limit + 1]
+        has_more = len(slice_items) > limit
+        slice_items = slice_items[:limit]
+        next_after = slice_items[-1].id if has_more and slice_items else None
+        return Page(data=slice_items, has_more=has_more, after=next_after)
+
+    async def add_thread_item(
+        self,
+        thread_id: str,
+        item: ThreadItem,
+        context: ChatRequestContext,
+    ) -> None:
+        self._items(thread_id).append(item.model_copy(deep=True))
+
+    async def save_item(
+        self,
+        thread_id: str,
+        item: ThreadItem,
+        context: ChatRequestContext,
+    ) -> None:
+        items = self._items(thread_id)
+        for idx, existing in enumerate(items):
+            if existing.id == item.id:
+                items[idx] = item.model_copy(deep=True)
+                return
+        items.append(item.model_copy(deep=True))
+
+    async def load_item(
+        self,
+        thread_id: str,
+        item_id: str,
+        context: ChatRequestContext,
+    ) -> ThreadItem:
+        for item in self._items(thread_id):
+            if item.id == item_id:
+                return item.model_copy(deep=True)
+        raise NotFoundError(f"Item {item_id} not found")
+
+    async def delete_thread_item(
+        self,
+        thread_id: str,
+        item_id: str,
+        context: ChatRequestContext,
+    ) -> None:
+        """Remove a thread item from the in-memory store."""
+        items = self._items(thread_id)
+        self._threads[thread_id].items = [item for item in items if item.id != item_id]
+
+    async def save_attachment(
+        self,
+        attachment: Any,
+        context: ChatRequestContext,
+    ) -> None:
+        """Attachments are unsupported in the in-memory store."""
+        raise NotImplementedError("InMemoryChatStore does not persist attachments.")
+
+    async def load_attachment(
+        self,
+        attachment_id: str,
+        context: ChatRequestContext,
+    ) -> Any:
+        """Attachments are unsupported in the in-memory store."""
+        raise NotImplementedError("InMemoryChatStore does not load attachments.")
+
+    async def delete_attachment(
+        self,
+        attachment_id: str,
+        context: ChatRequestContext,
+    ) -> None:
+        """Attachments are unsupported in the in-memory store."""
+        raise NotImplementedError("InMemoryChatStore does not delete attachments.")
+
+
+class WorkflowChatKitServer(ChatKitServer[ChatRequestContext]):
+    """ChatKit server that dispatches Orcheo workflows for chat triggers."""
+
+    def __init__(self, store: Store[ChatRequestContext]) -> None:
+        """Initialise the chat server with the provided persistence store."""
+        super().__init__(store)
+
+    async def respond(
+        self,
+        thread: ThreadMetadata,
+        input_user_message: UserMessageItem | None,
+        context: ChatRequestContext,
+    ) -> AsyncIterator[ThreadStreamEvent]:
+        """Process a user message and stream workflow execution events."""
+        if input_user_message is None:
+            return
+
+        self._ensure_thread_metadata(thread, context)
+        message_text = self._extract_message_text(input_user_message)
+        if not message_text:
+            yield self._build_assistant_event(
+                thread,
+                context,
+                "I didn't receive any text. Try sending a message again.",
+            )
+            return
+
+        summary = await self._dispatch_workflow(thread, context, message_text)
+        yield self._build_assistant_event(thread, context, summary)
+
+    async def _dispatch_workflow(
+        self,
+        thread: ThreadMetadata,
+        context: ChatRequestContext,
+        message_text: str,
+    ) -> str:
+        label = context.chat_label or (
+            f"chat:{context.node_id}" if context.node_id else "chatkit"
+        )
+
+        request = ManualDispatchRequest(
+            workflow_id=context.workflow.id,
+            actor=context.actor,
+            label=label,
+            runs=[
+                ManualDispatchItem(
+                    input_payload={
+                        "chat_message": message_text,
+                        "chat_thread_id": thread.id,
+                        "chat_node_id": context.node_id,
+                    },
+                )
+            ],
+        )
+
+        try:
+            runs = await context.repository.dispatch_manual_runs(request)
+        except WorkflowVersionNotFoundError as exc:  # pragma: no cover - defensive
+            logger.exception(
+                "Workflow version not found for chat dispatch",
+                exc_info=exc,
+            )
+            return (
+                "The workflow does not have an active version. "
+                "Publish a version and try again."
+            )
+        except CredentialHealthError as exc:
+            logger.warning(
+                "Credential health check failed for chat dispatch",
+                exc_info=exc,
+            )
+            return f"Workflow could not start due to credential health issues: {exc}"
+        except ManualDispatchValidationError as exc:
+            logger.warning("Invalid chat dispatch payload", exc_info=exc)
+            return f"Unable to dispatch the workflow: {exc}"
+        except Exception:  # noqa: BLE001
+            logger.exception("Unexpected error while dispatching chat workflow")
+            return (
+                "An unexpected error prevented the workflow from running. "
+                "Check the server logs for more details."
+            )
+
+        if not runs:
+            return "No workflow runs were created for this message."
+
+        run = runs[0]
+        return self._format_run_summary(run, context, message_text)
+
+    def _format_run_summary(
+        self,
+        run: WorkflowRun,
+        context: ChatRequestContext,
+        message_text: str,
+    ) -> str:
+        snippet = message_text.strip()
+        if len(snippet) > 120:
+            snippet = snippet[:117] + "…"
+
+        parts = [
+            f"Triggered run {run.id} for “{context.workflow.name}”.",
+            f"Current status: {run.status.value}.",
+        ]
+        if snippet:
+            parts.append(f'Input: "{snippet}"')
+        parts.append("Follow the execution history for live updates.")
+        return " ".join(parts)
+
+    def _ensure_thread_metadata(
+        self,
+        thread: ThreadMetadata,
+        context: ChatRequestContext,
+    ) -> None:
+        metadata = dict(thread.metadata or {})
+        updated = False
+        if metadata.get("workflow_id") != str(context.workflow.id):
+            metadata["workflow_id"] = str(context.workflow.id)
+            updated = True
+        if (
+            context.workflow.name
+            and metadata.get("workflow_name") != context.workflow.name
+        ):
+            metadata["workflow_name"] = context.workflow.name
+            updated = True
+        if context.node_id and metadata.get("node_id") != context.node_id:
+            metadata["node_id"] = context.node_id
+            updated = True
+        if updated:
+            thread.metadata = metadata
+
+    def _extract_message_text(self, item: UserMessageItem) -> str:
+        parts: list[str] = []
+        for content in item.content:
+            text = getattr(content, "text", None)
+            if text:
+                parts.append(text)
+        return " ".join(parts).strip()
+
+    def _build_assistant_event(
+        self,
+        thread: ThreadMetadata,
+        context: ChatRequestContext,
+        message: str,
+    ) -> ThreadItemDoneEvent:
+        item = AssistantMessageItem(
+            id=self.store.generate_item_id("message", thread, context),
+            thread_id=thread.id,
+            created_at=datetime.utcnow(),
+            content=[AssistantMessageContent(text=message, annotations=[])],
+        )
+        return ThreadItemDoneEvent(item=item)
+
+
+def create_chatkit_server() -> WorkflowChatKitServer:
+    """Instantiate the ChatKit server with an in-memory store."""
+    store = InMemoryChatStore()
+    return WorkflowChatKitServer(store)
+
+
+__all__ = [
+    "ChatRequestContext",
+    "InMemoryChatStore",
+    "WorkflowChatKitServer",
+    "create_chatkit_server",
+    "NonStreamingResult",
+    "StreamingResult",
+]

--- a/apps/canvas/index.html
+++ b/apps/canvas/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Orcheo Canvas</title>
+    <script
+      src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
+      async
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/canvas/package-lock.json
+++ b/apps/canvas/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@openai/chatkit": "^1.0.0",
+        "@openai/chatkit-react": "^1.1.1",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-aspect-ratio": "^1.1.2",
@@ -1877,6 +1879,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openai/chatkit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit/-/chatkit-1.0.0.tgz",
+      "integrity": "sha512-BlRu1UMz29z01bn0D2nA5lgSeo0Eu/5uNdGUMKchoFEDHWQ8ViCHDRFO45O6FT/cdqhXbYZOzIrjUryq6djk4w==",
+      "license": "MIT"
+    },
+    "node_modules/@openai/chatkit-react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit-react/-/chatkit-react-1.1.1.tgz",
+      "integrity": "sha512-sbYZBqLkx5nEIRmBFXJ8OCsRB+0II1eu/9QSVJP4T73PdAsggTMPfxw8FUGioFFJcYrNVoFvYaBFHZVUC71jtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/chatkit": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/apps/canvas/package.json
+++ b/apps/canvas/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@openai/chatkit": "^1.0.0",
+    "@openai/chatkit-react": "^1.1.1",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-aspect-ratio": "^1.1.2",

--- a/apps/canvas/src/features/workflow/components/workflow-chatkit-panel.tsx
+++ b/apps/canvas/src/features/workflow/components/workflow-chatkit-panel.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef } from "react";
+import { ChatKit, useChatKit } from "@openai/chatkit-react";
+import { XIcon } from "lucide-react";
+
+import { Button } from "@/design-system/ui/button";
+import { cn } from "@/lib/utils";
+import { buildBackendHttpUrl } from "@lib/config";
+
+export interface WorkflowChatKitPanelProps {
+  open: boolean;
+  onClose: () => void;
+  workflowId?: string | null;
+  workflowName: string;
+  nodeId?: string | null;
+  title: string;
+  className?: string;
+}
+
+const PANEL_BASE_CLASSES =
+  "fixed bottom-4 right-4 z-50 flex h-[520px] w-80 flex-col rounded-lg border bg-background shadow-lg sm:w-96";
+
+const PANEL_BODY_CLASSES = "flex-1 overflow-hidden";
+
+function WorkflowChatUnavailable({
+  title,
+  workflowName,
+  onClose,
+  message,
+  className,
+}: {
+  title: string;
+  workflowName: string;
+  onClose: () => void;
+  message: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn(PANEL_BASE_CLASSES, className)}>
+      <div className="flex items-center justify-between border-b p-3">
+        <div>
+          <h3 className="font-medium">{title}</h3>
+          <p className="text-xs text-muted-foreground">
+            {workflowName
+              ? `Messages run ${workflowName}`
+              : "Messages run this workflow."}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onClose}
+        >
+          <XIcon className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 p-4 text-center text-sm text-muted-foreground">
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export function WorkflowChatKitPanel({
+  open,
+  onClose,
+  workflowId,
+  workflowName,
+  nodeId,
+  title,
+  className,
+}: WorkflowChatKitPanelProps) {
+  const fetchSupported = typeof fetch === "function";
+  const backendUrl = useMemo(() => buildBackendHttpUrl("/api/chatkit"), []);
+
+  const fetchWithHeaders = useMemo(() => {
+    if (!workflowId || !fetchSupported) {
+      return async () => {
+        throw new Error("Chat backend is not available.");
+      };
+    }
+
+    return async (url: string, options: RequestInit = {}) => {
+      const headers = new Headers(options.headers ?? {});
+      headers.set("X-Orcheo-Workflow-Id", workflowId);
+      if (nodeId) {
+        headers.set("X-Orcheo-Node-Id", nodeId);
+      }
+      headers.set("X-Orcheo-Chat-Actor", "canvas-chat");
+      headers.set("X-Orcheo-Chat-Label", title);
+      if (workflowName) {
+        headers.set("X-Orcheo-Workflow-Name", workflowName);
+      }
+
+      return fetch(url, { ...options, headers });
+    };
+  }, [workflowId, fetchSupported, nodeId, title, workflowName]);
+
+  const previousNodeRef = useRef<string | null>(null);
+
+  const { control, focusComposer, setThreadId, fetchUpdates } = useChatKit({
+    api: {
+      url: backendUrl,
+      fetch: fetchWithHeaders,
+    },
+    header: {
+      enabled: true,
+      title: { text: title },
+    },
+    startScreen: {
+      enabled: true,
+      title: `Test ${title}`,
+      subtitle: workflowName
+        ? `Messages run “${workflowName}”.`
+        : "Messages run this workflow.",
+    },
+    history: {
+      enabled: true,
+    },
+    theme: {
+      colorScheme: "light",
+      radius: "round",
+    },
+    composer: {
+      placeholder: "Describe what you want this workflow to handle…",
+    },
+  });
+
+  useEffect(() => {
+    if (!open || !fetchSupported || !workflowId) {
+      previousNodeRef.current = nodeId ?? null;
+      return;
+    }
+
+    const resetThread = previousNodeRef.current !== nodeId;
+    previousNodeRef.current = nodeId ?? null;
+    if (resetThread) {
+      void setThreadId(null);
+    }
+    void focusComposer();
+    void fetchUpdates();
+  }, [
+    open,
+    fetchSupported,
+    workflowId,
+    nodeId,
+    setThreadId,
+    focusComposer,
+    fetchUpdates,
+  ]);
+
+  if (!open) {
+    return null;
+  }
+
+  if (!fetchSupported) {
+    return (
+      <WorkflowChatUnavailable
+        title={title}
+        workflowName={workflowName}
+        onClose={onClose}
+        className={className}
+        message="The Fetch API is not available in this environment."
+      />
+    );
+  }
+
+  if (!workflowId) {
+    return (
+      <WorkflowChatUnavailable
+        title={title}
+        workflowName={workflowName}
+        onClose={onClose}
+        className={className}
+        message="Save the workflow to generate an identifier before testing chat triggers."
+      />
+    );
+  }
+
+  return (
+    <div className={cn(PANEL_BASE_CLASSES, className)}>
+      <div className="flex items-center justify-between border-b p-3">
+        <div>
+          <h3 className="font-medium">{title}</h3>
+          <p className="text-xs text-muted-foreground">
+            {workflowName
+              ? `Messages run ${workflowName}`
+              : "Messages run this workflow."}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onClose}
+        >
+          <XIcon className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className={PANEL_BODY_CLASSES}>
+        <ChatKit control={control} className="h-full" />
+      </div>
+    </div>
+  );
+}
+
+export default WorkflowChatKitPanel;

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -45,8 +45,7 @@ import WorkflowControls from "@features/workflow/components/canvas/workflow-cont
 import WorkflowSearch from "@features/workflow/components/canvas/workflow-search";
 import NodeInspector from "@features/workflow/components/panels/node-inspector";
 import ChatTriggerNode from "@features/workflow/components/nodes/chat-trigger-node";
-import ChatInterface from "@features/shared/components/chat-interface";
-import type { Attachment } from "@features/shared/components/chat-input";
+import WorkflowChatKitPanel from "@features/workflow/components/workflow-chatkit-panel";
 import WorkflowExecutionHistory, {
   type WorkflowExecution as HistoryWorkflowExecution,
 } from "@features/workflow/components/panels/workflow-execution-history";
@@ -2157,68 +2156,6 @@ export default function WorkflowCanvas({
     [handleOpenChat, setNodes],
   );
 
-  // Handle chat message sending
-  const handleSendChatMessage = (
-    message: string,
-    attachments: Attachment[],
-  ) => {
-    if (!activeChatNodeId) {
-      toast({
-        title: "Select a chat-enabled node",
-        description: "Open a node chat to send messages.",
-      });
-      return;
-    }
-
-    const activeNode = nodes.find((node) => node.id === activeChatNodeId);
-    const attachmentSummary =
-      attachments.length === 0
-        ? ""
-        : attachments.length === 1
-          ? " with 1 attachment"
-          : ` with ${attachments.length} attachments`;
-
-    toast({
-      title: `Message sent to ${activeNode?.data?.label ?? "workflow"}`,
-      description: `"${message}"${attachmentSummary}`,
-    });
-
-    // Here you would typically process the message and trigger the workflow
-    // For now, we'll just update the node status to simulate activity
-    setNodes((nds) =>
-      nds.map((n) => {
-        if (n.id === activeChatNodeId) {
-          return {
-            ...n,
-            data: {
-              ...n.data,
-              status: "running" as NodeStatus,
-            },
-          };
-        }
-        return n;
-      }),
-    );
-
-    // Simulate workflow execution
-    setTimeout(() => {
-      setNodes((nds) =>
-        nds.map((n) => {
-          if (n.id === activeChatNodeId) {
-            return {
-              ...n,
-              data: {
-                ...n.data,
-                status: "success" as NodeStatus,
-              },
-            };
-          }
-          return n;
-        }),
-      );
-    }, 2000);
-  };
-
   // Handle workflow execution
   const handleRunWorkflow = useCallback(() => {
     if (nodes.length === 0) {
@@ -2823,19 +2760,6 @@ export default function WorkflowCanvas({
     }, 100);
   }, [nodes]);
 
-  // User and AI info for chat
-  const user = {
-    id: "user-1",
-    name: "Avery Chen",
-    avatar: "https://avatar.vercel.sh/avery",
-  };
-
-  const ai = {
-    id: "ai-1",
-    name: "Orcheo Canvas Assistant",
-    avatar: "https://avatar.vercel.sh/orcheo-canvas",
-  };
-
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <TopNavigation
@@ -3172,28 +3096,17 @@ export default function WorkflowCanvas({
         />
       )}
 
-      {/* Chat Interface */}
-      {isChatOpen && (
-        <ChatInterface
-          title={chatTitle}
-          user={user}
-          ai={ai}
-          isClosable={true}
-          onSendMessage={handleSendChatMessage}
-          position="bottom-right"
-          initialMessages={[
-            {
-              id: "welcome-msg",
-              content: `Welcome to the ${chatTitle} interface. How can I help you today?`,
-              sender: {
-                ...ai,
-                isAI: true,
-              },
-              timestamp: new Date(),
-            },
-          ]}
-        />
-      )}
+      <WorkflowChatKitPanel
+        open={isChatOpen}
+        onClose={() => {
+          setIsChatOpen(false);
+          setActiveChatNodeId(null);
+        }}
+        workflowId={currentWorkflowId}
+        workflowName={workflowName}
+        nodeId={activeChatNodeId}
+        title={chatTitle}
+      />
     </div>
   );
 }

--- a/apps/canvas/tsconfig.app.json
+++ b/apps/canvas/tsconfig.app.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "baseUrl": ".",
+    "types": ["@openai/chatkit"],
     "paths": {
       "@/*": ["src/*"],
       "@lib/*": ["src/lib/*"],

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
 - [x] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
 - [x] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
-- [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
+- [x] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 - [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.
 
 ### Milestone 5 – Node Ecosystem & Integrations

--- a/examples/chatkit/README.md
+++ b/examples/chatkit/README.md
@@ -1,0 +1,27 @@
+# ChatKit Embed Example
+
+This minimal example shows how to embed the OpenAI ChatKit web component so it
+can talk to the Orcheo backend. Update the constants at the bottom of
+`embed.html` with the ID of a workflow that includes a chat trigger and (optionally)
+the specific node identifier you want to exercise.
+
+## Quick start
+
+1. Install the backend dependencies and start the Orcheo backend on
+   `http://localhost:8000`.
+2. Save the workflow that you want to trigger via chat and copy its UUID.
+3. Edit `embed.html` and replace the placeholder workflow (and node) identifiers.
+4. Serve the file locally, for example:
+
+   ```bash
+   cd examples/chatkit
+   python -m http.server 8090
+   ```
+
+5. Visit `http://localhost:8090/embed.html` and send a chat message. Each message
+   is sent to `/api/chatkit` with the workflow headers so the backend dispatches
+   the appropriate run.
+
+The UI uses the same ChatKit component that is now integrated with Orcheo Canvas,
+so any configuration changes you make here can be transferred to the application
+with minimal adjustments.

--- a/examples/chatkit/embed.html
+++ b/examples/chatkit/embed.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Orcheo ChatKit Embed Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script
+      src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
+      async
+    ></script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 2rem;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at top, #f4f7fb, #eef1f6);
+      }
+
+      .wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: min(560px, 100%);
+      }
+
+      .wrapper h1 {
+        font-size: 1.75rem;
+        margin: 0;
+      }
+
+      .wrapper p {
+        margin: 0;
+        line-height: 1.5;
+      }
+
+      openai-chatkit {
+        width: 100%;
+        height: 560px;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 16px 48px rgba(15, 35, 95, 0.18);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrapper">
+      <div>
+        <h1>Chat-triggered Workflow Demo</h1>
+        <p>
+          Update the constants in <code>examples/chatkit/embed.html</code> with your
+          workflow information and serve this file locally (for example with
+          <code>python -m http.server</code>). Messages sent below will be forwarded to the
+          Orcheo backend through the new ChatKit endpoint.
+        </p>
+      </div>
+      <openai-chatkit id="orcheo-chat"></openai-chatkit>
+    </main>
+    <script type="module">
+      const WORKFLOW_ID = "replace-with-workflow-id";
+      const NODE_ID = "replace-with-chat-trigger-node-id"; // optional
+      const BACKEND_URL = "http://localhost:8000"; // adjust if the backend runs elsewhere
+
+      if (!WORKFLOW_ID || WORKFLOW_ID.startsWith("replace")) {
+        console.warn("Update WORKFLOW_ID in examples/chatkit/embed.html before testing.");
+      }
+
+      const chatkit = document.getElementById("orcheo-chat");
+      if (!chatkit) {
+        throw new Error("ChatKit element not found");
+      }
+
+      const apiBase = BACKEND_URL.replace(/\/$/, "");
+
+      chatkit.setOptions({
+        api: {
+          url: `${apiBase}/api/chatkit`,
+          fetch(url, options = {}) {
+            const headers = new Headers(options.headers ?? {});
+            headers.set("X-Orcheo-Workflow-Id", WORKFLOW_ID);
+            if (NODE_ID && !NODE_ID.startsWith("replace")) {
+              headers.set("X-Orcheo-Node-Id", NODE_ID);
+            }
+            headers.set("X-Orcheo-Chat-Actor", "embed-example");
+            headers.set("X-Orcheo-Chat-Label", "Embedded Chat Demo");
+            return fetch(url, { ...options, headers });
+          },
+        },
+        header: {
+          enabled: true,
+          title: { text: "Orcheo Assistant" },
+        },
+        startScreen: {
+          enabled: true,
+          title: "Test your workflow",
+          subtitle:
+            "Send a message to dispatch the configured workflow through the ChatKit API.",
+        },
+        history: { enabled: true },
+        theme: {
+          colorScheme: "light",
+          radius: "round",
+        },
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a ChatKit-powered workflow chat panel in Canvas, wiring CDN assets and types
- add a backend ChatKit runtime adapter with a `/api/chatkit` proxy endpoint
- provide an embeddable ChatKit example and tick the roadmap milestone

## Testing
- make lint
- make test
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68f7bd910ec483278003b1f305229e06