### PR TITLE
Integrate OpenAI ChatKit support

### DIFF
--- a/apps/canvas/index.html
+++ b/apps/canvas/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Orcheo Canvas</title>
+    <script
+      src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
+      async
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/canvas/package-lock.json
+++ b/apps/canvas/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@openai/chatkit": "^1.0.0",
+        "@openai/chatkit-react": "^1.1.1",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-aspect-ratio": "^1.1.2",
@@ -1877,6 +1879,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openai/chatkit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit/-/chatkit-1.0.0.tgz",
+      "integrity": "sha512-BlRu1UMz29z01bn0D2nA5lgSeo0Eu/5uNdGUMKchoFEDHWQ8ViCHDRFO45O6FT/cdqhXbYZOzIrjUryq6djk4w==",
+      "license": "MIT"
+    },
+    "node_modules/@openai/chatkit-react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit-react/-/chatkit-react-1.1.1.tgz",
+      "integrity": "sha512-sbYZBqLkx5nEIRmBFXJ8OCsRB+0II1eu/9QSVJP4T73PdAsggTMPfxw8FUGioFFJcYrNVoFvYaBFHZVUC71jtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/chatkit": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/apps/canvas/package.json
+++ b/apps/canvas/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@openai/chatkit": "^1.0.0",
+    "@openai/chatkit-react": "^1.1.1",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-aspect-ratio": "^1.1.2",

--- a/apps/canvas/src/features/shared/components/chat-interface.tsx
+++ b/apps/canvas/src/features/shared/components/chat-interface.tsx
@@ -15,12 +15,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/design-system/ui/tooltip";
-import { buildBackendHttpUrl } from "@/lib/config";
+import { toast } from "@/hooks/use-toast";
+import {
+  buildBackendHttpUrl,
+  getChatKitComposerPlaceholder,
+  getChatKitDomainKey,
+} from "@/lib/config";
 import { cn } from "@/lib/utils";
 import { MessageSquare, MinimizeIcon, XIcon } from "lucide-react";
