### PR TITLE
Persist canvas workflows through the backend repository

### DIFF
--- a/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
+++ b/apps/canvas/src/features/workflow/components/nodes/workflow-node.tsx
@@ -85,6 +85,8 @@ const WorkflowNode = ({ data, selected }: NodeProps) => {
       "bg-amber-50 border-amber-200 dark:bg-amber-950/30 dark:border-amber-800/50",
     data: "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800/50",
     ai: "bg-indigo-50 border-indigo-200 dark:bg-indigo-950/30 dark:border-indigo-800/50",
+    python:
+      "bg-orange-50 border-orange-200 dark:bg-orange-950/30 dark:border-orange-800/50",
   } as const;
 
   const nodeColor =

--- a/apps/canvas/src/features/workflow/data/workflow-data.ts
+++ b/apps/canvas/src/features/workflow/data/workflow-data.ts
@@ -29,6 +29,7 @@ export interface Workflow {
   description?: string;
   createdAt: string;
   updatedAt: string;
+  sourceExample?: string;
   owner: {
     id: string;
     name: string;
@@ -44,296 +45,487 @@ export interface Workflow {
   edges: WorkflowEdge[];
 }
 
+const TEMPLATE_OWNER: Workflow["owner"] = {
+  id: "team-templates",
+  name: "Orcheo Templates",
+  avatar: "https://avatar.vercel.sh/templates",
+};
+
 export const SAMPLE_WORKFLOWS: Workflow[] = [
   {
-    id: "workflow-1",
-    name: "Customer Onboarding",
-    description: "Automates the customer onboarding process",
-    createdAt: "2023-10-15T10:30:00Z",
-    updatedAt: "2023-11-02T14:45:00Z",
-    owner: {
-      id: "user-1",
-      name: "Avery Chen",
-      avatar: "https://avatar.vercel.sh/avery",
-    },
-    tags: ["production", "customer", "automation", "template"],
+    id: "workflow-quickstart",
+    name: "Canvas Quickstart — Welcome Bot",
+    description:
+      "Greets a new teammate with a PythonCode node and saves the message to the canvas flow.",
+    createdAt: "2024-01-15T10:00:00Z",
+    updatedAt: "2024-03-04T15:30:00Z",
+    sourceExample: "examples/quickstart/canvas_welcome.json",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "quickstart", "canvas"],
     lastRun: {
       status: "success",
-      timestamp: "2023-11-05T09:15:00Z",
-      duration: 45.2,
+      timestamp: "2024-03-05T08:45:00Z",
+      duration: 3.1,
     },
     nodes: [
       {
-        id: "node-1",
-        type: "trigger",
-        position: { x: 100, y: 100 },
+        id: "start",
+        type: "start",
+        position: { x: 0, y: 0 },
         data: {
-          label: "New Customer Webhook",
-          description: "Triggered when a new customer is created in CRM",
-          status: "success",
+          label: "Start",
+          type: "start",
+          description: "Entry point for the welcome flow.",
         },
       },
       {
-        id: "node-2",
-        type: "api",
-        position: { x: 400, y: 100 },
-        data: {
-          label: "Fetch Customer Details",
-          description: "Get full customer information from CRM API",
-          status: "success",
-        },
-      },
-      {
-        id: "node-3",
+        id: "compose-welcome-message",
         type: "function",
-        position: { x: 700, y: 100 },
+        position: { x: 260, y: 0 },
         data: {
-          label: "Format Customer Data",
-          description: "Transform customer data for downstream systems",
-          status: "success",
+          label: "Compose welcome message",
+          type: "function",
+          description:
+            "PythonCode node returns a templated greeting for the new teammate.",
+          examplePath: "examples/quickstart/canvas_welcome.json",
         },
       },
       {
-        id: "node-4",
-        type: "api",
-        position: { x: 400, y: 300 },
+        id: "end",
+        type: "end",
+        position: { x: 520, y: 0 },
         data: {
-          label: "Create Account",
-          description: "Create customer account in billing system",
-          status: "success",
-        },
-      },
-      {
-        id: "node-5",
-        type: "api",
-        position: { x: 700, y: 300 },
-        data: {
-          label: "Send Welcome Email",
-          description: "Send personalized welcome email to customer",
-          status: "success",
+          label: "Finish",
+          type: "end",
+          description: "Flow completes after crafting the welcome message.",
         },
       },
     ],
-
     edges: [
       {
-        id: "edge-1-2",
-        source: "node-1",
-        target: "node-2",
-        animated: false,
+        id: "edge-start-compose",
+        source: "start",
+        target: "compose-welcome-message",
       },
       {
-        id: "edge-2-3",
-        source: "node-2",
-        target: "node-3",
-        animated: false,
-      },
-      {
-        id: "edge-3-4",
-        source: "node-3",
-        target: "node-4",
-        animated: false,
-      },
-      {
-        id: "edge-4-5",
-        source: "node-4",
-        target: "node-5",
-        animated: false,
+        id: "edge-compose-end",
+        source: "compose-welcome-message",
+        target: "end",
       },
     ],
   },
   {
-    id: "workflow-2",
-    name: "Data Sync Pipeline",
-    description: "Synchronizes data between systems",
-    createdAt: "2023-09-20T08:15:00Z",
-    updatedAt: "2023-11-01T11:30:00Z",
-    owner: {
-      id: "user-2",
-      name: "Sky Patel",
-      avatar: "https://avatar.vercel.sh/sky",
-    },
-    tags: ["data", "integration", "scheduled", "template"],
+    id: "workflow-python-hello",
+    name: "Simple Python Task",
+    description: "Runs a standalone PythonCode node and returns a greeting.",
+    createdAt: "2024-01-18T12:00:00Z",
+    updatedAt: "2024-03-10T09:15:00Z",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "python", "utility"],
+    nodes: [
+      {
+        id: "python-start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          type: "start",
+          description: "Kick off the simple Python workflow.",
+        },
+      },
+      {
+        id: "python-greet",
+        type: "Python",
+        position: { x: 260, y: 0 },
+        data: {
+          label: "Run Python code",
+          type: "python",
+          description: "PythonCode node that returns a hello message.",
+          codeExample: "return {'message': 'Hello from Python!'}",
+        },
+      },
+      {
+        id: "python-end",
+        type: "end",
+        position: { x: 520, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description: "Ends after the Python node executes.",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "edge-python-start-greet",
+        source: "python-start",
+        target: "python-greet",
+      },
+      {
+        id: "edge-python-greet-end",
+        source: "python-greet",
+        target: "python-end",
+      },
+    ],
+  },
+  {
+    id: "workflow-feedly-digest",
+    name: "Feedly Digest to Telegram",
+    description:
+      "Captures a Feedly token, fetches unread items, and sends a Telegram digest.",
+    createdAt: "2024-01-22T09:10:00Z",
+    updatedAt: "2024-03-07T12:05:00Z",
+    sourceExample: "examples/feedly_news.py",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "news", "telegram", "automation"],
     lastRun: {
-      status: "error",
-      timestamp: "2023-11-05T02:00:00Z",
-      duration: 134.7,
+      status: "success",
+      timestamp: "2024-03-08T05:00:00Z",
+      duration: 57.8,
     },
     nodes: [
       {
-        id: "node-1",
-        type: "trigger",
-        position: { x: 100, y: 100 },
+        id: "feedly-start",
+        type: "start",
+        position: { x: 0, y: 0 },
         data: {
-          label: "Scheduled Trigger",
-          description: "Runs every day at 2:00 AM",
-          status: "success",
+          label: "Start",
+          type: "start",
+          description: "Kick off the Feedly news digest workflow.",
         },
       },
       {
-        id: "node-2",
-        type: "api",
-        position: { x: 400, y: 100 },
-        data: {
-          label: "Extract Data",
-          description: "Pull data from source system",
-          status: "success",
-        },
-      },
-      {
-        id: "node-3",
+        id: "collect-feedly-token",
         type: "function",
-        position: { x: 700, y: 100 },
+        position: { x: 220, y: 0 },
         data: {
-          label: "Transform Data",
-          description: "Clean and transform data",
-          status: "success",
+          label: "Collect Feedly token",
+          type: "function",
+          description:
+            "Browser automation retrieves the Feedly developer token.",
+          examplePath: "examples/feedly_news.py",
         },
       },
       {
-        id: "node-4",
-        type: "data",
-        position: { x: 1000, y: 100 },
-        data: {
-          label: "Load to Database",
-          description: "Insert data into target database",
-          status: "error",
-        },
-      },
-      {
-        id: "node-5",
+        id: "fetch-unread-articles",
         type: "api",
-        position: { x: 1000, y: 300 },
+        position: { x: 440, y: 0 },
         data: {
-          label: "Send Notification",
-          description: "Notify team about sync results",
-          status: "idle",
+          label: "Fetch unread articles",
+          type: "api",
+          description:
+            "HTTP request pulls unread articles and formats them for Telegram.",
+          examplePath: "examples/feedly_news.py",
+        },
+      },
+      {
+        id: "send-telegram-digest",
+        type: "api",
+        position: { x: 660, y: 0 },
+        data: {
+          label: "Send Telegram digest",
+          type: "api",
+          description:
+            "MessageTelegram sends the formatted digest to the configured chat.",
+          examplePath: "examples/feedly_news.py",
+        },
+      },
+      {
+        id: "mark-as-read",
+        type: "api",
+        position: { x: 660, y: 160 },
+        data: {
+          label: "Mark entries as read",
+          type: "api",
+          description:
+            "Optional HTTP call updates Feedly with the read status.",
           isDisabled: true,
+          examplePath: "examples/feedly_news.py",
+        },
+      },
+      {
+        id: "feedly-end",
+        type: "end",
+        position: { x: 880, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description: "Workflow completes after sending notifications.",
         },
       },
     ],
-
     edges: [
       {
-        id: "edge-1-2",
-        source: "node-1",
-        target: "node-2",
-        animated: false,
+        id: "edge-start-token",
+        source: "feedly-start",
+        target: "collect-feedly-token",
       },
       {
-        id: "edge-2-3",
-        source: "node-2",
-        target: "node-3",
-        animated: false,
+        id: "edge-token-fetch",
+        source: "collect-feedly-token",
+        target: "fetch-unread-articles",
       },
       {
-        id: "edge-3-4",
-        source: "node-3",
-        target: "node-4",
-        animated: false,
+        id: "edge-fetch-telegram",
+        source: "fetch-unread-articles",
+        target: "send-telegram-digest",
       },
       {
-        id: "edge-4-5",
-        source: "node-4",
-        target: "node-5",
-        animated: false,
+        id: "edge-telegram-end",
+        source: "send-telegram-digest",
+        target: "feedly-end",
+      },
+      {
+        id: "edge-telegram-mark",
+        source: "send-telegram-digest",
+        target: "mark-as-read",
+      },
+      {
+        id: "edge-mark-end",
+        source: "mark-as-read",
+        target: "feedly-end",
       },
     ],
   },
   {
-    id: "workflow-3",
-    name: "AI Content Generator",
-    description: "Generates and publishes content using AI",
-    createdAt: "2023-10-05T15:45:00Z",
-    updatedAt: "2023-11-03T09:20:00Z",
-    owner: {
-      id: "user-1",
-      name: "Avery Chen",
-      avatar: "https://avatar.vercel.sh/avery",
-    },
-    tags: ["ai", "content", "automation", "template"],
-    lastRun: {
-      status: "running",
-      timestamp: "2023-11-05T10:30:00Z",
-      duration: 67.3,
-    },
+    id: "workflow-slack-broadcast",
+    name: "Slack Channel Broadcast",
+    description: "Posts an announcement to a Slack channel.",
+    createdAt: "2024-02-01T13:20:00Z",
+    updatedAt: "2024-03-02T18:40:00Z",
+    sourceExample: "examples/slack.py",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "slack", "messaging"],
     nodes: [
       {
-        id: "node-1",
-        type: "trigger",
-        position: { x: 100, y: 100 },
+        id: "slack-start",
+        type: "start",
+        position: { x: 0, y: 0 },
         data: {
-          label: "Content Request",
-          description: "Triggered when content is requested",
-          status: "success",
+          label: "Start",
+          type: "start",
+          description: "Begin the Slack announcement workflow.",
         },
       },
       {
-        id: "node-2",
-        type: "function",
-        position: { x: 400, y: 100 },
-        data: {
-          label: "Prepare Prompt",
-          description: "Format content request into AI prompt",
-          status: "success",
-        },
-      },
-      {
-        id: "node-3",
-        type: "ai",
-        position: { x: 700, y: 100 },
-        data: {
-          label: "Generate Content",
-          description: "Use AI model to generate content",
-          status: "running",
-        },
-      },
-      {
-        id: "node-4",
-        type: "function",
-        position: { x: 1000, y: 100 },
-        data: {
-          label: "Format Content",
-          description: "Format and structure the generated content",
-          status: "idle",
-        },
-      },
-      {
-        id: "node-5",
+        id: "send-slack-message",
         type: "api",
-        position: { x: 1000, y: 300 },
+        position: { x: 260, y: 0 },
         data: {
-          label: "Publish Content",
-          description: "Publish to CMS or social media",
-          status: "idle",
+          label: "Send Slack message",
+          type: "api",
+          description:
+            "Slack node posts the message to the configured channel.",
+          examplePath: "examples/slack.py",
+        },
+      },
+      {
+        id: "slack-end",
+        type: "end",
+        position: { x: 520, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description: "Slack announcement has been delivered.",
         },
       },
     ],
