### PR TITLE
Move credential vault access to profile menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ format:
 	ruff check . --select F401 --fix
 
 test:
-	$(UV_RUN) pytest --cov --cov-report term-missing tests/
+	$(UV_RUN) pytest --cov --cov-report term-missing --cov-fail-under=100 tests/
 
 doc:
 	mkdocs serve --dev-addr=0.0.0.0:8080

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -177,6 +177,19 @@ class CredentialValidationRequest(BaseModel):
     actor: str = Field(default="system")
 
 
+class CredentialCreateRequest(BaseModel):
+    """Request payload for creating a credential entry."""
+
+    name: str
+    provider: str
+    secret: str
+    actor: str = Field(default="system")
+    scopes: list[str] = Field(default_factory=list)
+    access: Literal["private", "shared", "public"] = "private"
+    workflow_id: UUID | None = None
+    kind: CredentialKind = CredentialKind.SECRET
+
+
 class CredentialHealthItem(BaseModel):
     """Represents the health state for an individual credential."""
 

--- a/apps/backend/src/orcheo_backend/app/schemas.py
+++ b/apps/backend/src/orcheo_backend/app/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
@@ -283,6 +283,22 @@ class CredentialIssuanceResponse(BaseModel):
     template_id: str | None
     created_at: datetime
     updated_at: datetime
+
+
+class CredentialVaultEntryResponse(BaseModel):
+    """Response payload describing a credential stored in the vault."""
+
+    id: str
+    name: str
+    provider: str
+    kind: CredentialKind
+    created_at: datetime
+    updated_at: datetime
+    last_rotated_at: datetime | None
+    owner: str | None
+    access: Literal["private", "shared", "public"]
+    status: CredentialHealthStatus
+    secret_preview: str | None = None
 
 
 class GovernanceAlertResponse(BaseModel):

--- a/apps/canvas/src/features/account/pages/profile.tsx
+++ b/apps/canvas/src/features/account/pages/profile.tsx
@@ -20,6 +20,7 @@ import { Separator } from "@/design-system/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/design-system/ui/avatar";
 import { Badge } from "@/design-system/ui/badge";
 import TopNavigation from "@features/shared/components/top-navigation";