-
-const DEFAULT_DOMAIN_KEY = "domain_pk_orcheo_dev";
-const DEFAULT_PLACEHOLDER = "Describe what you want the workflow to do";
 
 export interface ChatInterfaceProps {
   title?: string;
@@ -58,7 +60,7 @@ export default function ChatInterface({
   domainKey,
   greeting,
   starterPrompts,
-  composerPlaceholder = DEFAULT_PLACEHOLDER,
+  composerPlaceholder = getChatKitComposerPlaceholder(),
   onResponseStart,
   onResponseEnd,
 }: ChatInterfaceProps) {
@@ -80,7 +82,7 @@ export default function ChatInterface({
   const chatkit = useChatKit({
     api: {
       url: backendUrl,
-      domainKey: domainKey ?? DEFAULT_DOMAIN_KEY,
+      domainKey: domainKey ?? getChatKitDomainKey(),
       fetch: (url: string, init?: RequestInit) => {
         const headers = new Headers(init?.headers ?? {});
         if (workflowId) {
@@ -114,6 +116,15 @@ export default function ChatInterface({
     },
     onError: ({ error }) => {
       console.error("ChatKit error", error);
+      const description =
+        error instanceof Error
+          ? error.message
+          : "Check the server logs for details.";
+      toast({
+        title: "Chat session unavailable",
+        description,
+        variant: "destructive",
+      });
     },
   });
 

--- a/apps/canvas/src/features/shared/components/chat-interface.tsx
+++ b/apps/canvas/src/features/shared/components/chat-interface.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { StartScreenPrompt } from "@openai/chatkit";
+import { ChatKit, useChatKit } from "@openai/chatkit-react";
 import { Button } from "@/design-system/ui/button";
 import {
   Dialog,
@@ -13,17 +15,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/design-system/ui/tooltip";
+import { buildBackendHttpUrl } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import { MessageSquare, MinimizeIcon, XIcon } from "lucide-react";
-import ChatMessage, {
-  ChatMessageProps,
-} from "@features/shared/components/chat-message";
-import ChatInput, { Attachment } from "@features/shared/components/chat-input";
+
+const DEFAULT_DOMAIN_KEY = "domain_pk_orcheo_dev";
+const DEFAULT_PLACEHOLDER = "Describe what you want the workflow to do";
 
 export interface ChatInterfaceProps {
   title?: string;
-  initialMessages?: ChatMessageProps[];
-  onSendMessage?: (message: string, attachments: Attachment[]) => void;
   className?: string;
   isMinimizable?: boolean;
   isClosable?: boolean;
@@ -34,110 +34,107 @@ export interface ChatInterfaceProps {
     | "top-left"
     | "center";
   triggerButton?: React.ReactNode;
-  user: {
-    id: string;
-    name: string;
-    avatar?: string;
-  };
-  ai: {
-    id: string;
-    name: string;
-    avatar?: string;
-  };
+  workflowId?: string | null;
+  chatNodeId?: string | null;
+  chatNodeLabel?: string | null;
+  domainKey?: string;
+  greeting?: string;
+  starterPrompts?: StartScreenPrompt[];
+  composerPlaceholder?: string;
+  onResponseStart?: () => void;
+  onResponseEnd?: () => void;
 }
 
 export default function ChatInterface({
   title = "Chat",
-  initialMessages = [],
-  onSendMessage,
   className,
   isMinimizable = true,
   isClosable = true,
   position = "bottom-right",
   triggerButton,
-  user,
-  ai,
+  workflowId,
+  chatNodeId,
+  chatNodeLabel,
+  domainKey,
+  greeting,
+  starterPrompts,
+  composerPlaceholder = DEFAULT_PLACEHOLDER,
+  onResponseStart,
+  onResponseEnd,
 }: ChatInterfaceProps) {
-  const [messages, setMessages] = useState<ChatMessageProps[]>(initialMessages);
   const [isOpen, setIsOpen] = useState(false);
   const [isMinimized, setIsMinimized] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const handleSendMessage = (message: string, attachments: Attachment[]) => {
-    if (!message.trim() && attachments.length === 0) return;
+  const backendUrl = useMemo(() => buildBackendHttpUrl("/api/chatkit"), []);
 
-    const newMessage: ChatMessageProps = {
-      id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-      content: message,
-      sender: user,
-      timestamp: new Date(),
-      isUserMessage: true,
-      status: "sending",
-      attachments: attachments.map((att) => ({
-        id: att.id,
-        type: att.type,
-        name: att.file.name,
-        url: att.previewUrl || URL.createObjectURL(att.file),
-        size: formatFileSize(att.file.size),
-      })),
-    };
-
-    setMessages((prev) => [...prev, newMessage]);
-
-    // Simulate sending and response
-    setTimeout(() => {
-      setMessages((prev) =>
-        prev.map((msg) =>
-          msg.id === newMessage.id ? { ...msg, status: "sent" } : msg,
-        ),
-      );
-
-      if (onSendMessage) {
-        onSendMessage(message, attachments);
-      }
-
-      // Simulate AI response after a delay
-      if (!onSendMessage) {
-        setTimeout(() => {
-          const aiResponse: ChatMessageProps = {
-            id: `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-            content: getAIResponse(message),
-            sender: {
-              ...ai,
-              isAI: true,
-            },
-            timestamp: new Date(),
-          };
-          setMessages((prev) => [...prev, aiResponse]);
-        }, 1000);
-      }
-    }, 500);
-  };
-
-  const getAIResponse = (message: string): string => {
-    if (
-      message.toLowerCase().includes("hello") ||
-      message.toLowerCase().includes("hi")
-    ) {
-      return "Hello! How can I assist you with your workflow today?";
-    } else if (message.toLowerCase().includes("help")) {
-      return "I'm here to help! You can ask me about creating workflows, connecting nodes, or troubleshooting issues.";
-    } else if (message.toLowerCase().includes("workflow")) {
-      return "Workflows in Orcheo Canvas allow you to automate processes by connecting different nodes together. Would you like me to explain how to create one?";
-    } else {
-      return "I understand. Is there anything specific about the Orcheo Canvas platform you'd like to know more about?";
+  const startScreen = useMemo(() => {
+    if (!greeting && (!starterPrompts || starterPrompts.length === 0)) {
+      return undefined;
     }
-  };
+    return {
+      greeting: greeting ?? undefined,
+      prompts: starterPrompts,
+    };
+  }, [greeting, starterPrompts]);
 
-  const formatFileSize = (bytes: number): string => {
-    if (bytes < 1024) return bytes + " B";
-    else if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KB";
-    else if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + " MB";
-    else return (bytes / 1073741824).toFixed(1) + " GB";
-  };
+  const chatkit = useChatKit({
+    api: {
+      url: backendUrl,
+      domainKey: domainKey ?? DEFAULT_DOMAIN_KEY,
+      fetch: (url: string, init?: RequestInit) => {
+        const headers = new Headers(init?.headers ?? {});
+        if (workflowId) {
+          headers.set("x-orcheo-chat-workflow-id", workflowId);
+        }
+        if (chatNodeId) {
+          headers.set("x-orcheo-chat-node-id", chatNodeId);
+        }
+        if (chatNodeLabel) {
+          headers.set("x-orcheo-chat-node-name", chatNodeLabel);
+        }
+        return fetch(url, { ...init, headers });
+      },
+    },
+    header: {
+      title: {
+        enabled: true,
+        text: title,
+      },
+    },
+    startScreen,
+    history: { enabled: true },
+    composer: {
+      placeholder: composerPlaceholder,
+    },
+    onResponseStart: () => {
+      onResponseStart?.();
+    },
+    onResponseEnd: () => {
+      onResponseEnd?.();
+    },
+    onError: ({ error }) => {
+      console.error("ChatKit error", error);
+    },
+  });
+
+  const { control, focusComposer } = chatkit;
+
+  useEffect(() => {
+    if (isOpen && !isMinimized) {
+      void focusComposer().catch(() => undefined);
+    }
+  }, [isOpen, isMinimized, focusComposer]);
+
+  const positionClasses = {
+    "bottom-right": "bottom-4 right-4",
+    "bottom-left": "bottom-4 left-4",
+    "top-right": "top-4 right-4",
+    "top-left": "top-4 left-4",
+    center: "bottom-1/2 right-1/2 translate-x-1/2 translate-y-1/2",
+  } as const;
 
   const handleToggleMinimize = () => {
-    setIsMinimized(!isMinimized);
+    setIsMinimized((prev) => !prev);
   };
 
   const handleClose = () => {
@@ -145,23 +142,6 @@ export default function ChatInterface({
     setIsMinimized(false);
   };
 
-  // Scroll to bottom when messages change
-  useEffect(() => {
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [messages]);
-
-  // Position classes
-  const positionClasses = {
-    "bottom-right": "bottom-4 right-4",
-    "bottom-left": "bottom-4 left-4",
-    "top-right": "top-4 right-4",
-    "top-left": "top-4 left-4",
-    center: "bottom-1/2 right-1/2 transform translate-x-1/2 translate-y-1/2",
-  };
-
-  // If using Dialog mode (with trigger button)
   if (triggerButton) {
     return (
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -170,34 +150,14 @@ export default function ChatInterface({
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
           </DialogHeader>
-          <div className="flex flex-col h-[60vh]">
-            <div className="flex-1 overflow-y-auto p-2">
-              {messages.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-                  <MessageSquare className="h-12 w-12 mb-2 opacity-20" />
-
-                  <p>No messages yet</p>
-                  <p className="text-sm">Start a conversation!</p>
-                </div>
-              ) : (
-                messages.map((message) => (
-                  <ChatMessage key={message.id} {...message} />
-                ))
-              )}
-              <div ref={messagesEndRef} />
-            </div>
-            <ChatInput
-              onSendMessage={handleSendMessage}
-              placeholder="Type your message..."
-              className="border-t"
-            />
+          <div className="h-[60vh]">
+            <ChatKit control={control} className="h-full w-full" />
           </div>
         </DialogContent>
       </Dialog>
     );
   }
 
-  // Floating chat interface
   return (
     <>
       {!isOpen && (
@@ -206,7 +166,7 @@ export default function ChatInterface({
             <TooltipTrigger asChild>
               <Button
                 onClick={() => setIsOpen(true)}
-                className="rounded-full h-14 w-14 shadow-lg fixed z-50 bottom-4 right-4"
+                className="fixed bottom-4 right-4 z-50 h-14 w-14 rounded-full shadow-lg"
               >
                 <MessageSquare className="h-6 w-6" />
               </Button>
@@ -219,13 +179,13 @@ export default function ChatInterface({
       {isOpen && (
         <div
           className={cn(
-            "fixed z-50 flex flex-col rounded-lg shadow-lg bg-background border",
+            "fixed z-50 flex flex-col rounded-lg border bg-background shadow-lg",
             positionClasses[position],
-            isMinimized ? "w-72 h-12" : "w-80 sm:w-96 h-[500px]",
+            isMinimized ? "h-12 w-72" : "h-[500px] w-80 sm:w-96",
             className,
           )}
         >
-          <div className="flex items-center justify-between p-3 border-b">
+          <div className="flex items-center justify-between border-b p-3">
             <h3 className="font-medium truncate">{title}</h3>
             <div className="flex items-center gap-1">
               {isMinimizable && (
@@ -252,28 +212,9 @@ export default function ChatInterface({
           </div>
 
           {!isMinimized && (
-            <>
-              <div className="flex-1 overflow-y-auto p-2">
-                {messages.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-                    <MessageSquare className="h-12 w-12 mb-2 opacity-20" />
-
-                    <p>No messages yet</p>
-                    <p className="text-sm">Start a conversation!</p>
-                  </div>
-                ) : (
-                  messages.map((message) => (
-                    <ChatMessage key={message.id} {...message} />
-                  ))
-                )}
-                <div ref={messagesEndRef} />
-              </div>
-              <ChatInput
-                onSendMessage={handleSendMessage}
-                placeholder="Type your message..."
-                className="border-t"
-              />
-            </>
+            <div className="flex-1 min-h-0">
+              <ChatKit control={control} className="h-full w-full" />
+            </div>
           )}
         </div>
       )}

--- a/apps/canvas/src/features/support/pages/help-support.tsx
+++ b/apps/canvas/src/features/support/pages/help-support.tsx
@@ -29,26 +29,23 @@ import ChatInterface from "@features/shared/components/chat-interface";
 export default function HelpSupport() {
   const [searchQuery, setSearchQuery] = useState("");
 
-  const user = {
-    id: "user-1",
-    name: "Avery Chen",
-    avatar: "https://avatar.vercel.sh/avery",
-  };
-
-  const ai = {
-    id: "ai-1",
-    name: "Orcheo Canvas Support",
-    avatar: "https://avatar.vercel.sh/orcheo-canvas",
-    isAI: true,
-  };
-
-  const initialMessages = [
+  const supportGreeting =
+    "Hello! I'm the Orcheo Canvas support assistant. How can I help you today?";
+  const supportPrompts = [
     {
-      id: "msg-1",
-      content:
-        "Hello! I'm the Orcheo Canvas support assistant. How can I help you today?",
-      sender: ai,
-      timestamp: new Date(Date.now() - 60000),
+      label: "Reset my credentials",
+      prompt: "How do I rotate or reset stored credentials?",
+      icon: "keys",
+    },
+    {
+      label: "Canvas walkthrough",
+      prompt: "Give me a quick tour of Orcheo Canvas features.",
+      icon: "compass",
+    },
+    {
+      label: "Debug a workflow",
+      prompt: "Help me debug a failing workflow run.",
+      icon: "bug",
     },
   ];
 
@@ -531,9 +528,9 @@ export default function HelpSupport() {
             </div>
             <ChatInterface
               title="Orcheo Canvas Support"
-              initialMessages={initialMessages}
-              user={user}
-              ai={ai}
+              greeting={supportGreeting}
+              starterPrompts={supportPrompts}
+              composerPlaceholder="Ask a question about Canvas"
               triggerButton={
                 <Button size="lg" className="w-full md:w-auto">
                   <svg

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -1019,6 +1019,60 @@ export default function WorkflowCanvas({
     }
   }, []);
 
+  const handleChatResponseStart = useCallback(() => {
+    if (!activeChatNodeId) {
+      toast({
+        title: "Select a chat-enabled node",
+        description: "Open a node chat to send a message.",
+      });
+      return;
+    }
+
+    const activeNode = nodesRef.current.find(
+      (node) => node.id === activeChatNodeId,
+    );
+    const targetLabel = activeNode?.data?.label ?? "workflow";
+
+    toast({
+      title: `Dispatching ${targetLabel}`,
+      description: "ChatKit forwarded your message to this workflow.",
+    });
+
+    setNodes((current) =>
+      current.map((node) =>
+        node.id === activeChatNodeId
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                status: "running" as NodeStatus,
+              },
+            }
+          : node,
+      ),
+    );
+  }, [activeChatNodeId, setNodes]);
+
+  const handleChatResponseEnd = useCallback(() => {
+    if (!activeChatNodeId) {
+      return;
+    }
+
+    setNodes((current) =>
+      current.map((node) =>
+        node.id === activeChatNodeId
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                status: "success" as NodeStatus,
+              },
+            }
+          : node,
+      ),
+    );
+  }, [activeChatNodeId, setNodes]);
+
   const convertPersistedNodesToCanvas = useCallback(
     (persistedNodes: PersistedWorkflowNode[]) =>
       persistedNodes.map((node) => {
@@ -3133,56 +3187,3 @@ export default function WorkflowCanvas({
     </div>
   );
 }
-const handleChatResponseStart = () => {
-  if (!activeChatNodeId) {
-    toast({
-      title: "Select a chat-enabled node",
-      description: "Open a node chat to send a message.",
-    });
-    return;
-  }
-
-  const activeNode = nodesRef.current.find(
-    (node) => node.id === activeChatNodeId,
-  );
-  const targetLabel = activeNode?.data?.label ?? "workflow";
-
-  toast({
-    title: `Dispatching ${targetLabel}`,
-    description: "ChatKit forwarded your message to this workflow.",
-  });
-
-  setNodes((current) =>
-    current.map((node) =>
-      node.id === activeChatNodeId
-        ? {
-            ...node,
-            data: {
-              ...node.data,
-              status: "running" as NodeStatus,
-            },
-          }
-        : node,
-    ),
-  );
-};
-
-const handleChatResponseEnd = () => {
-  if (!activeChatNodeId) {
-    return;
-  }
-
-  setNodes((current) =>
-    current.map((node) =>
-      node.id === activeChatNodeId
-        ? {
-            ...node,
-            data: {
-              ...node.data,
-              status: "success" as NodeStatus,
-            },
-          }
-        : node,
-    ),
-  );
-};

--- a/apps/canvas/src/lib/config.ts
+++ b/apps/canvas/src/lib/config.ts
@@ -1,4 +1,6 @@
 const DEFAULT_BACKEND_URL = "http://localhost:8000";
+const DEFAULT_CHATKIT_DOMAIN_KEY = "domain_pk_orcheo_dev";
+const DEFAULT_CHATKIT_PLACEHOLDER = "Describe what you want the workflow to do";
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
@@ -64,6 +66,28 @@ export const buildBackendHttpUrl = (path: string, baseUrl?: string): string => {
   const normalised = trimTrailingSlash(resolved);
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${normalised}${suffix}`;
+};
+
+const resolveEnvString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const getChatKitDomainKey = (): string => {
+  return (
+    resolveEnvString(import.meta.env?.VITE_ORCHEO_CHATKIT_DOMAIN_KEY) ??
+    DEFAULT_CHATKIT_DOMAIN_KEY
+  );
+};
+
+export const getChatKitComposerPlaceholder = (): string => {
+  return (
+    resolveEnvString(import.meta.env?.VITE_ORCHEO_CHATKIT_PLACEHOLDER) ??
+    DEFAULT_CHATKIT_PLACEHOLDER
+  );
 };
 
 export const buildWorkflowWebSocketUrl = (

--- a/apps/canvas/tsconfig.app.json
+++ b/apps/canvas/tsconfig.app.json
@@ -23,7 +23,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["@openai/chatkit"]
   },
   "include": ["src"]
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 - [x] Implement workflow operations: replace mocked save/load with persistence, wire JSON import/export, enable template onboarding, and surface a version diff viewer.
 - [x] Integrate credential management UI, reusable sub-workflows, and publish-time validation flows throughout the canvas.
 - [x] Connect canvas executions to backend WebSocket streams for live status, token metrics, and run replay hooks.
-- [ ] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
+- [x] Ship a ChatKit-inspired chat frontend (via OpenAI ChatKit or a custom equivalent) for testing workflows and production handoff.
 - [ ] Execute the [frontend experience plan](./frontend_plan.md) covering design system creation, architecture refactor, and QA expansion to de-risk the canvas rebuild.
 
 ### Milestone 5 – Node Ecosystem & Integrations

--- a/examples/chatkit-embed.html
+++ b/examples/chatkit-embed.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Orcheo ChatKit Embed Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script
+      src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
+      async
+    ></script>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1.5rem;
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+        color: #e2e8f0;
+      }
+      openai-chatkit {
+        height: 600px;
+        width: min(420px, 90vw);
+        border-radius: 16px;
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+        overflow: hidden;
+      }
+      code {
+        background: rgba(15, 23, 42, 0.4);
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.375rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>ChatKit + Orcheo Backend</h1>
+      <p>
+        Replace <code>&lt;workflow-id&gt;</code> with a workflow identifier from
+        your Orcheo environment and open this file in a browser while the
+        backend is running on <code>http://localhost:8000</code>.
+      </p>
+    </div>
+    <openai-chatkit id="orcheo-chat"></openai-chatkit>
+    <script type="module">
+      const chatkit = document.getElementById("orcheo-chat");
+      if (!chatkit) {
+        throw new Error("ChatKit element not found");
+      }
+
+      chatkit.setOptions({
+        api: {
+          url: "http://localhost:8000/api/chatkit",
+          domainKey: "domain_pk_orcheo_dev",
+          fetch(url, init) {
+            const headers = new Headers(init?.headers ?? {});
+            headers.set("x-orcheo-chat-workflow-id", "<workflow-id>");
+            // Optional: scope runs to a specific node on the canvas.
+            headers.set("x-orcheo-chat-node-id", "chat-trigger-node-id");
+            return fetch(url, { ...init, headers });
+          },
+        },
+        header: {
+          title: {
+            enabled: true,
+            text: "Orcheo Assistant",
+          },
+        },
+        startScreen: {
+          greeting: "Hello! I can dispatch Orcheo workflows from chat.",
+          prompts: [
+            {
+              label: "Trigger the workflow",
+              prompt: "Run this workflow now.",
+              icon: "sparkle",
+            },
+            {
+              label: "Summarise last run",
+              prompt: "Summarise the most recent workflow execution.",
+              icon: "notebook",
+            },
+          ],
+        },
+        composer: {
+          placeholder: "Describe what you want the workflow to do",
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "python-dotenv>=1.0.0",
   "websockets>=12.0",
   "openai>=1.0.0",
+  "openai-chatkit>=1.0.2",
   "croniter>=2.0.0",
   "langgraph-checkpoint-sqlite>=2.0.7",
   "aiosqlite>=0.21.0",

--- a/src/orcheo/chatkit/__init__.py
+++ b/src/orcheo/chatkit/__init__.py
@@ -1,0 +1,7 @@
+"""ChatKit integration helpers for the Orcheo backend."""
+
+from .server import OrcheoChatKitServer
+from .store import InMemoryChatKitStore
+
+
+__all__ = ["OrcheoChatKitServer", "InMemoryChatKitStore"]

--- a/src/orcheo/chatkit/server.py
+++ b/src/orcheo/chatkit/server.py
@@ -1,0 +1,105 @@
+"""ChatKit server implementation backed by Orcheo services."""
+
+from __future__ import annotations
+from collections.abc import AsyncIterator, Iterable
+from datetime import datetime
+from chatkit.server import ChatKitServer
+from chatkit.types import (
+    AssistantMessageContent,
+    AssistantMessageItem,
+    ThreadItemDoneEvent,
+    ThreadMetadata,
+    ThreadStreamEvent,
+    UserMessageItem,
+)
+from orcheo_backend.app.repository import WorkflowRepository
+from .service import ChatTriggerService
+from .store import InMemoryChatKitStore
+
+
+class OrcheoChatKitServer(ChatKitServer[dict[str, object]]):
+    """ChatKit server that delegates chat messages to Orcheo workflows."""
+
+    def __init__(self) -> None:
+        """Initialise the ChatKit server with the in-memory store."""
+        super().__init__(InMemoryChatKitStore())
+
+    async def respond(
+        self,
+        thread: ThreadMetadata,
+        input_user_message: UserMessageItem | None,
+        context: dict[str, object],
+    ) -> AsyncIterator[ThreadStreamEvent]:
+        """Respond to the incoming chat message by delegating to Orcheo."""
+        if input_user_message is None:
+            return
+
+        message_text = self._extract_text(input_user_message.content)
+        if not message_text:
+            yield ThreadItemDoneEvent(
+                item=self._build_assistant_message(
+                    thread,
+                    "I wasn't able to read any text in that message.",
+                    context,
+                )
+            )
+            return
+
+        repository = self._resolve_repository(context)
+        request = context.get("request")
+        workflow_id = None
+        node_id = None
+        node_label = None
+
+        if request is not None:
+            headers = getattr(request, "headers", {})
+            workflow_id = headers.get("x-orcheo-chat-workflow-id")
+            node_id = headers.get("x-orcheo-chat-node-id")
+            node_label = headers.get("x-orcheo-chat-node-name")
+
+        if repository is None:
+            response = (
+                "I received your message but couldn't reach the workflow repository. "
+                "Try again once the server is fully initialised."
+            )
+        else:
+            service = ChatTriggerService(repository)
+            response = await service.handle_message(
+                message_text,
+                workflow_id=workflow_id,
+                node_id=node_id,
+                node_label=node_label,
+            )
+
+        yield ThreadItemDoneEvent(
+            item=self._build_assistant_message(thread, response, context)
+        )
+
+    def _build_assistant_message(
+        self,
+        thread: ThreadMetadata,
+        content: str,
+        context: dict[str, object],
+    ) -> AssistantMessageItem:
+        return AssistantMessageItem(
+            id=self.store.generate_item_id("message", thread, context),
+            thread_id=thread.id,
+            created_at=datetime.now(),
+            content=[AssistantMessageContent(text=content)],
+        )
+
+    @staticmethod
+    def _extract_text(parts: Iterable[object]) -> str:
+        texts: list[str] = []
+        for part in parts:
+            text = getattr(part, "text", None)
+            if isinstance(text, str) and text.strip():
+                texts.append(text.strip())
+        return " ".join(texts).strip()
+
+    @staticmethod
+    def _resolve_repository(context: dict[str, object]) -> WorkflowRepository | None:
+        repository = context.get("repository")
+        if isinstance(repository, WorkflowRepository):
+            return repository
+        return None

--- a/src/orcheo/chatkit/service.py
+++ b/src/orcheo/chatkit/service.py
@@ -1,0 +1,120 @@
+"""Utilities for orchestrating ChatKit-triggered workflow runs."""
+
+from __future__ import annotations
+import logging
+from textwrap import shorten
+from typing import Any
+from uuid import UUID
+from orcheo.triggers.manual import ManualDispatchItem, ManualDispatchRequest
+from orcheo_backend.app.repository import (
+    WorkflowNotFoundError,
+    WorkflowRepository,
+    WorkflowVersionNotFoundError,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ChatTriggerService:
+    """Bridge between ChatKit conversations and Orcheo workflows."""
+
+    def __init__(self, repository: WorkflowRepository) -> None:
+        """Store the workflow repository used for dispatching chat runs."""
+        self._repository = repository
+
+    async def handle_message(
+        self,
+        message: str,
+        *,
+        workflow_id: str | None,
+        node_id: str | None,
+        node_label: str | None,
+    ) -> str:
+        """Dispatch the incoming chat message to a workflow when possible."""
+        stripped = message.strip()
+        if not stripped:
+            return "I didn't receive any text to route to the workflow."
+
+        context: dict[str, Any] = {
+            "chat_message": stripped,
+            "chat_node_id": node_id,
+            "chat_node_label": node_label,
+        }
+
+        if not workflow_id:
+            return self._acknowledge_without_dispatch(context)
+
+        try:
+            workflow_uuid = UUID(workflow_id)
+        except ValueError:
+            LOGGER.info("Ignoring chat trigger with invalid workflow id", extra=context)
+            return self._acknowledge_without_dispatch(
+                context,
+                "The workflow identifier provided by the canvas isn't valid yet. "
+                "Save the workflow before testing the chat trigger.",
+            )
+
+        request = ManualDispatchRequest(
+            workflow_id=workflow_uuid,
+            actor="chatkit",
+            label="chat_trigger",
+            runs=[ManualDispatchItem(input_payload=context)],
+        )
+
+        response: str
+        try:
+            runs = await self._repository.dispatch_manual_runs(request)
+        except WorkflowNotFoundError:
+            LOGGER.warning("Chat trigger workflow not found", extra=context)
+            response = self._acknowledge_without_dispatch(
+                context,
+                "I couldn't find that workflow on the server. "
+                "Make sure it's been saved and published.",
+            )
+        except WorkflowVersionNotFoundError:
+            LOGGER.warning("Chat trigger workflow has no versions", extra=context)
+            response = self._acknowledge_without_dispatch(
+                context,
+                "The workflow doesn't have an active version yet. "
+                "Save a version before testing the chat trigger.",
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.exception("Chat trigger dispatch failed", extra=context)
+            response = self._acknowledge_without_dispatch(
+                context,
+                "Something went wrong while dispatching the workflow run. "
+                "Check the server logs for details.",
+            )
+        else:
+            if not runs:
+                LOGGER.info("Chat trigger dispatch returned no runs", extra=context)
+                response = self._acknowledge_without_dispatch(
+                    context,
+                    "The workflow repository didn't create a run for this request. "
+                    "Verify the workflow configuration and try again.",
+                )
+            else:
+                run = runs[0]
+                snippet = shorten(stripped, width=120, placeholder="…")
+                node_display = node_label or node_id or "chat trigger"
+                response = (
+                    f"Queued workflow run {run.id} from {node_display}. "
+                    f'Message excerpt: "{snippet}". '
+                    "Track progress from the execution history panel."
+                )
+
+        return response
+
+    @staticmethod
+    def _acknowledge_without_dispatch(
+        context: dict[str, Any],
+        problem: str | None = None,
+    ) -> str:
+        base = "I'll keep this message handy for when the workflow is ready."
+        if problem:
+            return f"{problem} {base}".strip()
+        node_display = context.get("chat_node_label") or context.get("chat_node_id")
+        if node_display:
+            return f"Message received for {node_display}. {base}"
+        return base

--- a/src/orcheo/chatkit/service.py
+++ b/src/orcheo/chatkit/service.py
@@ -96,15 +96,19 @@ class ChatTriggerService:
                 )
             else:
                 run = runs[0]
-                snippet = shorten(stripped, width=120, placeholder="…")
                 node_display = node_label or node_id or "chat trigger"
                 response = (
                     f"Queued workflow run {run.id} from {node_display}. "
-                    f'Message excerpt: "{snippet}". '
+                    f'Message excerpt: "{self._format_message_excerpt(stripped)}". '
                     "Track progress from the execution history panel."
                 )
 
         return response
+
+    @staticmethod
+    def _format_message_excerpt(message: str) -> str:
+        """Return a shortened representation of the user message."""
+        return shorten(message, width=120, placeholder="…")
 
     @staticmethod
     def _acknowledge_without_dispatch(

--- a/src/orcheo/chatkit/store.py
+++ b/src/orcheo/chatkit/store.py
@@ -1,0 +1,196 @@
+"""Lightweight in-memory store for ChatKit threads and messages."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from chatkit.store import NotFoundError, Store
+from chatkit.types import Attachment, Page, Thread, ThreadItem, ThreadMetadata
+
+
+@dataclass
+class _ThreadState:
+    """Runtime container for a thread and its stored items."""
+
+    thread: ThreadMetadata
+    items: list[ThreadItem]
+
+
+class InMemoryChatKitStore(Store[dict[str, Any]]):
+    """Simple in-memory :class:`~chatkit.store.Store` implementation.
+
+    The store keeps thread metadata and items in dictionaries so the
+    ChatKit server can satisfy queries from the Orcheo backend without an
+    external persistence layer. It is intentionally minimal and does not
+    support attachment storage.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the in-memory structures for ChatKit conversations."""
+        self._threads: dict[str, _ThreadState] = {}
+
+    @staticmethod
+    def _coerce_thread_metadata(thread: ThreadMetadata | Thread) -> ThreadMetadata:
+        """Return thread metadata without any embedded items."""
+        has_items = isinstance(thread, Thread) or "items" in getattr(
+            thread, "model_fields_set", set()
+        )
+        if not has_items:
+            return thread.model_copy(deep=True)
+
+        data = thread.model_dump()
+        data.pop("items", None)
+        return ThreadMetadata(**data).model_copy(deep=True)
+
+    async def load_thread(
+        self, thread_id: str, context: dict[str, Any]
+    ) -> ThreadMetadata:
+        """Return metadata for the given thread identifier."""
+        state = self._threads.get(thread_id)
+        if not state:
+            raise NotFoundError(f"Thread {thread_id} not found")
+        return self._coerce_thread_metadata(state.thread)
+
+    async def save_thread(
+        self, thread: ThreadMetadata, context: dict[str, Any]
+    ) -> None:
+        """Persist the provided thread metadata in-memory."""
+        metadata = self._coerce_thread_metadata(thread)
+        state = self._threads.get(thread.id)
+        if state:
+            state.thread = metadata
+        else:
+            self._threads[thread.id] = _ThreadState(thread=metadata, items=[])
+
+    async def load_threads(
+        self,
+        limit: int,
+        after: str | None,
+        order: str,
+        context: dict[str, Any],
+    ) -> Page[ThreadMetadata]:
+        """Return a paginated list of stored thread metadata."""
+        threads = sorted(
+            (
+                self._coerce_thread_metadata(state.thread)
+                for state in self._threads.values()
+            ),
+            key=lambda thread: thread.created_at or datetime.min,
+            reverse=(order == "desc"),
+        )
+
+        if after:
+            index_map = {thread.id: idx for idx, thread in enumerate(threads)}
+            start = index_map.get(after, -1) + 1
+        else:
+            start = 0
+
+        slice_threads = threads[start : start + limit + 1]
+        has_more = len(slice_threads) > limit
+        slice_threads = slice_threads[:limit]
+        next_after = slice_threads[-1].id if has_more and slice_threads else None
+        return Page(data=slice_threads, has_more=has_more, after=next_after)
+
+    async def delete_thread(self, thread_id: str, context: dict[str, Any]) -> None:
+        """Remove the thread from the in-memory index if present."""
+        self._threads.pop(thread_id, None)
+
+    # -- Thread items -------------------------------------------------
+    def _items(self, thread_id: str) -> list[ThreadItem]:
+        state = self._threads.get(thread_id)
+        if state is None:
+            state = _ThreadState(
+                thread=ThreadMetadata(id=thread_id, created_at=datetime.utcnow()),
+                items=[],
+            )
+            self._threads[thread_id] = state
+        return state.items
+
+    async def load_thread_items(
+        self,
+        thread_id: str,
+        after: str | None,
+        limit: int,
+        order: str,
+        context: dict[str, Any],
+    ) -> Page[ThreadItem]:
+        """Return a paginated set of thread items for a conversation."""
+        items = [item.model_copy(deep=True) for item in self._items(thread_id)]
+        items.sort(
+            key=lambda item: getattr(item, "created_at", datetime.utcnow()),
+            reverse=(order == "desc"),
+        )
+
+        if after:
+            index_map = {item.id: idx for idx, item in enumerate(items)}
+            start = index_map.get(after, -1) + 1
+        else:
+            start = 0
+
+        slice_items = items[start : start + limit + 1]
+        has_more = len(slice_items) > limit
+        slice_items = slice_items[:limit]
+        next_after = slice_items[-1].id if has_more and slice_items else None
+        return Page(data=slice_items, has_more=has_more, after=next_after)
+
+    async def add_thread_item(
+        self, thread_id: str, item: ThreadItem, context: dict[str, Any]
+    ) -> None:
+        """Append a new item to the specified thread."""
+        self._items(thread_id).append(item.model_copy(deep=True))
+
+    async def save_item(
+        self, thread_id: str, item: ThreadItem, context: dict[str, Any]
+    ) -> None:
+        """Insert or update a thread item in the in-memory store."""
+        items = self._items(thread_id)
+        for index, existing in enumerate(items):
+            if existing.id == item.id:
+                items[index] = item.model_copy(deep=True)
+                return
+        items.append(item.model_copy(deep=True))
+
+    async def load_item(
+        self, thread_id: str, item_id: str, context: dict[str, Any]
+    ) -> ThreadItem:
+        """Fetch a thread item by identifier."""
+        for item in self._items(thread_id):
+            if item.id == item_id:
+                return item.model_copy(deep=True)
+        raise NotFoundError(f"Item {item_id} not found")
+
+    async def delete_thread_item(
+        self, thread_id: str, item_id: str, context: dict[str, Any]
+    ) -> None:
+        """Delete an item from the conversation if it exists."""
+        items = self._items(thread_id)
+        self._threads[thread_id].items = [item for item in items if item.id != item_id]
+
+    # -- Attachments --------------------------------------------------
+    async def save_attachment(
+        self,
+        attachment: Attachment,
+        context: dict[str, Any],
+    ) -> None:
+        """Raise because attachments require external storage."""
+        raise NotImplementedError(
+            "In-memory store does not persist attachments. "
+            "Provide a secure store implementation before enabling uploads."
+        )
+
+    async def load_attachment(
+        self, attachment_id: str, context: dict[str, Any]
+    ) -> Attachment:
+        """Raise because attachments are not stored locally."""
+        raise NotImplementedError(
+            "In-memory store does not load attachments because they are not persisted."
+        )
+
+    async def delete_attachment(
+        self, attachment_id: str, context: dict[str, Any]
+    ) -> None:
+        """Raise because attachment deletion is unsupported."""
+        raise NotImplementedError(
+            "In-memory store does not delete attachments because they are not "
+            "persisted."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -944,37 +944,70 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.9.0"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/c2/e4562507f52f0af7036da125bb699602ead37a2332af0788f8e0a3417f36/jiter-0.9.0.tar.gz", hash = "sha256:aadba0964deb424daa24492abc3d229c60c4a31bfee205aedbf1acc7639d7893", size = 162604, upload-time = "2025-03-10T21:37:03.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/68/0357982493a7b20925aece061f7fb7a2678e3b232f8d73a6edb7e5304443/jiter-0.11.1.tar.gz", hash = "sha256:849dcfc76481c0ea0099391235b7ca97d7279e0fa4c86005457ac7c88e8b76dc", size = 168385, upload-time = "2025-10-17T11:31:15.186Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/d7/c55086103d6f29b694ec79156242304adf521577530d9031317ce5338c59/jiter-0.9.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:7b46249cfd6c48da28f89eb0be3f52d6fdb40ab88e2c66804f546674e539ec11", size = 309203, upload-time = "2025-03-10T21:35:44.852Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/01/f775dfee50beb420adfd6baf58d1c4d437de41c9b666ddf127c065e5a488/jiter-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:609cf3c78852f1189894383cf0b0b977665f54cb38788e3e6b941fa6d982c00e", size = 319678, upload-time = "2025-03-10T21:35:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b8/09b73a793714726893e5d46d5c534a63709261af3d24444ad07885ce87cb/jiter-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d726a3890a54561e55a9c5faea1f7655eda7f105bd165067575ace6e65f80bb2", size = 341816, upload-time = "2025-03-10T21:35:47.856Z" },
-    { url = "https://files.pythonhosted.org/packages/35/6f/b8f89ec5398b2b0d344257138182cc090302854ed63ed9c9051e9c673441/jiter-0.9.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2e89dc075c1fef8fa9be219e249f14040270dbc507df4215c324a1839522ea75", size = 364152, upload-time = "2025-03-10T21:35:49.397Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ca/978cc3183113b8e4484cc7e210a9ad3c6614396e7abd5407ea8aa1458eef/jiter-0.9.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04e8ffa3c353b1bc4134f96f167a2082494351e42888dfcf06e944f2729cbe1d", size = 406991, upload-time = "2025-03-10T21:35:50.745Z" },
-    { url = "https://files.pythonhosted.org/packages/13/3a/72861883e11a36d6aa314b4922125f6ae90bdccc225cd96d24cc78a66385/jiter-0.9.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:203f28a72a05ae0e129b3ed1f75f56bc419d5f91dfacd057519a8bd137b00c42", size = 395824, upload-time = "2025-03-10T21:35:52.162Z" },
-    { url = "https://files.pythonhosted.org/packages/87/67/22728a86ef53589c3720225778f7c5fdb617080e3deaed58b04789418212/jiter-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fca1a02ad60ec30bb230f65bc01f611c8608b02d269f998bc29cca8619a919dc", size = 351318, upload-time = "2025-03-10T21:35:53.566Z" },
-    { url = "https://files.pythonhosted.org/packages/69/b9/f39728e2e2007276806d7a6609cda7fac44ffa28ca0d02c49a4f397cc0d9/jiter-0.9.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:237e5cee4d5d2659aaf91bbf8ec45052cc217d9446070699441a91b386ae27dc", size = 384591, upload-time = "2025-03-10T21:35:54.95Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/8f/8a708bc7fd87b8a5d861f1c118a995eccbe6d672fe10c9753e67362d0dd0/jiter-0.9.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:528b6b71745e7326eed73c53d4aa57e2a522242320b6f7d65b9c5af83cf49b6e", size = 520746, upload-time = "2025-03-10T21:35:56.444Z" },
-    { url = "https://files.pythonhosted.org/packages/95/1e/65680c7488bd2365dbd2980adaf63c562d3d41d3faac192ebc7ef5b4ae25/jiter-0.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9f48e86b57bc711eb5acdfd12b6cb580a59cc9a993f6e7dcb6d8b50522dcd50d", size = 512754, upload-time = "2025-03-10T21:35:58.789Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f3/fdc43547a9ee6e93c837685da704fb6da7dba311fc022e2766d5277dfde5/jiter-0.9.0-cp312-cp312-win32.whl", hash = "sha256:699edfde481e191d81f9cf6d2211debbfe4bd92f06410e7637dffb8dd5dfde06", size = 207075, upload-time = "2025-03-10T21:36:00.616Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/9d/742b289016d155f49028fe1bfbeb935c9bf0ffeefdf77daf4a63a42bb72b/jiter-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:099500d07b43f61d8bd780466d429c45a7b25411b334c60ca875fa775f68ccb0", size = 207999, upload-time = "2025-03-10T21:36:02.366Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/1b/4cd165c362e8f2f520fdb43245e2b414f42a255921248b4f8b9c8d871ff1/jiter-0.9.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:2764891d3f3e8b18dce2cff24949153ee30c9239da7c00f032511091ba688ff7", size = 308197, upload-time = "2025-03-10T21:36:03.828Z" },
-    { url = "https://files.pythonhosted.org/packages/13/aa/7a890dfe29c84c9a82064a9fe36079c7c0309c91b70c380dc138f9bea44a/jiter-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:387b22fbfd7a62418d5212b4638026d01723761c75c1c8232a8b8c37c2f1003b", size = 318160, upload-time = "2025-03-10T21:36:05.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/38/5888b43fc01102f733f085673c4f0be5a298f69808ec63de55051754e390/jiter-0.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d8da8629ccae3606c61d9184970423655fb4e33d03330bcdfe52d234d32f69", size = 341259, upload-time = "2025-03-10T21:36:06.716Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/5e/bbdbb63305bcc01006de683b6228cd061458b9b7bb9b8d9bc348a58e5dc2/jiter-0.9.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1be73d8982bdc278b7b9377426a4b44ceb5c7952073dd7488e4ae96b88e1103", size = 363730, upload-time = "2025-03-10T21:36:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/75/85/53a3edc616992fe4af6814c25f91ee3b1e22f7678e979b6ea82d3bc0667e/jiter-0.9.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2228eaaaa111ec54b9e89f7481bffb3972e9059301a878d085b2b449fbbde635", size = 405126, upload-time = "2025-03-10T21:36:10.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b3/1ee26b12b2693bd3f0b71d3188e4e5d817b12e3c630a09e099e0a89e28fa/jiter-0.9.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:11509bfecbc319459647d4ac3fd391d26fdf530dad00c13c4dadabf5b81f01a4", size = 393668, upload-time = "2025-03-10T21:36:12.468Z" },
-    { url = "https://files.pythonhosted.org/packages/11/87/e084ce261950c1861773ab534d49127d1517b629478304d328493f980791/jiter-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f22238da568be8bbd8e0650e12feeb2cfea15eda4f9fc271d3b362a4fa0604d", size = 352350, upload-time = "2025-03-10T21:36:14.148Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/06/7dca84b04987e9df563610aa0bc154ea176e50358af532ab40ffb87434df/jiter-0.9.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:17f5d55eb856597607562257c8e36c42bc87f16bef52ef7129b7da11afc779f3", size = 384204, upload-time = "2025-03-10T21:36:15.545Z" },
-    { url = "https://files.pythonhosted.org/packages/16/2f/82e1c6020db72f397dd070eec0c85ebc4df7c88967bc86d3ce9864148f28/jiter-0.9.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6a99bed9fbb02f5bed416d137944419a69aa4c423e44189bc49718859ea83bc5", size = 520322, upload-time = "2025-03-10T21:36:17.016Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fd/4f0cd3abe83ce208991ca61e7e5df915aa35b67f1c0633eb7cf2f2e88ec7/jiter-0.9.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e057adb0cd1bd39606100be0eafe742de2de88c79df632955b9ab53a086b3c8d", size = 512184, upload-time = "2025-03-10T21:36:18.47Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/3c/8a56f6d547731a0b4410a2d9d16bf39c861046f91f57c98f7cab3d2aa9ce/jiter-0.9.0-cp313-cp313-win32.whl", hash = "sha256:f7e6850991f3940f62d387ccfa54d1a92bd4bb9f89690b53aea36b4364bcab53", size = 206504, upload-time = "2025-03-10T21:36:19.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1c/0c996fd90639acda75ed7fa698ee5fd7d80243057185dc2f63d4c1c9f6b9/jiter-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:c8ae3bf27cd1ac5e6e8b7a27487bf3ab5f82318211ec2e1346a5b058756361f7", size = 204943, upload-time = "2025-03-10T21:36:21.536Z" },
-    { url = "https://files.pythonhosted.org/packages/78/0f/77a63ca7aa5fed9a1b9135af57e190d905bcd3702b36aca46a01090d39ad/jiter-0.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f0b2827fb88dda2cbecbbc3e596ef08d69bda06c6f57930aec8e79505dc17001", size = 317281, upload-time = "2025-03-10T21:36:22.959Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/39/a3a1571712c2bf6ec4c657f0d66da114a63a2e32b7e4eb8e0b83295ee034/jiter-0.9.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:062b756ceb1d40b0b28f326cba26cfd575a4918415b036464a52f08632731e5a", size = 350273, upload-time = "2025-03-10T21:36:24.414Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/47/3729f00f35a696e68da15d64eb9283c330e776f3b5789bac7f2c0c4df209/jiter-0.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6f7838bc467ab7e8ef9f387bd6de195c43bad82a569c1699cb822f6609dd4cdf", size = 206867, upload-time = "2025-03-10T21:36:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8b/318e8af2c904a9d29af91f78c1e18f0592e189bbdb8a462902d31fe20682/jiter-0.11.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c92148eec91052538ce6823dfca9525f5cfc8b622d7f07e9891a280f61b8c96c", size = 305655, upload-time = "2025-10-17T11:29:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/29/6c7de6b5d6e511d9e736312c0c9bfcee8f9b6bef68182a08b1d78767e627/jiter-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ecd4da91b5415f183a6be8f7158d127bdd9e6a3174138293c0d48d6ea2f2009d", size = 315645, upload-time = "2025-10-17T11:29:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5f/ef9e5675511ee0eb7f98dd8c90509e1f7743dbb7c350071acae87b0145f3/jiter-0.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7e3ac25c00b9275684d47aa42febaa90a9958e19fd1726c4ecf755fbe5e553b", size = 348003, upload-time = "2025-10-17T11:29:22.712Z" },
+    { url = "https://files.pythonhosted.org/packages/56/1b/abe8c4021010b0a320d3c62682769b700fb66f92c6db02d1a1381b3db025/jiter-0.11.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57d7305c0a841858f866cd459cd9303f73883fb5e097257f3d4a3920722c69d4", size = 365122, upload-time = "2025-10-17T11:29:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2d/4a18013939a4f24432f805fbd5a19893e64650b933edb057cd405275a538/jiter-0.11.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e86fa10e117dce22c547f31dd6d2a9a222707d54853d8de4e9a2279d2c97f239", size = 488360, upload-time = "2025-10-17T11:29:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/77/38124f5d02ac4131f0dfbcfd1a19a0fac305fa2c005bc4f9f0736914a1a4/jiter-0.11.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae5ef1d48aec7e01ee8420155d901bb1d192998fa811a65ebb82c043ee186711", size = 376884, upload-time = "2025-10-17T11:29:27.056Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/43/59fdc2f6267959b71dd23ce0bd8d4aeaf55566aa435a5d00f53d53c7eb24/jiter-0.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb68e7bf65c990531ad8715e57d50195daf7c8e6f1509e617b4e692af1108939", size = 358827, upload-time = "2025-10-17T11:29:28.698Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d0/b3cc20ff5340775ea3bbaa0d665518eddecd4266ba7244c9cb480c0c82ec/jiter-0.11.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:43b30c8154ded5845fa454ef954ee67bfccce629b2dea7d01f795b42bc2bda54", size = 385171, upload-time = "2025-10-17T11:29:30.078Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bc/94dd1f3a61f4dc236f787a097360ec061ceeebebf4ea120b924d91391b10/jiter-0.11.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:586cafbd9dd1f3ce6a22b4a085eaa6be578e47ba9b18e198d4333e598a91db2d", size = 518359, upload-time = "2025-10-17T11:29:31.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/12ee132bd67e25c75f542c227f5762491b9a316b0dad8e929c95076f773c/jiter-0.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:677cc2517d437a83bb30019fd4cf7cad74b465914c56ecac3440d597ac135250", size = 509205, upload-time = "2025-10-17T11:29:32.895Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d5/9de848928ce341d463c7e7273fce90ea6d0ea4343cd761f451860fa16b59/jiter-0.11.1-cp312-cp312-win32.whl", hash = "sha256:fa992af648fcee2b850a3286a35f62bbbaeddbb6dbda19a00d8fbc846a947b6e", size = 205448, upload-time = "2025-10-17T11:29:34.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b0/8002d78637e05009f5e3fb5288f9d57d65715c33b5d6aa20fd57670feef5/jiter-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88b5cae9fa51efeb3d4bd4e52bfd4c85ccc9cac44282e2a9640893a042ba4d87", size = 204285, upload-time = "2025-10-17T11:29:35.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a2/bb24d5587e4dff17ff796716542f663deee337358006a80c8af43ddc11e5/jiter-0.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:9a6cae1ab335551917f882f2c3c1efe7617b71b4c02381e4382a8fc80a02588c", size = 188712, upload-time = "2025-10-17T11:29:37.027Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4b/e4dd3c76424fad02a601d570f4f2a8438daea47ba081201a721a903d3f4c/jiter-0.11.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:71b6a920a5550f057d49d0e8bcc60945a8da998019e83f01adf110e226267663", size = 305272, upload-time = "2025-10-17T11:29:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/67/83/2cd3ad5364191130f4de80eacc907f693723beaab11a46c7d155b07a092c/jiter-0.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b3de72e925388453a5171be83379549300db01284f04d2a6f244d1d8de36f94", size = 314038, upload-time = "2025-10-17T11:29:40.563Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3c/8e67d9ba524e97d2f04c8f406f8769a23205026b13b0938d16646d6e2d3e/jiter-0.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc19dd65a2bd3d9c044c5b4ebf657ca1e6003a97c0fc10f555aa4f7fb9821c00", size = 345977, upload-time = "2025-10-17T11:29:42.009Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/489ce64d992c29bccbffabb13961bbb0435e890d7f2d266d1f3df5e917d2/jiter-0.11.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d58faaa936743cd1464540562f60b7ce4fd927e695e8bc31b3da5b914baa9abd", size = 364503, upload-time = "2025-10-17T11:29:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c0/e321dd83ee231d05c8fe4b1a12caf1f0e8c7a949bf4724d58397104f10f2/jiter-0.11.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:902640c3103625317291cb73773413b4d71847cdf9383ba65528745ff89f1d14", size = 487092, upload-time = "2025-10-17T11:29:44.835Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/8f24ec49c8d37bd37f34ec0112e0b1a3b4b5a7b456c8efff1df5e189ad43/jiter-0.11.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30405f726e4c2ed487b176c09f8b877a957f535d60c1bf194abb8dadedb5836f", size = 376328, upload-time = "2025-10-17T11:29:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/70/ded107620e809327cf7050727e17ccfa79d6385a771b7fe38fb31318ef00/jiter-0.11.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3217f61728b0baadd2551844870f65219ac4a1285d5e1a4abddff3d51fdabe96", size = 356632, upload-time = "2025-10-17T11:29:47.454Z" },
+    { url = "https://files.pythonhosted.org/packages/19/53/c26f7251613f6a9079275ee43c89b8a973a95ff27532c421abc2a87afb04/jiter-0.11.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1364cc90c03a8196f35f396f84029f12abe925415049204446db86598c8b72c", size = 384358, upload-time = "2025-10-17T11:29:49.377Z" },
+    { url = "https://files.pythonhosted.org/packages/84/16/e0f2cc61e9c4d0b62f6c1bd9b9781d878a427656f88293e2a5335fa8ff07/jiter-0.11.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:53a54bf8e873820ab186b2dca9f6c3303f00d65ae5e7b7d6bda1b95aa472d646", size = 517279, upload-time = "2025-10-17T11:29:50.968Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/4cd095eaee68961bca3081acbe7c89e12ae24a5dae5fd5d2a13e01ed2542/jiter-0.11.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7e29aca023627b0e0c2392d4248f6414d566ff3974fa08ff2ac8dbb96dfee92a", size = 508276, upload-time = "2025-10-17T11:29:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/25/f459240e69b0e09a7706d96ce203ad615ca36b0fe832308d2b7123abf2d0/jiter-0.11.1-cp313-cp313-win32.whl", hash = "sha256:f153e31d8bca11363751e875c0a70b3d25160ecbaee7b51e457f14498fb39d8b", size = 205593, upload-time = "2025-10-17T11:29:53.938Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/16/461bafe22bae79bab74e217a09c907481a46d520c36b7b9fe71ee8c9e983/jiter-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:f773f84080b667c69c4ea0403fc67bb08b07e2b7ce1ef335dea5868451e60fed", size = 203518, upload-time = "2025-10-17T11:29:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/72/c45de6e320edb4fa165b7b1a414193b3cae302dd82da2169d315dcc78b44/jiter-0.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:635ecd45c04e4c340d2187bcb1cea204c7cc9d32c1364d251564bf42e0e39c2d", size = 188062, upload-time = "2025-10-17T11:29:56.631Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/4a57922437ca8753ef823f434c2dec5028b237d84fa320f06a3ba1aec6e8/jiter-0.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d892b184da4d94d94ddb4031296931c74ec8b325513a541ebfd6dfb9ae89904b", size = 313814, upload-time = "2025-10-17T11:29:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/76/50/62a0683dadca25490a4bedc6a88d59de9af2a3406dd5a576009a73a1d392/jiter-0.11.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa22c223a3041dacb2fcd37c70dfd648b44662b4a48e242592f95bda5ab09d58", size = 344987, upload-time = "2025-10-17T11:30:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/da/00/2355dbfcbf6cdeaddfdca18287f0f38ae49446bb6378e4a5971e9356fc8a/jiter-0.11.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:330e8e6a11ad4980cd66a0f4a3e0e2e0f646c911ce047014f984841924729789", size = 356399, upload-time = "2025-10-17T11:30:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/07/c2bd748d578fa933d894a55bff33f983bc27f75fc4e491b354bef7b78012/jiter-0.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:09e2e386ebf298547ca3a3704b729471f7ec666c2906c5c26c1a915ea24741ec", size = 203289, upload-time = "2025-10-17T11:30:03.656Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ee/ace64a853a1acbd318eb0ca167bad1cf5ee037207504b83a868a5849747b/jiter-0.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:fe4a431c291157e11cee7c34627990ea75e8d153894365a3bc84b7a959d23ca8", size = 188284, upload-time = "2025-10-17T11:30:05.046Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/00/d6006d069e7b076e4c66af90656b63da9481954f290d5eca8c715f4bf125/jiter-0.11.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:0fa1f70da7a8a9713ff8e5f75ec3f90c0c870be6d526aa95e7c906f6a1c8c676", size = 304624, upload-time = "2025-10-17T11:30:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/45/4a0e31eb996b9ccfddbae4d3017b46f358a599ccf2e19fbffa5e531bd304/jiter-0.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:569ee559e5046a42feb6828c55307cf20fe43308e3ae0d8e9e4f8d8634d99944", size = 315042, upload-time = "2025-10-17T11:30:08.87Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/91/22f5746f5159a28c76acdc0778801f3c1181799aab196dbea2d29e064968/jiter-0.11.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f69955fa1d92e81987f092b233f0be49d4c937da107b7f7dcf56306f1d3fcce9", size = 346357, upload-time = "2025-10-17T11:30:10.222Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4f/57620857d4e1dc75c8ff4856c90cb6c135e61bff9b4ebfb5dc86814e82d7/jiter-0.11.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:090f4c9d4a825e0fcbd0a2647c9a88a0f366b75654d982d95a9590745ff0c48d", size = 365057, upload-time = "2025-10-17T11:30:11.585Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/34/caf7f9cc8ae0a5bb25a5440cc76c7452d264d1b36701b90fdadd28fe08ec/jiter-0.11.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bbf3d8cedf9e9d825233e0dcac28ff15c47b7c5512fdfe2e25fd5bbb6e6b0cee", size = 487086, upload-time = "2025-10-17T11:30:13.052Z" },
+    { url = "https://files.pythonhosted.org/packages/50/17/85b5857c329d533d433fedf98804ebec696004a1f88cabad202b2ddc55cf/jiter-0.11.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2aa9b1958f9c30d3d1a558b75f0626733c60eb9b7774a86b34d88060be1e67fe", size = 376083, upload-time = "2025-10-17T11:30:14.416Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d3/2d9f973f828226e6faebdef034097a2918077ea776fb4d88489949024787/jiter-0.11.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42d1ca16590b768c5e7d723055acd2633908baacb3628dd430842e2e035aa90", size = 357825, upload-time = "2025-10-17T11:30:15.765Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/55/848d4dabf2c2c236a05468c315c2cb9dc736c5915e65449ccecdba22fb6f/jiter-0.11.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5db4c2486a023820b701a17aec9c5a6173c5ba4393f26662f032f2de9c848b0f", size = 383933, upload-time = "2025-10-17T11:30:17.34Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6c/204c95a4fbb0e26dfa7776c8ef4a878d0c0b215868011cc904bf44f707e2/jiter-0.11.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:4573b78777ccfac954859a6eff45cbd9d281d80c8af049d0f1a3d9fc323d5c3a", size = 517118, upload-time = "2025-10-17T11:30:18.684Z" },
+    { url = "https://files.pythonhosted.org/packages/88/25/09956644ea5a2b1e7a2a0f665cb69a973b28f4621fa61fc0c0f06ff40a31/jiter-0.11.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7593ac6f40831d7961cb67633c39b9fef6689a211d7919e958f45710504f52d3", size = 508194, upload-time = "2025-10-17T11:30:20.719Z" },
+    { url = "https://files.pythonhosted.org/packages/09/49/4d1657355d7f5c9e783083a03a3f07d5858efa6916a7d9634d07db1c23bd/jiter-0.11.1-cp314-cp314-win32.whl", hash = "sha256:87202ec6ff9626ff5f9351507def98fcf0df60e9a146308e8ab221432228f4ea", size = 203961, upload-time = "2025-10-17T11:30:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bd/f063bd5cc2712e7ca3cf6beda50894418fc0cfeb3f6ff45a12d87af25996/jiter-0.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:a5dd268f6531a182c89d0dd9a3f8848e86e92dfff4201b77a18e6b98aa59798c", size = 202804, upload-time = "2025-10-17T11:30:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ca/4d84193dfafef1020bf0bedd5e1a8d0e89cb67c54b8519040effc694964b/jiter-0.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:5d761f863f912a44748a21b5c4979c04252588ded8d1d2760976d2e42cd8d991", size = 188001, upload-time = "2025-10-17T11:30:24.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/3b05e5c9d32efc770a8510eeb0b071c42ae93a5b576fd91cee9af91689a1/jiter-0.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2cc5a3965285ddc33e0cab933e96b640bc9ba5940cea27ebbbf6695e72d6511c", size = 312561, upload-time = "2025-10-17T11:30:26.742Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/335822eb216154ddb79a130cbdce88fdf5c3e2b43dc5dba1fd95c485aaf5/jiter-0.11.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b572b3636a784c2768b2342f36a23078c8d3aa6d8a30745398b1bab58a6f1a8", size = 344551, upload-time = "2025-10-17T11:30:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6d/a0bed13676b1398f9b3ba61f32569f20a3ff270291161100956a577b2dd3/jiter-0.11.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad93e3d67a981f96596d65d2298fe8d1aa649deb5374a2fb6a434410ee11915e", size = 363051, upload-time = "2025-10-17T11:30:30.009Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/03/313eda04aa08545a5a04ed5876e52f49ab76a4d98e54578896ca3e16313e/jiter-0.11.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a83097ce379e202dcc3fe3fc71a16d523d1ee9192c8e4e854158f96b3efe3f2f", size = 485897, upload-time = "2025-10-17T11:30:31.429Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/a1011b9d325e40b53b1b96a17c010b8646013417f3902f97a86325b19299/jiter-0.11.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7042c51e7fbeca65631eb0c332f90c0c082eab04334e7ccc28a8588e8e2804d9", size = 375224, upload-time = "2025-10-17T11:30:33.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/da/1b45026b19dd39b419e917165ff0ea629dbb95f374a3a13d2df95e40a6ac/jiter-0.11.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a68d679c0e47649a61df591660507608adc2652442de7ec8276538ac46abe08", size = 356606, upload-time = "2025-10-17T11:30:34.572Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9acb0e54d6a8ba59ce923a180ebe824b4e00e80e56cefde86cc8e0a948be/jiter-0.11.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a1b0da75dbf4b6ec0b3c9e604d1ee8beaf15bc046fff7180f7d89e3cdbd3bb51", size = 384003, upload-time = "2025-10-17T11:30:35.987Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2b/e5a5fe09d6da2145e4eed651e2ce37f3c0cf8016e48b1d302e21fb1628b7/jiter-0.11.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:69dd514bf0fa31c62147d6002e5ca2b3e7ef5894f5ac6f0a19752385f4e89437", size = 516946, upload-time = "2025-10-17T11:30:37.425Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fe/db936e16e0228d48eb81f9934e8327e9fde5185e84f02174fcd22a01be87/jiter-0.11.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:bb31ac0b339efa24c0ca606febd8b77ef11c58d09af1b5f2be4c99e907b11111", size = 507614, upload-time = "2025-10-17T11:30:38.977Z" },
+    { url = "https://files.pythonhosted.org/packages/86/db/c4438e8febfb303486d13c6b72f5eb71cf851e300a0c1f0b4140018dd31f/jiter-0.11.1-cp314-cp314t-win32.whl", hash = "sha256:b2ce0d6156a1d3ad41da3eec63b17e03e296b78b0e0da660876fccfada86d2f7", size = 204043, upload-time = "2025-10-17T11:30:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/36/59/81badb169212f30f47f817dfaabf965bc9b8204fed906fab58104ee541f9/jiter-0.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f4db07d127b54c4a2d43b4cf05ff0193e4f73e0dd90c74037e16df0b29f666e1", size = 204046, upload-time = "2025-10-17T11:30:41.692Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/01/43f7b4eb61db3e565574c4c5714685d042fb652f9eef7e5a3de6aafa943a/jiter-0.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:28e4fdf2d7ebfc935523e50d1efa3970043cfaa161674fe66f9642409d001dfe", size = 188069, upload-time = "2025-10-17T11:30:43.23Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/bc/950dd7f170c6394b6fdd73f989d9e729bd98907bcc4430ef080a72d06b77/jiter-0.11.1-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:0d4d6993edc83cf75e8c6828a8d6ce40a09ee87e38c7bfba6924f39e1337e21d", size = 302626, upload-time = "2025-10-17T11:31:09.645Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/65/43d7971ca82ee100b7b9b520573eeef7eabc0a45d490168ebb9a9b5bb8b2/jiter-0.11.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f78d151c83a87a6cf5461d5ee55bc730dd9ae227377ac6f115b922989b95f838", size = 297034, upload-time = "2025-10-17T11:31:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/000e1e0c0c67e96557a279f8969487ea2732d6c7311698819f977abae837/jiter-0.11.1-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9022974781155cd5521d5cb10997a03ee5e31e8454c9d999dcdccd253f2353f", size = 337328, upload-time = "2025-10-17T11:31:12.399Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/71/71408b02c6133153336d29fa3ba53000f1e1a3f78bb2fc2d1a1865d2e743/jiter-0.11.1-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18c77aaa9117510d5bdc6a946baf21b1f0cfa58ef04d31c8d016f206f2118960", size = 343697, upload-time = "2025-10-17T11:31:13.773Z" },
 ]
 
 [[package]]
@@ -1123,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.58"
+version = "0.3.79"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1134,9 +1167,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/9c/b430593bf98d55b966fb2f38fdd5f23e77ce07a63c84923ba6de1b2ffe76/langchain_core-0.3.58.tar.gz", hash = "sha256:6ee2282b02fa65bf4ee1afa869d431505536757ff2f1f9f0b432d8ca755d66c6", size = 557004, upload-time = "2025-05-02T16:54:48.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/99/f926495f467e0f43289f12e951655d267d1eddc1136c3cf4dd907794a9a7/langchain_core-0.3.79.tar.gz", hash = "sha256:024ba54a346dd9b13fb8b2342e0c83d0111e7f26fa01f545ada23ad772b55a60", size = 580895, upload-time = "2025-10-09T21:59:08.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/91/454a94275d323c0969e1f17a293cc87cb1398ab2d73f7db0a5de7883f2a9/langchain_core-0.3.58-py3-none-any.whl", hash = "sha256:266f90d2a079fe9510190ad3be88bd993baad43e6cee0f822a883767a4bfdd5b", size = 437550, upload-time = "2025-05-02T16:54:46.545Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/71/46b0efaf3fc6ad2c2bd600aef500f1cb2b7038a4042f58905805630dd29d/langchain_core-0.3.79-py3-none-any.whl", hash = "sha256:92045bfda3e741f8018e1356f83be203ec601561c6a7becfefe85be5ddc58fdb", size = 449779, upload-time = "2025-10-09T21:59:06.493Z" },
 ]
 
 [[package]]
@@ -1154,16 +1187,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.16"
+version = "0.3.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/fb/536562278d932c80e6a7143f46f14cc3006c0828d77c4cb6a69be112519c/langchain_openai-0.3.16.tar.gz", hash = "sha256:4e423e39d072f1432adc9430f2905fe635cc019f01ad1bdffa5ed8d0dda32149", size = 271031, upload-time = "2025-05-02T17:30:49.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/96/06d0d25a37e05a0ff2d918f0a4b0bf0732aed6a43b472b0b68426ce04ef8/langchain_openai-0.3.35.tar.gz", hash = "sha256:fa985fd041c3809da256a040c98e8a43e91c6d165b96dcfeb770d8bd457bf76f", size = 786635, upload-time = "2025-10-06T15:09:28.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/d0/bb39691e8ca3748668aa660920afc20e4c92231f3bca0cf85c62214171d3/langchain_openai-0.3.16-py3-none-any.whl", hash = "sha256:eae74a6758d38a26159c5fde5abf8ef313e6400efb01a08f12dd7410c9f4fd0f", size = 62758, upload-time = "2025-05-02T17:30:48.027Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d5/c90c5478215c20ee71d8feaf676f7ffd78d0568f8c98bd83f81ce7562ed7/langchain_openai-0.3.35-py3-none-any.whl", hash = "sha256:76d5707e6e81fd461d33964ad618bd326cb661a1975cef7c1cb0703576bdada5", size = 75952, upload-time = "2025-10-06T15:09:27.137Z" },
 ]
 
 [[package]]
@@ -1264,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.3.42"
+version = "0.3.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1275,9 +1308,9 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/44/fe171c0b0fb0377b191aebf0b7779e0c7b2a53693c6a01ddad737212495d/langsmith-0.3.42.tar.gz", hash = "sha256:2b5cbc450ab808b992362aac6943bb1d285579aa68a3a8be901d30a393458f25", size = 345619, upload-time = "2025-05-03T03:07:17.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/86/b941012013260f95af2e90a3d9415af4a76a003a28412033fc4b09f35731/langsmith-0.3.45.tar.gz", hash = "sha256:1df3c6820c73ed210b2c7bc5cdb7bfa19ddc9126cd03fdf0da54e2e171e6094d", size = 348201, upload-time = "2025-06-05T05:10:28.948Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/8e/e8a58e0abaae3f3ac4702e9ca35d1fc6159711556b64ffd0e247771a3f12/langsmith-0.3.42-py3-none-any.whl", hash = "sha256:18114327f3364385dae4026ebfd57d1c1cb46d8f80931098f0f10abe533475ff", size = 360334, upload-time = "2025-05-03T03:07:15.491Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f4/c206c0888f8a506404cb4f16ad89593bdc2f70cf00de26a1a0a7a76ad7a3/langsmith-0.3.45-py3-none-any.whl", hash = "sha256:5b55f0518601fa65f3bb6b1a3100379a96aa7b3ed5e9380581615ba9c65ed8ed", size = 363002, upload-time = "2025-06-05T05:10:27.228Z" },
 ]
 
 [[package]]
@@ -1779,7 +1812,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.77.0"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1791,9 +1824,42 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c0/ea2e9a78bf88404b97e7b708f0823b4699ab2ee3f5564425b8531a890a43/openai-1.77.0.tar.gz", hash = "sha256:897969f927f0068b8091b4b041d1f8175bcf124f7ea31bab418bf720971223bc", size = 435778, upload-time = "2025-05-02T19:17:27.971Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/c7/e42bcd89dfd47fec8a30b9e20f93e512efdbfbb3391b05bbb79a2fb295fa/openai-2.6.0.tar.gz", hash = "sha256:f119faf7fc07d7e558c1e7c32c873e241439b01bd7480418234291ee8c8f4b9d", size = 592904, upload-time = "2025-10-20T17:17:24.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/58/37ae3ca75936b824a0a5ca30491c968192007857319d6836764b548b9d9b/openai-1.77.0-py3-none-any.whl", hash = "sha256:07706e91eb71631234996989a8ea991d5ee56f0744ef694c961e0824d4f39218", size = 662031, upload-time = "2025-05-02T19:17:26.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0a/58e9dcd34abe273eaeac3807a8483073767b5609d01bb78ea2f048e515a0/openai-2.6.0-py3-none-any.whl", hash = "sha256:f33fa12070fe347b5787a7861c8dd397786a4a17e1c3186e239338dac7e2e743", size = 1005403, upload-time = "2025-10-20T17:17:22.091Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/2d/aad75797e1d88d655c6d0af2c387e49a222dae331c67d6e65f42abe99bea/openai_agents-0.4.0.tar.gz", hash = "sha256:428970f77ac377d165359cfedb98df395d872b2278ded6ef73f268ff2ee05122", size = 1921260, upload-time = "2025-10-17T23:22:19.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/4d/ddc1f3b331e7bd2bddb121328ae34063a3e9f75517eddc0cf3cc75e697cb/openai_agents-0.4.0-py3-none-any.whl", hash = "sha256:92e4221ba53257cddc9b77857a208949528b7ce2631145f32886e4755a96b36c", size = 214921, upload-time = "2025-10-17T23:22:17.279Z" },
+]
+
+[[package]]
+name = "openai-chatkit"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai" },
+    { name = "openai-agents" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/cc/cdbf0bdc633e5f5be109d15b1c2e840fe8303fd3e9548ac9dcf8ea427e70/openai_chatkit-1.0.2.tar.gz", hash = "sha256:a553114d232c51bda383cbf118370d3863530a936d674b9acfdba5ed0c7c0a9e", size = 49351, upload-time = "2025-10-09T21:29:20.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/01/31349758df071f8b4c35d455fb6187c5dd06b4cb3b7b060e6f6d47e1c154/openai_chatkit-1.0.2-py3-none-any.whl", hash = "sha256:ebe97eb95778ab3ca005b9f07640607c3ea0c2ba1b63157367c32a70d4e7f8c4", size = 35231, upload-time = "2025-10-09T21:29:19.267Z" },
 ]
 
 [[package]]
@@ -1829,6 +1895,7 @@ dependencies = [
     { name = "langgraph-checkpoint-sqlite" },
     { name = "mcp", extra = ["cli"] },
     { name = "openai" },
+    { name = "openai-chatkit" },
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dotenv" },
@@ -1879,6 +1946,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
     { name = "openai", specifier = ">=1.0.0" },
+    { name = "openai-chatkit", specifier = ">=1.0.2" },
     { name = "pydantic", specifier = ">=2.4.2" },
     { name = "pymongo", specifier = ">=4.13.2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- add an Orcheo ChatKit server/service/store and expose a `/api/chatkit` endpoint for streaming responses from workflows
- wire the Canvas chat interface, workflow canvas, and support page to use the OpenAI ChatKit widgets and headers
- add an embeddable HTML demo and dependency updates while marking the roadmap ChatKit milestone complete

## Testing
- make lint
- make test
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68f7bd910ec483278003b1f305229e06