-
     edges: [
       {
-        id: "edge-1-2",
-        source: "node-1",
-        target: "node-2",
-        animated: false,
+        id: "edge-slack-start-send",
+        source: "slack-start",
+        target: "send-slack-message",
       },
       {
-        id: "edge-2-3",
-        source: "node-2",
-        target: "node-3",
-        animated: true,
+        id: "edge-slack-end",
+        source: "send-slack-message",
+        target: "slack-end",
+      },
+    ],
+  },
+  {
+    id: "workflow-rss-monitor",
+    name: "RSS Feed Monitor",
+    description: "Pulls unread entries from multiple RSS feeds.",
+    createdAt: "2024-02-12T07:05:00Z",
+    updatedAt: "2024-03-06T11:20:00Z",
+    sourceExample: "examples/pull_rss_updates.py",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "rss", "monitoring"],
+    nodes: [
+      {
+        id: "rss-start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          type: "start",
+          description: "Begin monitoring configured RSS feeds.",
+        },
       },
       {
-        id: "edge-3-4",
-        source: "node-3",
-        target: "node-4",
-        animated: false,
+        id: "rss-fetch",
+        type: "data",
+        position: { x: 260, y: 0 },
+        data: {
+          label: "Fetch RSS updates",
+          type: "data",
+          description:
+            "RSS node retrieves the latest unread entries from the feed list.",
+          examplePath: "examples/pull_rss_updates.py",
+        },
       },
       {
-        id: "edge-4-5",
-        source: "node-4",
-        target: "node-5",
-        animated: false,
+        id: "rss-end",
+        type: "end",
+        position: { x: 520, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description:
+            "Results are ready for downstream storage or notifications.",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "edge-rss-start-fetch",
+        source: "rss-start",
+        target: "rss-fetch",
+      },
+      {
+        id: "edge-rss-fetch-end",
+        source: "rss-fetch",
+        target: "rss-end",
+      },
+    ],
+  },
+  {
+    id: "workflow-mongodb-session",
+    name: "MongoDB Query Session",
+    description: "Demonstrates MongoDB node reuse across runs.",
+    createdAt: "2024-02-18T16:10:00Z",
+    updatedAt: "2024-03-05T19:55:00Z",
+    sourceExample: "examples/mongodb.py",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "database", "storage"],
+    nodes: [
+      {
+        id: "mongodb-start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          type: "start",
+          description: "Start the MongoDB query workflow.",
+        },
+      },
+      {
+        id: "mongodb-query",
+        type: "data",
+        position: { x: 260, y: 0 },
+        data: {
+          label: "Query MongoDB collection",
+          type: "data",
+          description:
+            "MongoDB node performs a find operation using the configured session.",
+          examplePath: "examples/mongodb.py",
+        },
+      },
+      {
+        id: "mongodb-end",
+        type: "end",
+        position: { x: 520, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description: "Workflow ends after retrieving the MongoDB results.",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "edge-mongodb-start-query",
+        source: "mongodb-start",
+        target: "mongodb-query",
+      },
+      {
+        id: "edge-mongodb-query-end",
+        source: "mongodb-query",
+        target: "mongodb-end",
+      },
+    ],
+  },
+  {
+    id: "workflow-telegram-broadcast",
+    name: "Python to Telegram Broadcast",
+    description: "Generates a message in Python and forwards it to Telegram.",
+    createdAt: "2024-02-24T21:00:00Z",
+    updatedAt: "2024-03-08T09:30:00Z",
+    sourceExample: "examples/telegram_example.py",
+    owner: TEMPLATE_OWNER,
+    tags: ["template", "telegram", "python"],
+    nodes: [
+      {
+        id: "telegram-start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          type: "start",
+          description: "Entry point for the Telegram broadcast.",
+        },
+      },
+      {
+        id: "compose-telegram-message",
+        type: "function",
+        position: { x: 220, y: 0 },
+        data: {
+          label: "Compose message with Python",
+          type: "function",
+          description:
+            "PythonCode node prepares the message payload for Telegram.",
+          examplePath: "examples/telegram_example.py",
+        },
+      },
+      {
+        id: "send-telegram-message",
+        type: "api",
+        position: { x: 440, y: 0 },
+        data: {
+          label: "Send Telegram message",
+          type: "api",
+          description:
+            "MessageTelegram node sends the composed message to the target chat.",
+          examplePath: "examples/telegram_example.py",
+        },
+      },
+      {
+        id: "telegram-end",
+        type: "end",
+        position: { x: 660, y: 0 },
+        data: {
+          label: "Finish",
+          type: "end",
+          description: "Broadcast completed successfully.",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "edge-telegram-start-compose",
+        source: "telegram-start",
+        target: "compose-telegram-message",
+      },
+      {
+        id: "edge-telegram-compose-send",
+        source: "compose-telegram-message",
+        target: "send-telegram-message",
+      },
+      {
+        id: "edge-telegram-send-end",
+        source: "send-telegram-message",
+        target: "telegram-end",
       },
     ],
   },