+import useCredentialVault from "@/hooks/use-credential-vault";
 
 export default function Profile() {
   const [user] = useState({
@@ -31,9 +32,21 @@ export default function Profile() {
     twoFactorEnabled: false,
   });
 
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onDeleteCredential,
+  } = useCredentialVault({ actorName: user.name });
+
   return (
     <div className="flex min-h-screen flex-col">
-      <TopNavigation />
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onDeleteCredential={onDeleteCredential}
+      />
 
       <div className="flex-1 space-y-4 p-8 pt-6 mx-auto w-full max-w-7xl">
         <div className="flex items-center justify-between space-y-2">

--- a/apps/canvas/src/features/account/pages/settings.tsx
+++ b/apps/canvas/src/features/account/pages/settings.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/design-system/ui/label";
 import { Separator } from "@/design-system/ui/separator";
 import TopNavigation from "@features/shared/components/top-navigation";
 import ThemeSettings from "@features/account/components/theme-settings";
+import useCredentialVault from "@/hooks/use-credential-vault";
 
 export default function Settings() {
   const [emailNotifications, setEmailNotifications] = useState({
@@ -34,9 +35,21 @@ export default function Settings() {
     showMinimap: false,
   });
 
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onDeleteCredential,
+  } = useCredentialVault();
+
   return (
     <div className="flex min-h-screen flex-col">
-      <TopNavigation />
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onDeleteCredential={onDeleteCredential}
+      />
 
       <div className="flex-1 space-y-4 p-8 pt-6 mx-auto w-full max-w-7xl">
         <div className="flex items-center justify-between space-y-2">

--- a/apps/canvas/src/features/shared/components/top-navigation.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation.tsx
@@ -348,9 +348,10 @@ export default function TopNavigation({
               }}
               className="cursor-pointer"
             >
-              <Key className="mr-2 h-4 w-4" />
-
-              <span>Credential Vault</span>
+              <div className="flex items-center w-full">
+                <Key className="mr-2 h-4 w-4" />
+                <span>Credential Vault</span>
+              </div>
             </DropdownMenuItem>
             <DropdownMenuItem>
               <Link to="/help-support" className="flex items-center w-full">

--- a/apps/canvas/src/features/shared/components/top-navigation.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation.tsx
@@ -47,6 +47,7 @@ interface TopNavigationProps {
   };
   className?: string;
   credentials?: Credential[];
+  isCredentialsLoading?: boolean;
   onAddCredential?: (credential: CredentialInput) => void;
   onDeleteCredential?: (id: string) => void;
 }
@@ -55,6 +56,7 @@ export default function TopNavigation({
   currentWorkflow,
   className,
   credentials = [],
+  isCredentialsLoading = false,
   onAddCredential,
   onDeleteCredential,
 }: TopNavigationProps) {
@@ -372,6 +374,7 @@ export default function TopNavigation({
           <DialogContent className="max-w-4xl">
             <CredentialsVault
               credentials={credentials}
+              isLoading={isCredentialsLoading}
               onAddCredential={onAddCredential}
               onDeleteCredential={onDeleteCredential}
             />

--- a/apps/canvas/src/features/shared/components/top-navigation.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation.tsx
@@ -50,7 +50,7 @@ interface TopNavigationProps {
   credentials?: Credential[];
   isCredentialsLoading?: boolean;
   onAddCredential?: (credential: CredentialInput) => Promise<void> | void;
-  onDeleteCredential?: (id: string) => void;
+  onDeleteCredential?: (id: string) => Promise<void> | void;
 }
 
 export default function TopNavigation({

--- a/apps/canvas/src/features/shared/components/top-navigation.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation.tsx
@@ -35,10 +35,11 @@ import {
   DialogTrigger,
 } from "@/design-system/ui/dialog";
 import { Input } from "@/design-system/ui/input";
-import CredentialsVault, {
-  type Credential,
-  type CredentialInput,
-} from "@features/workflow/components/dialogs/credentials-vault";
+import CredentialsVault from "@features/workflow/components/dialogs/credentials-vault";
+import type {
+  Credential,
+  CredentialInput,
+} from "@features/workflow/types/credential-vault";
 
 interface TopNavigationProps {
   currentWorkflow?: {
@@ -48,7 +49,7 @@ interface TopNavigationProps {
   className?: string;
   credentials?: Credential[];
   isCredentialsLoading?: boolean;
-  onAddCredential?: (credential: CredentialInput) => void;
+  onAddCredential?: (credential: CredentialInput) => Promise<void> | void;
   onDeleteCredential?: (id: string) => void;
 }
 

--- a/apps/canvas/src/features/shared/components/top-navigation.tsx
+++ b/apps/canvas/src/features/shared/components/top-navigation.tsx
@@ -22,6 +22,7 @@ import {
   Folder,
   Plus,
   MoreHorizontal,
+  Key,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/design-system/ui/badge";
@@ -34,6 +35,10 @@ import {
   DialogTrigger,
 } from "@/design-system/ui/dialog";
 import { Input } from "@/design-system/ui/input";
+import CredentialsVault, {
+  type Credential,
+  type CredentialInput,
+} from "@features/workflow/components/dialogs/credentials-vault";
 
 interface TopNavigationProps {
   currentWorkflow?: {
@@ -41,13 +46,20 @@ interface TopNavigationProps {
     path?: string[];
   };
   className?: string;
+  credentials?: Credential[];
+  onAddCredential?: (credential: CredentialInput) => void;
+  onDeleteCredential?: (id: string) => void;
 }
 
 export default function TopNavigation({
   currentWorkflow,
   className,
+  credentials = [],
+  onAddCredential,
+  onDeleteCredential,
 }: TopNavigationProps) {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [isVaultOpen, setIsVaultOpen] = useState(false);
   const [windowWidth, setWindowWidth] = useState(
     typeof window !== "undefined" ? window.innerWidth : 0,
   );
@@ -327,6 +339,17 @@ export default function TopNavigation({
                 <span>Settings</span>
               </Link>
             </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                setIsVaultOpen(true);
+              }}
+              className="cursor-pointer"
+            >
+              <Key className="mr-2 h-4 w-4" />
+
+              <span>Credential Vault</span>
+            </DropdownMenuItem>
             <DropdownMenuItem>
               <Link to="/help-support" className="flex items-center w-full">
                 <HelpCircle className="mr-2 h-4 w-4" />
@@ -345,6 +368,15 @@ export default function TopNavigation({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <Dialog open={isVaultOpen} onOpenChange={setIsVaultOpen}>
+          <DialogContent className="max-w-4xl">
+            <CredentialsVault
+              credentials={credentials}
+              onAddCredential={onAddCredential}
+              onDeleteCredential={onDeleteCredential}
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     </header>
   );

--- a/apps/canvas/src/features/support/pages/help-support.tsx
+++ b/apps/canvas/src/features/support/pages/help-support.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/design-system/ui/accordion";
 import TopNavigation from "@features/shared/components/top-navigation";
 import ChatInterface from "@features/shared/components/chat-interface";
+import useCredentialVault from "@/hooks/use-credential-vault";
 
 export default function HelpSupport() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -52,9 +53,21 @@ export default function HelpSupport() {
     },
   ];
 
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onDeleteCredential,
+  } = useCredentialVault({ actorName: user.name });
+
   return (
     <div className="flex min-h-screen flex-col">
-      <TopNavigation />
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onDeleteCredential={onDeleteCredential}
+      />
 
       <div className="flex-1 space-y-4 p-8 pt-6 mx-auto w-full max-w-7xl">
         <div className="flex items-center justify-between space-y-2">

--- a/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
@@ -62,7 +62,7 @@ interface CredentialsVaultProps {
   credentials?: Credential[];
   isLoading?: boolean;
   onAddCredential?: (credential: CredentialInput) => Promise<void> | void;
-  onDeleteCredential?: (id: string) => void;
+  onDeleteCredential?: (id: string) => Promise<void> | void;
   className?: string;
 }
 

--- a/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/credentials-vault.tsx
@@ -47,7 +47,12 @@ import {
   Lock,
   Users,
   Shield,
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
+  Circle,
 } from "lucide-react";
+import type { CredentialVaultHealthStatus } from "@features/workflow/types/credential-vault";
 
 export interface Credential {
   id: string;
@@ -58,7 +63,7 @@ export interface Credential {
   owner?: string | null;
   access: "private" | "shared" | "public";
   secrets?: Record<string, string>;
-  status?: string;
+  status?: CredentialVaultHealthStatus;
 }
 
 export type CredentialInput = Omit<
@@ -70,6 +75,7 @@ export type CredentialInput = Omit<
 
 interface CredentialsVaultProps {
   credentials?: Credential[];
+  isLoading?: boolean;
   onAddCredential?: (credential: CredentialInput) => void;
   onDeleteCredential?: (id: string) => void;
   className?: string;
@@ -77,6 +83,7 @@ interface CredentialsVaultProps {
 
 export default function CredentialsVault({
   credentials = [],
+  isLoading = false,
   onAddCredential,
   onDeleteCredential,
   className,
@@ -162,6 +169,44 @@ export default function CredentialsVault({
 
       default:
         return null;
+    }
+  };
+
+  const getStatusBadge = (status: CredentialVaultHealthStatus | undefined) => {
+    const normalized = status ?? "unknown";
+
+    switch (normalized) {
+      case "healthy":
+        return (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800"
+          >
+            <CheckCircle2 className="h-3 w-3" />
+            Healthy
+          </Badge>
+        );
+      case "unhealthy":
+        return (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800"
+          >
+            <AlertTriangle className="h-3 w-3" />
+            Unhealthy
+          </Badge>
+        );
+      case "unknown":
+      default:
+        return (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 bg-muted text-muted-foreground border-border"
+          >
+            <Circle className="h-3 w-3" />
+            Unknown
+          </Badge>
+        );
     }
   };
 
@@ -309,15 +354,26 @@ export default function CredentialsVault({
               <TableHead>Name</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Access</TableHead>
+              <TableHead>Status</TableHead>
               <TableHead>Secret</TableHead>
               <TableHead>Last Updated</TableHead>
               <TableHead className="w-[80px]"></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filteredCredentials.length === 0 ? (
+            {isLoading && (
               <TableRow>
-                <TableCell colSpan={6} className="text-center py-8">
+                <TableCell colSpan={7} className="py-6 text-center">
+                  <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading credentials...
+                  </div>
+                </TableCell>
+              </TableRow>
+            )}
+            {!isLoading && filteredCredentials.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-8">
                   <div className="text-muted-foreground">
                     No credentials found
                     {searchQuery && (
@@ -342,6 +398,7 @@ export default function CredentialsVault({
                     </Badge>
                   </TableCell>
                   <TableCell>{getAccessBadge(credential.access)}</TableCell>
+                  <TableCell>{getStatusBadge(credential.status)}</TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
                       <div className="font-mono text-xs bg-muted px-2 py-1 rounded">

--- a/apps/canvas/src/features/workflow/components/panels/workflow-governance-panel.tsx
+++ b/apps/canvas/src/features/workflow/components/panels/workflow-governance-panel.tsx
@@ -21,10 +21,6 @@ import { Button } from "@/design-system/ui/button";
 import { Badge } from "@/design-system/ui/badge";
 import { Alert, AlertDescription, AlertTitle } from "@/design-system/ui/alert";
 
-import CredentialsVault, {
-  type Credential,
-  type CredentialInput,
-} from "../dialogs/credentials-vault";
 import type { ValidationError } from "../canvas/connection-validator";
 
 export interface SubworkflowTemplate {
@@ -39,9 +35,6 @@ export interface SubworkflowTemplate {
 }
 
 export interface WorkflowGovernancePanelProps {
-  credentials: Credential[];
-  onAddCredential: (credential: CredentialInput) => void;
-  onDeleteCredential: (id: string) => void;
   subworkflows: SubworkflowTemplate[];
   onCreateSubworkflow: () => void;
   onInsertSubworkflow: (subworkflow: SubworkflowTemplate) => void;
@@ -62,9 +55,6 @@ const STATUS_LABEL: Record<SubworkflowTemplate["status"], string> = {
 };
 
 export default function WorkflowGovernancePanel({
-  credentials,
-  onAddCredential,
-  onDeleteCredential,
   subworkflows,
   onCreateSubworkflow,
   onInsertSubworkflow,
@@ -98,12 +88,6 @@ export default function WorkflowGovernancePanel({
 
   return (
     <div className={cn("space-y-6", className)}>
-      <CredentialsVault
-        credentials={credentials}
-        onAddCredential={onAddCredential}
-        onDeleteCredential={onDeleteCredential}
-      />
-
       <Card>
         <CardHeader className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
           <div>

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -4294,6 +4294,9 @@ export default function WorkflowCanvas({
           name: workflowName,
           path: ["Projects", "Workflows", workflowName],
         }}
+        credentials={credentials}
+        onAddCredential={handleAddCredential}
+        onDeleteCredential={handleDeleteCredential}
       />
 
       <WorkflowTabs
@@ -4407,9 +4410,6 @@ export default function WorkflowCanvas({
           <TabsContent value="readiness" className="m-0 p-4 overflow-auto">
             <div className="mx-auto max-w-5xl pb-12">
               <WorkflowGovernancePanel
-                credentials={credentials}
-                onAddCredential={handleAddCredential}
-                onDeleteCredential={handleDeleteCredential}
                 subworkflows={subworkflows}
                 onCreateSubworkflow={handleCreateSubworkflow}
                 onInsertSubworkflow={handleInsertSubworkflow}

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -78,25 +78,12 @@ import type {
   Credential,
   CredentialInput,
 } from "@features/workflow/components/dialogs/credentials-vault";
+import type { CredentialVaultEntryResponse } from "@features/workflow/types/credential-vault";
 import { buildGraphConfigFromCanvas } from "@features/workflow/lib/graph-config";
 import {
   getNodeIcon,
   inferNodeIconKey,
 } from "@features/workflow/lib/node-icons";
-
-type CredentialVaultEntryResponse = {
-  id: string;
-  name: string;
-  provider: string;
-  kind: "secret" | "oauth";
-  created_at: string;
-  updated_at: string;
-  last_rotated_at: string | null;
-  owner: string | null;
-  access: "private" | "shared" | "public";
-  status: string;
-  secret_preview?: string | null;
-};
 
 // Add default style to remove ReactFlow node container
 const defaultNodeStyle = {
@@ -1069,6 +1056,7 @@ export default function WorkflowCanvas({
   >([]);
   const [workflowTags, setWorkflowTags] = useState<string[]>(["draft"]);
   const [credentials, setCredentials] = useState<Credential[]>([]);
+  const [isCredentialsLoading, setIsCredentialsLoading] = useState(true);
   const [subworkflows, setSubworkflows] = useState<SubworkflowTemplate[]>([
     {
       id: "subflow-customer-onboarding",
@@ -1129,6 +1117,11 @@ export default function WorkflowCanvas({
     let isActive = true;
 
     const fetchCredentials = async () => {
+      if (!isActive) {
+        return;
+      }
+
+      setIsCredentialsLoading(true);
       try {
         const url = new URL(buildBackendHttpUrl("/api/credentials"));
         if (workflowId) {
@@ -1185,6 +1178,10 @@ export default function WorkflowCanvas({
               : "An unexpected error occurred while loading credentials.",
           variant: "destructive",
         });
+      } finally {
+        if (isActive) {
+          setIsCredentialsLoading(false);
+        }
       }
     };
 
@@ -4361,6 +4358,7 @@ export default function WorkflowCanvas({
           path: ["Projects", "Workflows", workflowName],
         }}
         credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
         onAddCredential={handleAddCredential}
         onDeleteCredential={handleDeleteCredential}
       />

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/design-system/ui/button";
 import { Input } from "@/design-system/ui/input";
+import useCredentialVault from "@/hooks/use-credential-vault";
 import {
   Card,
   CardContent,
@@ -110,6 +111,13 @@ export default function WorkflowGallery() {
       development: false,
     },
   });
+
+  const {
+    credentials,
+    isLoading: isCredentialsLoading,
+    onAddCredential,
+    onDeleteCredential,
+  } = useCredentialVault();
 
   useEffect(() => {
     let isMounted = true;
@@ -466,7 +474,12 @@ export default function WorkflowGallery() {
 
   return (
     <div className="flex flex-col h-screen">
-      <TopNavigation />
+      <TopNavigation
+        credentials={credentials}
+        isCredentialsLoading={isCredentialsLoading}
+        onAddCredential={onAddCredential}
+        onDeleteCredential={onDeleteCredential}
+      />
 
       <main className="flex-1 overflow-auto">
         <div className="h-full">

--- a/apps/canvas/src/features/workflow/types/credential-vault.ts
+++ b/apps/canvas/src/features/workflow/types/credential-vault.ts
@@ -1,0 +1,17 @@
+export type CredentialVaultAccessLevel = "private" | "shared" | "public";
+
+export type CredentialVaultHealthStatus = "healthy" | "unhealthy" | "unknown";
+
+export interface CredentialVaultEntryResponse {
+  id: string;
+  name: string;
+  provider: string;
+  kind: "secret" | "oauth";
+  created_at: string;
+  updated_at: string;
+  last_rotated_at: string | null;
+  owner: string | null;
+  access: CredentialVaultAccessLevel;
+  status: CredentialVaultHealthStatus;
+  secret_preview?: string | null;
+}

--- a/apps/canvas/src/features/workflow/types/credential-vault.ts
+++ b/apps/canvas/src/features/workflow/types/credential-vault.ts
@@ -2,6 +2,25 @@ export type CredentialVaultAccessLevel = "private" | "shared" | "public";
 
 export type CredentialVaultHealthStatus = "healthy" | "unhealthy" | "unknown";
 
+export interface Credential {
+  id: string;
+  name: string;
+  type?: string;
+  createdAt: string;
+  updatedAt: string;
+  owner?: string | null;
+  access: CredentialVaultAccessLevel;
+  secrets?: Record<string, string>;
+  status?: CredentialVaultHealthStatus;
+}
+
+export type CredentialInput = Omit<
+  Credential,
+  "id" | "createdAt" | "updatedAt" | "owner"
+> & {
+  owner?: string;
+};
+
 export interface CredentialVaultEntryResponse {
   id: string;
   name: string;

--- a/apps/canvas/src/hooks/use-credential-vault.ts
+++ b/apps/canvas/src/hooks/use-credential-vault.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "@/hooks/use-toast";
+import { buildBackendHttpUrl, getBackendBaseUrl } from "@/lib/config";
+import type {
+  Credential,
+  CredentialInput,
+  CredentialVaultEntryResponse,
+} from "@features/workflow/types/credential-vault";
+
+interface UseCredentialVaultOptions {
+  actorName?: string;
+  workflowId?: string | null;
+}
+
+interface UseCredentialVaultResult {
+  credentials: Credential[];
+  isLoading: boolean;
+  onAddCredential: (credential: CredentialInput) => Promise<void>;
+  onDeleteCredential: (id: string) => void;
+}
+
+const DEFAULT_ACTOR = "system";
+
+const mapEntryToCredential = (
+  entry: CredentialVaultEntryResponse,
+): Credential => ({
+  id: entry.id,
+  name: entry.name,
+  type: entry.provider ?? entry.kind,
+  createdAt: entry.created_at,
+  updatedAt: entry.updated_at,
+  owner: entry.owner,
+  access: entry.access,
+  secrets: entry.secret_preview ? { secret: entry.secret_preview } : undefined,
+  status: entry.status,
+});
+
+export function useCredentialVault(
+  options: UseCredentialVaultOptions = {},
+): UseCredentialVaultResult {
+  const { workflowId = null } = options;
+  const backendBaseUrl = useMemo(() => getBackendBaseUrl(), []);
+  const actorName = options.actorName?.trim() || DEFAULT_ACTOR;
+
+  const [credentials, setCredentials] = useState<Credential[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCancelled = false;
+
+    const fetchCredentials = async () => {
+      setIsLoading(true);
+      try {
+        const url = new URL(
+          buildBackendHttpUrl("/api/credentials", backendBaseUrl),
+        );
+        if (workflowId) {
+          url.searchParams.set("workflow_id", workflowId);
+        }
+
+        const response = await fetch(url.toString(), {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load credentials (status ${response.status})`,
+          );
+        }
+
+        const payload =
+          (await response.json()) as CredentialVaultEntryResponse[];
+
+        if (isCancelled) {
+          return;
+        }
+
+        setCredentials(payload.map(mapEntryToCredential));
+      } catch (error) {
+        if (controller.signal.aborted || isCancelled) {
+          return;
+        }
+
+        console.error("Failed to load credential vault", error);
+        toast({
+          title: "Unable to load credentials",
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unexpected error occurred while loading credentials.",
+          variant: "destructive",
+        });
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchCredentials();
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [backendBaseUrl, workflowId]);
+
+  const onAddCredential = useCallback(
+    async (credential: CredentialInput) => {
+      const secret = credential.secrets?.apiKey?.trim();
+      if (!secret) {
+        const message = "API key is required to save a credential.";
+        toast({
+          title: "Missing credential secret",
+          description: message,
+          variant: "destructive",
+        });
+        throw new Error(message);
+      }
+
+      const response = await fetch(
+        buildBackendHttpUrl("/api/credentials", backendBaseUrl),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: credential.name,
+            provider: credential.type ?? "custom",
+            secret,
+            actor: actorName,
+            access: credential.access,
+            workflow_id: workflowId,
+            scopes: [],
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        let detail = `Failed to save credential (status ${response.status})`;
+        try {
+          const payload = (await response.json()) as { detail?: unknown };
+          if (typeof payload?.detail === "string") {
+            detail = payload.detail;
+          } else if (
+            payload?.detail &&
+            typeof (payload.detail as { message?: unknown }).message ===
+              "string"
+          ) {
+            detail = (payload.detail as { message?: string }).message as string;
+          }
+        } catch (parseError) {
+          console.warn("Failed to parse credential creation error", parseError);
+        }
+
+        toast({
+          title: "Unable to save credential",
+          description: detail,
+          variant: "destructive",
+        });
+        throw new Error(detail);
+      }
+
+      const payload = (await response.json()) as CredentialVaultEntryResponse;
+      const credentialRecord: Credential = {
+        id: payload.id,
+        name: payload.name,
+        type: payload.provider ?? payload.kind,
+        createdAt: payload.created_at,
+        updatedAt: payload.updated_at,
+        owner: payload.owner,
+        access: payload.access,
+        secrets: credential.secrets,
+        status: payload.status,
+      };
+
+      setCredentials((previous) => {
+        const withoutDuplicate = previous.filter(
+          (existing) => existing.id !== credentialRecord.id,
+        );
+        return [...withoutDuplicate, credentialRecord];
+      });
+
+      toast({
+        title: "Credential added to vault",
+        description: `${credentialRecord.name} is now available for nodes that require secure access.`,
+      });
+    },
+    [actorName, backendBaseUrl, workflowId],
+  );
+
+  const onDeleteCredential = useCallback((id: string) => {
+    setCredentials((previous) =>
+      previous.filter((credential) => credential.id !== id),
+    );
+    toast({
+      title: "Credential removed",
+      description:
+        "Nodes referencing this credential will require reconfiguration before publish.",
+    });
+  }, []);
+
+  return {
+    credentials,
+    isLoading,
+    onAddCredential,
+    onDeleteCredential,
+  };
+}
+
+export default useCredentialVault;

--- a/tests/backend/test_app_integration.py
+++ b/tests/backend/test_app_integration.py
@@ -1,0 +1,296 @@
+"""Integration tests for backend API using TestClient."""
+
+from __future__ import annotations
+from uuid import uuid4
+import pytest
+from fastapi.testclient import TestClient
+from orcheo_backend.app import create_app
+from orcheo_backend.app.history import InMemoryRunHistoryStore
+from orcheo_backend.app.repository import InMemoryWorkflowRepository
+
+
+@pytest.fixture
+def repository():
+    """Create an in-memory repository for testing."""
+    return InMemoryWorkflowRepository()
+
+
+@pytest.fixture
+def history_store():
+    """Create an in-memory history store for testing."""
+    return InMemoryRunHistoryStore()
+
+
+@pytest.fixture
+def client(repository, history_store):
+    """Create a test client with in-memory dependencies."""
+    app = create_app(repository=repository, history_store=history_store)
+    return TestClient(app)
+
+
+def test_list_workflows_empty(client):
+    """List workflows returns empty list initially."""
+    response = client.get("/api/workflows")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_create_and_get_workflow(client):
+    """Create and retrieve a workflow."""
+    # Create workflow
+    create_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "description": "A test workflow",
+            "tags": ["test"],
+            "actor": "admin",
+        },
+    )
+    assert create_response.status_code == 201
+    workflow_data = create_response.json()
+    workflow_id = workflow_data["id"]
+
+    # Get workflow
+    get_response = client.get(f"/api/workflows/{workflow_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["name"] == "Test Workflow"
+
+
+def test_update_workflow(client):
+    """Update workflow attributes."""
+    # Create workflow first
+    create_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Original Name",
+            "slug": "original-slug",
+            "actor": "admin",
+        },
+    )
+    workflow_id = create_response.json()["id"]
+
+    # Update workflow
+    update_response = client.put(
+        f"/api/workflows/{workflow_id}",
+        json={
+            "name": "Updated Name",
+            "description": "Updated description",
+            "tags": ["updated"],
+            "is_archived": False,
+            "actor": "admin",
+        },
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["name"] == "Updated Name"
+
+
+def test_archive_workflow(client):
+    """Archive a workflow via DELETE."""
+    # Create workflow first
+    create_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "To Archive",
+            "slug": "to-archive",
+            "actor": "admin",
+        },
+    )
+    workflow_id = create_response.json()["id"]
+
+    # Archive workflow
+    delete_response = client.delete(f"/api/workflows/{workflow_id}?actor=admin")
+    assert delete_response.status_code == 200
+    assert delete_response.json()["is_archived"] is True
+
+
+def test_get_workflow_not_found(client):
+    """Get non-existent workflow returns 404."""
+    random_id = str(uuid4())
+    response = client.get(f"/api/workflows/{random_id}")
+    assert response.status_code == 404
+
+
+def test_create_workflow_version(client):
+    """Create a workflow version."""
+    # Create workflow first
+    workflow_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "actor": "admin",
+        },
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    # Create version
+    version_response = client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": [], "edges": []},
+            "metadata": {"test": "data"},
+            "notes": "Initial version",
+            "created_by": "admin",
+        },
+    )
+    assert version_response.status_code == 201
+    assert version_response.json()["version"] == 1
+
+
+def test_list_workflow_versions(client):
+    """List workflow versions."""
+    # Create workflow and version
+    workflow_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "actor": "admin",
+        },
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {},
+            "created_by": "admin",
+        },
+    )
+
+    # List versions
+    versions_response = client.get(f"/api/workflows/{workflow_id}/versions")
+    assert versions_response.status_code == 200
+    assert len(versions_response.json()) == 1
+
+
+def test_get_workflow_version(client):
+    """Get specific workflow version."""
+    # Create workflow and version
+    workflow_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "actor": "admin",
+        },
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {},
+            "created_by": "admin",
+        },
+    )
+
+    # Get version by number
+    version_response = client.get(f"/api/workflows/{workflow_id}/versions/1")
+    assert version_response.status_code == 200
+    assert version_response.json()["version"] == 1
+
+
+def test_diff_workflow_versions(client):
+    """Generate diff between workflow versions."""
+    # Create workflow and two versions
+    workflow_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "actor": "admin",
+        },
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": []},
+            "created_by": "admin",
+        },
+    )
+
+    client.post(
+        f"/api/workflows/{workflow_id}/versions",
+        json={
+            "graph": {"nodes": ["node1"]},
+            "created_by": "admin",
+        },
+    )
+
+    # Get diff
+    diff_response = client.get(f"/api/workflows/{workflow_id}/versions/1/diff/2")
+    assert diff_response.status_code == 200
+    assert diff_response.json()["base_version"] == 1
+    assert diff_response.json()["target_version"] == 2
+
+
+def test_list_workflow_execution_histories(client):
+    """List execution histories for a workflow."""
+    workflow_id = uuid4()
+
+    # List histories (should be empty)
+    response = client.get(f"/api/workflows/{workflow_id}/executions?limit=50")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_dispatch_cron_triggers(client):
+    """Dispatch cron triggers."""
+    response = client.post("/api/triggers/cron/dispatch")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_execute_node_missing_type(client):
+    """Execute node without type field returns 400."""
+    response = client.post(
+        "/api/nodes/execute",
+        json={
+            "node_config": {"name": "test"},
+            "inputs": {},
+        },
+    )
+    assert response.status_code == 400
+    assert "type" in response.json()["detail"]
+
+
+def test_execute_node_unknown_type(client):
+    """Execute node with unknown type returns 400."""
+    response = client.post(
+        "/api/nodes/execute",
+        json={
+            "node_config": {"type": "unknown_node_type", "name": "test"},
+            "inputs": {},
+        },
+    )
+    assert response.status_code == 400
+    assert "Unknown node type" in response.json()["detail"]
+
+
+def test_ingest_workflow_version_invalid_script(client):
+    """Ingest invalid LangGraph script returns 400."""
+    # Create workflow first
+    workflow_response = client.post(
+        "/api/workflows",
+        json={
+            "name": "Test Workflow",
+            "slug": "test-workflow",
+            "actor": "admin",
+        },
+    )
+    workflow_id = workflow_response.json()["id"]
+
+    # Try to ingest invalid script
+    response = client.post(
+        f"/api/workflows/{workflow_id}/versions/ingest",
+        json={
+            "script": "# Not a valid LangGraph script",
+            "created_by": "admin",
+        },
+    )
+    assert response.status_code == 400

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -490,6 +490,37 @@ def test_list_credentials_endpoint_returns_vault_entries(
     assert credential["secret_preview"]
 
 
+def test_create_credential(api_client: TestClient) -> None:
+    workflow_id = uuid4()
+    response = api_client.post(
+        "/api/credentials",
+        json={
+            "name": "Canvas API",
+            "provider": "api",
+            "secret": "sk_test_canvas",
+            "actor": "tester",
+            "access": "private",
+            "workflow_id": str(workflow_id),
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["name"] == "Canvas API"
+    assert payload["provider"] == "api"
+    assert payload["owner"] == "tester"
+    assert payload["access"] == "private"
+
+    fetch_response = api_client.get(
+        "/api/credentials",
+        params={"workflow_id": str(workflow_id)},
+    )
+
+    assert fetch_response.status_code == 200
+    entries = fetch_response.json()
+    assert any(entry["id"] == payload["id"] for entry in entries)
+
+
 def test_credential_template_get_scope_violation_returns_403(
     api_client: TestClient,
 ) -> None:

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -521,6 +521,37 @@ def test_create_credential(api_client: TestClient) -> None:
     assert any(entry["id"] == payload["id"] for entry in entries)
 
 
+def test_delete_credential(api_client: TestClient) -> None:
+    workflow_id = uuid4()
+    create_response = api_client.post(
+        "/api/credentials",
+        json={
+            "name": "Canvas API",
+            "provider": "api",
+            "secret": "sk_test_canvas",
+            "actor": "tester",
+            "access": "private",
+            "workflow_id": str(workflow_id),
+        },
+    )
+    assert create_response.status_code == 201
+    credential_id = create_response.json()["id"]
+
+    delete_response = api_client.delete(
+        f"/api/credentials/{credential_id}",
+        params={"workflow_id": str(workflow_id)},
+    )
+    assert delete_response.status_code == 204
+
+    fetch_response = api_client.get(
+        "/api/credentials",
+        params={"workflow_id": str(workflow_id)},
+    )
+    assert fetch_response.status_code == 200
+    payload = fetch_response.json()
+    assert all(entry["id"] != credential_id for entry in payload)
+
+
 def test_credential_template_get_scope_violation_returns_403(
     api_client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary
- remove the credential vault section from the readiness tab
- surface the credential vault from the profile menu via a dedicated dialog
- pass vault data through the top navigation so it can manage credentials globally

## Testing
- make canvas-format
- make canvas-lint
- make canvas-test

------
https://chatgpt.com/codex/tasks/task_e_68ff8dc4dfb483279f31a346b46bdea4