### PR TITLE
Cache node inspector test results across session

### DIFF
--- a/apps/canvas/src/features/workflow/components/panels/node-inspector.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/node-inspector.tsx
@@ -43,6 +43,7 @@ import {
   findUpstreamNodes,
   hasIncomingConnections,
   collectUpstreamOutputs,
+  mergeRuntimeSummaries,
 } from "@features/workflow/lib/graph-utils";
 import { writeSchemaFieldDragData } from "./schema-dnd";
 
@@ -95,15 +96,9 @@ export default function NodeInspector({
     : undefined;
   const runtimeFromNode = isRecord(runtimeCandidate)
     ? (runtimeCandidate as NodeRuntimeCacheEntry)
-    : null;
+    : undefined;
   const cachedRuntime = node ? runtimeCache?.[node.id] : undefined;
-  const runtime =
-    runtimeFromNode || cachedRuntime
-      ? {
-          ...(runtimeFromNode ?? {}),
-          ...(cachedRuntime ?? {}),
-        }
-      : null;
+  const runtime = mergeRuntimeSummaries(runtimeFromNode, cachedRuntime) ?? null;
   const hasRuntime = Boolean(runtime);
   const [useLiveData, setUseLiveData] = useState(hasRuntime);
   const [draftData, setDraftData] = useState<Record<string, unknown>>(() =>

--- a/apps/canvas/src/features/workflow/lib/graph-utils.ts
+++ b/apps/canvas/src/features/workflow/lib/graph-utils.ts
@@ -60,12 +60,12 @@ export function hasIncomingConnections(nodeId: string, edges: Edge[]): boolean {
  * @param upstreamNodes - Array of upstream nodes
  * @returns Object with outputs keyed by node ID
  */
-type RuntimeSummary = {
+export type RuntimeSummary = {
   outputs?: unknown;
   messages?: unknown;
   raw?: unknown;
   updatedAt?: string;
-};
+} & Record<string, unknown>;
 
 function parseUpdatedAt(timestamp?: string): number | null {
   if (!timestamp) {
@@ -76,7 +76,7 @@ function parseUpdatedAt(timestamp?: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function mergeRuntimeSummaries(
+export function mergeRuntimeSummaries(
   runtimeFromNode?: RuntimeSummary,
   cachedRuntime?: RuntimeSummary,
 ): RuntimeSummary | undefined {

--- a/apps/canvas/src/features/workflow/lib/graph-utils.ts
+++ b/apps/canvas/src/features/workflow/lib/graph-utils.ts
@@ -64,7 +64,48 @@ type RuntimeSummary = {
   outputs?: unknown;
   messages?: unknown;
   raw?: unknown;
+  updatedAt?: string;
 };
+
+function parseUpdatedAt(timestamp?: string): number | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  const parsed = new Date(timestamp).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function mergeRuntimeSummaries(
+  runtimeFromNode?: RuntimeSummary,
+  cachedRuntime?: RuntimeSummary,
+): RuntimeSummary | undefined {
+  if (!runtimeFromNode && !cachedRuntime) {
+    return undefined;
+  }
+
+  if (!runtimeFromNode) {
+    return cachedRuntime;
+  }
+
+  if (!cachedRuntime) {
+    return runtimeFromNode;
+  }
+
+  const nodeTimestamp = parseUpdatedAt(runtimeFromNode.updatedAt);
+  const cacheTimestamp = parseUpdatedAt(cachedRuntime.updatedAt);
+
+  if (nodeTimestamp !== null && cacheTimestamp !== null) {
+    if (nodeTimestamp >= cacheTimestamp) {
+      return { ...cachedRuntime, ...runtimeFromNode };
+    }
+
+    return { ...runtimeFromNode, ...cachedRuntime };
+  }
+
+  // Fall back to preferring the live runtime when timestamps are missing or invalid.
+  return { ...cachedRuntime, ...runtimeFromNode };
+}
 
 export function collectUpstreamOutputs(
   upstreamNodes: Node[],
@@ -77,13 +118,7 @@ export function collectUpstreamOutputs(
     const runtimeFromNode = node.data?.runtime as RuntimeSummary | undefined;
     const cachedRuntime = runtimeCache?.[node.id];
 
-    const mergedRuntime =
-      runtimeFromNode || cachedRuntime
-        ? {
-            ...(runtimeFromNode ?? {}),
-            ...(cachedRuntime ?? {}),
-          }
-        : undefined;
+    const mergedRuntime = mergeRuntimeSummaries(runtimeFromNode, cachedRuntime);
 
     if (mergedRuntime) {
       // Prioritize outputs, then messages, then raw

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -204,7 +204,15 @@ const persistRuntimeCacheToSession = (
     return;
   }
 
-  window.sessionStorage.setItem(key, JSON.stringify(cache));
+  try {
+    const serialized = JSON.stringify(cache);
+    window.sessionStorage.setItem(key, serialized);
+  } catch (error) {
+    console.warn(
+      "Failed to persist node runtime cache to sessionStorage",
+      error,
+    );
+  }
 };
 
 const clearRuntimeCacheFromSession = (key: string) => {
@@ -1227,7 +1235,17 @@ export default function WorkflowCanvas({
   }, [runtimeCacheKey]);
 
   useEffect(() => {
-    persistRuntimeCacheToSession(runtimeCacheKey, nodeRuntimeCache);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handle = window.setTimeout(() => {
+      persistRuntimeCacheToSession(runtimeCacheKey, nodeRuntimeCache);
+    }, 200);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
   }, [nodeRuntimeCache, runtimeCacheKey]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- cache node inspector execution results in session storage and surface them as live data
- include cached runtimes when collecting upstream outputs for downstream nodes
- manage the cached run data lifecycle from the workflow canvas so it clears when workflows close

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68fe29e3659483278399840a47874148