@@ -364,5 +556,10 @@ export const NODE_TYPES = {
     label: "AI",
     description: "Uses artificial intelligence models",
     color: "indigo",
+  },
+  python: {
+    label: "Python",
+    description: "Executes custom Python code within the workflow",
+    color: "orange",
   },
 };

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.test.ts
@@ -2,124 +2,198 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   WORKFLOW_STORAGE_EVENT,
-  clearWorkflowStorage,
-  createWorkflow,
-  createWorkflowFromTemplate,
-  deleteWorkflow,
-  duplicateWorkflow,
-  getVersionSnapshot,
   listWorkflows,
   saveWorkflow,
 } from "./workflow-storage";
 
-const baseNode = {
-  id: "trigger-1",
-  type: "trigger" as const,
-  position: { x: 0, y: 0 },
-  data: {
-    type: "trigger" as const,
-    label: "Webhook trigger",
-    description: "Starts the workflow when a webhook fires.",
-    status: "idle" as const,
-  },
-};
+const mockFetch = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
 
-const updatedNode = {
-  ...baseNode,
-  data: {
-    ...baseNode.data,
-    label: "Webhook trigger (updated)",
-  },
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const queueResponses = (responses: Response[]) => {
+  const queue = [...responses];
+  mockFetch.mockImplementation(() => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("No more mocked responses available");
+    }
+    return Promise.resolve(next);
+  });
 };
 
 beforeEach(() => {
-  clearWorkflowStorage();
-  window.localStorage.clear();
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
 });
 
-describe("workflow-storage", () => {
-  it("creates and persists workflows while notifying listeners", () => {
+describe("workflow-storage API integration", () => {
+  it("saves workflows by invoking the backend endpoints", async () => {
+    const timestamp = new Date().toISOString();
+    const snapshot = {
+      name: "Marketing qualification",
+      description: "Scores inbound leads and routes them to reps.",
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          position: { x: 0, y: 0 },
+          data: {
+            type: "trigger",
+            label: "Webhook trigger",
+            description: "Starts the workflow when a webhook fires.",
+            status: "idle" as const,
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    queueResponses([
+      jsonResponse({
+        id: "workflow-123",
+        name: snapshot.name,
+        slug: "workflow-123",
+        description: snapshot.description,
+        tags: ["draft"],
+        is_archived: false,
+        created_at: timestamp,
+        updated_at: timestamp,
+      }),
+      jsonResponse({
+        id: "version-1",
+        workflow_id: "workflow-123",
+        version: 1,
+        graph: { nodes: [], edges: [] },
+        metadata: {},
+        notes: "Initial draft",
+        created_by: "canvas-app",
+        created_at: timestamp,
+        updated_at: timestamp,
+      }),
+      jsonResponse({
+        id: "workflow-123",
+        name: snapshot.name,
+        slug: "workflow-123",
+        description: snapshot.description,
+        tags: ["draft"],
+        is_archived: false,
+        created_at: timestamp,
+        updated_at: timestamp,
+      }),
+      jsonResponse([
+        {
+          id: "version-1",
+          workflow_id: "workflow-123",
+          version: 1,
+          graph: { nodes: [], edges: [] },
+          metadata: {
+            canvas: {
+              snapshot,
+              summary: { added: 0, removed: 0, modified: 0 },
+              message: "Initial draft",
+            },
+          },
+          notes: "Initial draft",
+          created_by: "canvas-app",
+          created_at: timestamp,
+          updated_at: timestamp,
+        },
+      ]),
+    ]);
+
     const listener = vi.fn();
     window.addEventListener(WORKFLOW_STORAGE_EVENT, listener);
 
-    const workflow = createWorkflow({
-      name: "Marketing qualification",
-      description: "Scores inbound leads and routes them to reps.",
-      nodes: [baseNode],
-      edges: [],
-    });
-
-    expect(workflow.id).toMatch(/^workflow-/);
-    expect(listWorkflows()).toHaveLength(1);
-    expect(listener).toHaveBeenCalled();
-
-    window.removeEventListener(WORKFLOW_STORAGE_EVENT, listener);
-  });
-
-  it("tracks version history whenever the workflow graph changes", () => {
-    const workflow = createWorkflow({
-      name: "Onboarding journey",
-      description: "Collects documents and provisions access.",
-      nodes: [baseNode],
-      edges: [],
-    });
-
-    const firstSave = saveWorkflow(
+    const saved = await saveWorkflow(
       {
-        id: workflow.id,
-        name: "Onboarding journey",
-        description: "Collects documents and provisions access.",
-        nodes: [baseNode],
-        edges: [],
+        name: snapshot.name,
+        description: snapshot.description,
+        tags: ["draft"],
+        nodes: snapshot.nodes,
+        edges: snapshot.edges,
       },
       { versionMessage: "Initial draft" },
     );
 
-    expect(firstSave.versions).toHaveLength(1);
-    expect(firstSave.versions[0]?.message).toContain("Initial draft");
+    expect(saved.id).toBe("workflow-123");
+    expect(saved.versions).toHaveLength(1);
+    expect(saved.nodes).toHaveLength(1);
+    expect(listener).toHaveBeenCalled();
 
-    const secondSave = saveWorkflow(
-      {
-        id: workflow.id,
-        name: "Onboarding journey",
-        description: "Collects documents and provisions access.",
-        nodes: [updatedNode],
-        edges: [],
-      },
-      { versionMessage: "Updated webhook copy" },
+    const versionPayload = JSON.parse(
+      (mockFetch.mock.calls[1]?.[1]?.body ?? "{}") as string,
     );
 
-    expect(secondSave.versions).toHaveLength(2);
-    const latest = secondSave.versions.at(-1);
-    expect(latest?.summary.modified).toBeGreaterThanOrEqual(1);
-    expect(getVersionSnapshot(secondSave.id, latest?.id ?? "")).toMatchObject({
-      name: "Onboarding journey",
-      nodes: [updatedNode],
-    });
+    expect(versionPayload.metadata.canvas.snapshot.nodes[0]?.id).toBe(
+      "trigger-1",
+    );
+
+    window.removeEventListener(WORKFLOW_STORAGE_EVENT, listener);
+
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain("/api/workflows");
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain(
+      "/api/workflows/workflow-123/versions",
+    );
   });
 
-  it("duplicates and removes workflows to support CRUD operations", () => {
-    const original = createWorkflow({
-      name: "Support triage",
-      nodes: [baseNode],
-      edges: [],
-    });
+  it("lists workflows by merging backing metadata", async () => {
+    const timestamp = new Date().toISOString();
+    queueResponses([
+      jsonResponse([
+        {
+          id: "workflow-abc",
+          name: "Support triage",
+          slug: "workflow-abc",
+          description: "Routes support tickets to the right queue.",
+          tags: ["support"],
+          is_archived: false,
+          created_at: timestamp,
+          updated_at: timestamp,
+        },
+      ]),
+      jsonResponse([
+        {
+          id: "version-1",
+          workflow_id: "workflow-abc",
+          version: 1,
+          graph: {},
+          metadata: {
+            canvas: {
+              snapshot: {
+                name: "Support triage",
+                description: "Routes support tickets to the right queue.",
+                nodes: [
+                  {
+                    id: "start",
+                    type: "trigger",
+                    position: { x: 0, y: 0 },
+                    data: { label: "Start" },
+                  },
+                ],
+                edges: [],
+              },
+              summary: { added: 0, removed: 0, modified: 0 },
+              message: "Initial draft",
+            },
+          },
+          notes: null,
+          created_by: "canvas-app",
+          created_at: timestamp,
+          updated_at: timestamp,
+        },
+      ]),
+    ]);
 
-    const copy = duplicateWorkflow(original.id);
-    expect(copy).toBeTruthy();
-    expect(copy?.id).not.toEqual(original.id);
-    expect(listWorkflows()).toHaveLength(2);
+    const workflows = await listWorkflows();
 
-    if (copy) {
-      deleteWorkflow(copy.id);
-    }
-
-    expect(listWorkflows()).toHaveLength(1);
-  });
-
-  it("creates workflows from curated templates", () => {
-    const template = createWorkflowFromTemplate("workflow-quickstart");
-    expect(template).toBeTruthy();
-    expect(template?.tags).not.toContain("template");
+    expect(workflows).toHaveLength(1);
+    expect(workflows[0]?.nodes).toHaveLength(1);
+    expect(workflows[0]?.versions[0]?.summary.modified).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.test.ts
@@ -118,7 +118,7 @@ describe("workflow-storage", () => {
   });
 
   it("creates workflows from curated templates", () => {
-    const template = createWorkflowFromTemplate("workflow-1");
+    const template = createWorkflowFromTemplate("workflow-quickstart");
     expect(template).toBeTruthy();
     expect(template?.tags).not.toContain("template");
   });

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -471,20 +471,43 @@ const toPersistedEdge = (edge: CanvasEdge): PersistedWorkflowEdge => ({
   style: edge.style,
 });
 
+const resolveReactFlowType = (
+  persistedType?: string,
+): "default" | "chatTrigger" | "startEnd" => {
+  if (!persistedType) {
+    return "default";
+  }
+
+  if (persistedType === "chatTrigger") {
+    return "chatTrigger";
+  }
+
+  if (
+    persistedType === "start" ||
+    persistedType === "end" ||
+    persistedType === "startEnd"
+  ) {
+    return "startEnd";
+  }
+
+  return "default";
+};
+
 const toCanvasNodeBase = (node: PersistedWorkflowNode): CanvasNode => {
   const extraEntries = Object.entries(node.data ?? {}).filter(
     ([key]) => !PERSISTED_NODE_FIELDS.has(key),
   );
 
   const extraData = Object.fromEntries(extraEntries);
+  const semanticType = node.data?.type ?? node.type ?? "default";
 
   return {
     id: node.id,
-    type: node.type ?? "default",
+    type: resolveReactFlowType(node.type),
     position: node.position ?? { x: 0, y: 0 },
     style: defaultNodeStyle,
     data: {
-      type: node.data?.type ?? node.type ?? "default",
+      type: semanticType,
       label: node.data?.label ?? "New Node",
       description: node.data?.description ?? "",
       status: (node.data?.status ?? "idle") as NodeStatus,

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
@@ -323,6 +323,7 @@ export default function WorkflowGallery() {
       function: "#8b5cf6",
       data: "#10b981",
       ai: "#6366f1",
+      python: "#f97316",
     };
 
     return (
@@ -864,6 +865,11 @@ export default function WorkflowGallery() {
                                 {workflow.description ||
                                   "No description provided"}
                               </CardDescription>
+                              {isTemplateCard && workflow.sourceExample && (
+                                <p className="text-xs text-muted-foreground/80 mt-1 line-clamp-1">
+                                  Based on {workflow.sourceExample}
+                                </p>
+                              )}
                             </CardHeader>
 
                             <CardContent className="pb-2 px-3">

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/design-system/ui/button";
 import { Input } from "@/design-system/ui/input";
@@ -84,9 +84,7 @@ import { toast } from "@/hooks/use-toast";
 
 export default function WorkflowGallery() {
   const navigate = useNavigate();
-  const [workflows, setWorkflows] = useState<StoredWorkflow[]>(() =>
-    listWorkflows(),
-  );
+  const [workflows, setWorkflows] = useState<StoredWorkflow[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTab, setSelectedTab] = useState("all");
   const [sortBy, setSortBy] = useState("updated");
@@ -114,20 +112,43 @@ export default function WorkflowGallery() {
   });
 
   useEffect(() => {
-    const updateWorkflows = () => {
-      setWorkflows(listWorkflows());
+    let isMounted = true;
+
+    const load = async () => {
+      try {
+        const items = await listWorkflows();
+        if (isMounted) {
+          setWorkflows(items);
+        }
+      } catch (error) {
+        if (isMounted) {
+          console.error("Failed to load workflows", error);
+          toast({
+            title: "Unable to load workflows",
+            description:
+              error instanceof Error ? error.message : "Unknown error occurred",
+            variant: "destructive",
+          });
+        }
+      }
     };
 
-    updateWorkflows();
+    void load();
 
     if (typeof window !== "undefined") {
-      window.addEventListener(WORKFLOW_STORAGE_EVENT, updateWorkflows);
+      const handler = () => {
+        void load();
+      };
+      window.addEventListener(WORKFLOW_STORAGE_EVENT, handler);
       return () => {
-        window.removeEventListener(WORKFLOW_STORAGE_EVENT, updateWorkflows);
+        isMounted = false;
+        window.removeEventListener(WORKFLOW_STORAGE_EVENT, handler);
       };
     }
 
-    return undefined;
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const templates = useMemo(() => SAMPLE_WORKFLOWS, []);
@@ -204,66 +225,103 @@ export default function WorkflowGallery() {
     setShowNewFolderDialog(false);
   };
 
-  const handleCreateWorkflow = () => {
+  const handleCreateWorkflow = useCallback(async () => {
     const name = newWorkflowName.trim() || "Untitled Workflow";
-    const workflow = createWorkflow({
-      name,
-      description: "",
-      tags: ["draft"],
-      nodes: [],
-      edges: [],
-    });
+    try {
+      const workflow = await createWorkflow({
+        name,
+        description: "",
+        tags: ["draft"],
+        nodes: [],
+        edges: [],
+      });
 
-    setNewWorkflowName("");
-    setShowNewWorkflowDialog(false);
-    setSelectedTab("all");
+      setNewWorkflowName("");
+      setShowNewWorkflowDialog(false);
+      setSelectedTab("all");
 
-    toast({
-      title: "Workflow created",
-      description: `"${workflow.name}" is ready to edit.`,
-    });
-
-    navigate(`/workflow-canvas/${workflow.id}`);
-  };
-
-  const handleUseTemplate = (templateId: string) => {
-    const workflow = createWorkflowFromTemplate(templateId);
-    if (!workflow) {
       toast({
-        title: "Template unavailable",
-        description: "We couldn't find that template. Please try another one.",
+        title: "Workflow created",
+        description: `"${workflow.name}" is ready to edit.`,
+      });
+
+      navigate(`/workflow-canvas/${workflow.id}`);
+    } catch (error) {
+      toast({
+        title: "Failed to create workflow",
+        description:
+          error instanceof Error ? error.message : "Unknown error occurred",
         variant: "destructive",
       });
-      return;
     }
+  }, [navigate, newWorkflowName]);
 
-    toast({
-      title: "Template copied",
-      description: `"${workflow.name}" has been added to your workspace.`,
-    });
+  const handleUseTemplate = useCallback(
+    async (templateId: string) => {
+      try {
+        const workflow = await createWorkflowFromTemplate(templateId);
+        if (!workflow) {
+          toast({
+            title: "Template unavailable",
+            description: "We couldn't find that template. Please try another.",
+            variant: "destructive",
+          });
+          return;
+        }
 
-    setSelectedTab("all");
-    navigate(`/workflow-canvas/${workflow.id}`);
-  };
+        setSelectedTab("all");
 
-  const handleDuplicateWorkflow = (workflowId: string) => {
-    const copy = duplicateWorkflow(workflowId);
-    if (!copy) {
-      toast({
-        title: "Duplicate failed",
-        description: "We couldn't duplicate this workflow. Please try again.",
-        variant: "destructive",
-      });
-      return;
-    }
+        toast({
+          title: "Template copied",
+          description: `"${workflow.name}" has been added to your workspace.`,
+        });
 
-    toast({
-      title: "Workflow duplicated",
-      description: `"${copy.name}" is ready to edit.`,
-    });
+        navigate(`/workflow-canvas/${workflow.id}`);
+      } catch (error) {
+        toast({
+          title: "Failed to create workflow from template",
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        });
+      }
+    },
+    [navigate],
+  );
 
-    navigate(`/workflow-canvas/${copy.id}`);
-  };
+  const handleDuplicateWorkflow = useCallback(
+    async (workflowId: string) => {
+      try {
+        const copy = await duplicateWorkflow(workflowId);
+        if (!copy) {
+          toast({
+            title: "Duplicate failed",
+            description:
+              "We couldn't duplicate this workflow. Please try again.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        setSelectedTab("all");
+
+        toast({
+          title: "Workflow duplicated",
+          description: `"${copy.name}" is ready to edit.`,
+        });
+
+        navigate(`/workflow-canvas/${copy.id}`);
+      } catch (error) {
+        toast({
+          title: "Failed to duplicate workflow",
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        });
+      }
+    },
+    [navigate],
+  );
 
   const handleExportWorkflow = (workflow: Workflow) => {
     try {
@@ -297,13 +355,25 @@ export default function WorkflowGallery() {
     }
   };
 
-  const handleDeleteWorkflow = (workflowId: string, workflowName: string) => {
-    deleteWorkflow(workflowId);
-    toast({
-      title: "Workflow deleted",
-      description: `"${workflowName}" has been removed from your workspace.`,
-    });
-  };
+  const handleDeleteWorkflow = useCallback(
+    async (workflowId: string, workflowName: string) => {
+      try {
+        await deleteWorkflow(workflowId);
+        toast({
+          title: "Workflow deleted",
+          description: `"${workflowName}" has been removed from your workspace.`,
+        });
+      } catch (error) {
+        toast({
+          title: "Failed to delete workflow",
+          description:
+            error instanceof Error ? error.message : "Unknown error occurred",
+          variant: "destructive",
+        });
+      }
+    },
+    [],
+  );
 
   const handleApplyFilters = () => {
     toast({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ version = "0.7.0"
 
 [project.scripts]
 orcheo-canvas-lint = "orcheo.tooling.commands:canvas_lint"
+orcheo-dev-canvas = "orcheo.tooling.commands:canvas_dev"
 orcheo-dev-server = "orcheo.tooling.commands:dev_server"
 orcheo-format = "orcheo.tooling.commands:format_code"
 orcheo-lint = "orcheo.tooling.commands:lint"

--- a/src/orcheo/tooling/commands.py
+++ b/src/orcheo/tooling/commands.py
@@ -56,3 +56,8 @@ def test() -> None:
 def canvas_lint() -> None:
     """Lint the React canvas application."""
     _run(["npm", "--prefix", "apps/canvas", "run", "lint"])
+
+
+def canvas_dev() -> None:
+    """Start the React canvas development server."""
+    _run(["npm", "--prefix", "apps/canvas", "run", "dev"])

--- a/tests/test_tooling_commands.py
+++ b/tests/test_tooling_commands.py
@@ -46,6 +46,10 @@ def test_canvas_lint_invokes_npm(successful_run: None) -> None:
     commands.canvas_lint()
 
 
+def test_canvas_dev_invokes_npm(successful_run: None) -> None:
+    commands.canvas_dev()
+
+
 def test_run_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     def _run(command: Sequence[str], check: bool = False) -> CompletedProcess[str]:
         return CompletedProcess(args=command, returncode=1)


### PR DESCRIPTION
* replaced the canvas localStorage helper with a backend-backed implementation that posts workflows/versions to /api/workflows and emits UI update events
* updated gallery and canvas pages to load/save/delete workflows asynchronously against the API with user-facing toasts when requests fail
* refreshed Vitest coverage to mock fetch-based persistence rather than local storage
