### PR TITLE
Add Orcheo CLI with full test coverage

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,13 +4,18 @@ requires = ["hatchling"]
 
 [project]
 dependencies = [
-  "httpx>=0.27.0"
+  "httpx>=0.27.0",
+  "rich>=13.7.0",
+  "typer>=0.12.3",
 ]
 description = "Client helpers for the Orcheo workflow orchestration platform"
 name = "orcheo-sdk"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.4.0"
+
+[project.scripts]
+orcheo = "orcheo_sdk.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/sdk/src/orcheo_sdk/cli/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/__init__.py
@@ -1,0 +1,7 @@
+"""Command line interface entrypoint for the Orcheo SDK."""
+
+from __future__ import annotations
+from .app import app, main
+
+
+__all__ = ["app", "main"]

--- a/packages/sdk/src/orcheo_sdk/cli/api.py
+++ b/packages/sdk/src/orcheo_sdk/cli/api.py
@@ -1,0 +1,141 @@
+"""HTTP client helpers for the Orcheo CLI."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+import httpx
+from .cache import CacheStore
+
+
+class ApiRequestError(RuntimeError):
+    """Raised when the CLI cannot complete an API request."""
+
+    def __init__(self, message: str, *, response: httpx.Response | None = None) -> None:
+        """Initialise the error with optional HTTP response context."""
+        super().__init__(message)
+        self.response = response
+
+
+class OfflineCacheMissError(ApiRequestError):
+    """Raised when offline mode is requested but no cached response exists."""
+
+
+@dataclass(slots=True)
+class FetchResult:
+    """Wrapper describing the origin of an API payload."""
+
+    data: Any
+    from_cache: bool
+    timestamp: datetime | None
+
+
+class APIClient:
+    """Small wrapper around :class:`httpx.Client` with caching support."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        service_token: str | None,
+        cache: CacheStore,
+        timeout: float = 30.0,
+    ) -> None:
+        """Create a client bound to the provided API endpoint."""
+        headers: dict[str, str] = {"User-Agent": "orcheo-cli/1.0"}
+        if service_token:
+            headers["Authorization"] = f"Bearer {service_token}"
+        self._client = httpx.Client(base_url=base_url, timeout=timeout, headers=headers)
+        self._cache = cache
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def fetch_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+        offline: bool = False,
+        description: str = "resource",
+    ) -> FetchResult:
+        """Return JSON data from the API with cache fallbacks."""
+        cache_key = self._cache.build_key(method, path, params)
+        if offline:
+            cached = self._cache.read(cache_key)
+            if cached:
+                return FetchResult(
+                    data=cached.data,
+                    from_cache=True,
+                    timestamp=cached.timestamp,
+                )
+            msg = f"No cached {description} available for offline mode"
+            raise OfflineCacheMissError(msg)
+
+        try:
+            response = self._client.request(method, path, params=params, json=json)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - exercised via tests
+            cached = self._cache.read(cache_key)
+            if cached:
+                return FetchResult(
+                    data=cached.data, from_cache=True, timestamp=cached.timestamp
+                )
+            status = exc.response.status_code
+            msg = (
+                f"API request failed with status {status} while fetching {description}"
+            )
+            raise ApiRequestError(msg, response=exc.response) from exc
+        except httpx.HTTPError as exc:
+            cached = self._cache.read(cache_key)
+            if cached:
+                return FetchResult(
+                    data=cached.data, from_cache=True, timestamp=cached.timestamp
+                )
+            msg = f"Unable to reach Orcheo API while fetching {description}"
+            raise ApiRequestError(msg) from exc
+
+        try:
+            data = response.json()
+        except ValueError:
+            data = None
+        if method.upper() == "GET":
+            self._cache.write(cache_key, data)
+        return FetchResult(data=data, from_cache=False, timestamp=datetime.now(tz=UTC))
+
+    def get_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        offline: bool = False,
+        description: str = "resource",
+    ) -> FetchResult:
+        """Helper for GET requests returning JSON payloads."""
+        return self.fetch_json(
+            "GET", path, params=params, offline=offline, description=description
+        )
+
+    def post_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+        description: str = "resource",
+    ) -> FetchResult:
+        """Helper for POST requests returning JSON payloads."""
+        return self.fetch_json(
+            "POST", path, params=params, json=json, description=description
+        )
+
+
+__all__ = [
+    "APIClient",
+    "ApiRequestError",
+    "FetchResult",
+    "OfflineCacheMissError",
+]

--- a/packages/sdk/src/orcheo_sdk/cli/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/app.py
@@ -1,0 +1,96 @@
+"""Typer application wiring for the Orcheo CLI."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Annotated
+import typer
+from rich.console import Console
+from .api import APIClient
+from .cache import CacheStore
+from .code import code_app
+from .config import ProfileNotFoundError, resolve_settings
+from .credentials import credential_app
+from .nodes import node_app
+from .state import CLIContext
+from .workflows import workflow_app
+
+
+app = typer.Typer(help="Command line tools for the Orcheo platform.")
+app.add_typer(node_app, name="node")
+app.add_typer(workflow_app, name="workflow")
+app.add_typer(credential_app, name="credential")
+app.add_typer(code_app, name="code")
+
+
+@app.callback()
+def _configure(
+    ctx: typer.Context,
+    api_url: Annotated[
+        str | None,
+        typer.Option(help="Override the Orcheo API URL."),
+    ] = None,
+    service_token: Annotated[
+        str | None,
+        typer.Option(help="Service token used for authentication."),
+    ] = None,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            "-p",
+            help="Named profile from the CLI config file.",
+        ),
+    ] = None,
+    offline: Annotated[
+        bool,
+        typer.Option(
+            help="Serve data from cache without network calls.",
+        ),
+    ] = False,
+    config_path: Annotated[
+        Path | None,
+        typer.Option(help="Path to cli.toml with saved profiles."),
+    ] = None,
+    cache_dir: Annotated[
+        Path | None,
+        typer.Option(help="Directory for cached responses."),
+    ] = None,
+) -> None:
+    """Initialise shared CLI state before executing a command."""
+    try:
+        settings = resolve_settings(
+            api_url=api_url,
+            service_token=service_token,
+            profile=profile,
+            config_path=config_path,
+            cache_dir=cache_dir,
+        )
+    except ProfileNotFoundError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    cache = CacheStore(settings.cache_dir)
+    cache.ensure()
+
+    base_url = settings.api_url.rstrip("/")
+    if not base_url.endswith("/api"):
+        base_url = f"{base_url}/api"
+
+    client = APIClient(
+        base_url=base_url,
+        service_token=settings.service_token,
+        cache=cache,
+    )
+    console = Console()
+
+    ctx.obj = CLIContext(
+        settings=settings, client=client, cache=cache, console=console, offline=offline
+    )
+    ctx.call_on_close(client.close)
+
+
+def main() -> None:
+    """Entry point for console script execution."""
+    app()
+
+
+__all__ = ["app", "main"]

--- a/packages/sdk/src/orcheo_sdk/cli/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/app.py
@@ -15,7 +15,9 @@ from .state import CLIContext
 from .workflows import workflow_app
 
 
-app = typer.Typer(help="Command line tools for the Orcheo platform.")
+app = typer.Typer(
+    help="Command line tools for the Orcheo platform.", add_completion=True
+)
 app.add_typer(node_app, name="node")
 app.add_typer(workflow_app, name="workflow")
 app.add_typer(credential_app, name="credential")

--- a/packages/sdk/src/orcheo_sdk/cli/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/app.py
@@ -1,6 +1,7 @@
 """Typer application wiring for the Orcheo CLI."""
 
 from __future__ import annotations
+import os
 from pathlib import Path
 from typing import Annotated
 import typer
@@ -66,6 +67,7 @@ def _configure(
             profile=profile,
             config_path=config_path,
             cache_dir=cache_dir,
+            env=os.environ,
         )
     except ProfileNotFoundError as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/packages/sdk/src/orcheo_sdk/cli/cache.py
+++ b/packages/sdk/src/orcheo_sdk/cli/cache.py
@@ -1,0 +1,73 @@
+"""Response caching utilities for the Orcheo CLI."""
+
+from __future__ import annotations
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    """Cached response payload stored on disk."""
+
+    data: Any
+    timestamp: datetime
+
+
+class CacheStore:
+    """Store JSON responses for offline reuse."""
+
+    def __init__(self, root: Path) -> None:
+        """Create a cache store rooted at the provided directory."""
+        self.root = root
+        self._responses_dir = self.root / "responses"
+
+    def ensure(self) -> None:
+        """Ensure the cache directory exists."""
+        self._responses_dir.mkdir(parents=True, exist_ok=True)
+
+    def build_key(
+        self, method: str, path: str, params: dict[str, Any] | None = None
+    ) -> str:
+        """Return a deterministic key for the given HTTP request."""
+        method = method.upper()
+        base = f"{method} {path}"
+        if params:
+            serialized = json.dumps(params, sort_keys=True, separators=(",", ":"))
+            base = f"{base}?{serialized}"
+        digest = hashlib.sha256(base.encode("utf-8")).hexdigest()
+        return digest
+
+    def _entry_path(self, key: str) -> Path:
+        return self._responses_dir / f"{key}.json"
+
+    def write(self, key: str, data: Any) -> None:
+        """Persist a payload to the cache."""
+        path = self._entry_path(key)
+        payload = {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "data": data,
+        }
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+    def read(self, key: str) -> CacheEntry | None:
+        """Return a cached payload if present."""
+        path = self._entry_path(key)
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        timestamp_raw = payload.get("timestamp")
+        timestamp: datetime | None = None
+        if isinstance(timestamp_raw, str):
+            timestamp = datetime.fromisoformat(timestamp_raw)
+        if timestamp is None:
+            timestamp = datetime.now(tz=UTC)
+        return CacheEntry(data=payload.get("data"), timestamp=timestamp)
+
+
+__all__ = ["CacheEntry", "CacheStore"]

--- a/packages/sdk/src/orcheo_sdk/cli/code.py
+++ b/packages/sdk/src/orcheo_sdk/cli/code.py
@@ -7,7 +7,7 @@ from .api import ApiRequestError
 from .utils import abort_with_error, get_context
 
 
-code_app = typer.Typer(help="Generate Orcheo SDK reference code.")
+code_app = typer.Typer(help="Generate Orcheo SDK reference code.", add_completion=True)
 
 
 @code_app.command("scaffold")

--- a/packages/sdk/src/orcheo_sdk/cli/code.py
+++ b/packages/sdk/src/orcheo_sdk/cli/code.py
@@ -1,0 +1,77 @@
+"""Reference code generation commands."""
+
+from __future__ import annotations
+from textwrap import dedent
+import typer
+from .api import ApiRequestError
+from .utils import abort_with_error, get_context
+
+
+code_app = typer.Typer(help="Generate Orcheo SDK reference code.")
+
+
+@code_app.command("scaffold")
+def scaffold_workflow(
+    ctx: typer.Context,
+    workflow_id: str = typer.Argument(..., help="Workflow identifier."),
+) -> None:
+    """Generate a Python snippet that triggers a workflow."""
+    context = get_context(ctx)
+
+    try:
+        versions = context.client.get_json(
+            f"/workflows/{workflow_id}/versions",
+            offline=context.offline,
+            description="workflow versions",
+        )
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    entries = versions.data if isinstance(versions.data, list) else []
+    if not entries:
+        context.console.print(
+            "[red]Workflow has no versions; deploy a version before scaffolding.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    latest = max(
+        (entry for entry in entries if isinstance(entry, dict)),
+        key=lambda item: int(item.get("version", 0) or 0),
+    )
+    version_id = str(latest.get("id"))
+
+    api_root = context.settings.api_url.rstrip("/")
+    if api_root.endswith("/api"):
+        api_root = api_root[: -len("/api")]
+
+    snippet = dedent(
+        f"""
+        import os
+        from orcheo_sdk import HttpWorkflowExecutor, OrcheoClient
+
+        api_url = os.getenv("ORCHEO_API_URL", "{api_root}")
+        service_token = os.getenv("ORCHEO_SERVICE_TOKEN")
+
+        default_headers = {{}}
+        if service_token:
+            default_headers["Authorization"] = f"Bearer {{service_token}}"
+
+        client = OrcheoClient(base_url=api_url, default_headers=default_headers)
+        executor = HttpWorkflowExecutor(client, auth_token=service_token)
+
+        run = executor.trigger_run(
+            workflow_id="{workflow_id}",
+            workflow_version_id="{version_id}",
+            triggered_by="cli",
+            inputs={{}},
+        )
+
+        print(run)
+        """
+    ).strip()
+
+    context.console.print("[bold]Python scaffold:[/bold]")
+    context.console.print(snippet)
+
+
+__all__ = ["code_app"]

--- a/packages/sdk/src/orcheo_sdk/cli/config.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config.py
@@ -1,0 +1,123 @@
+"""Configuration helpers for the Orcheo CLI."""
+
+from __future__ import annotations
+import os
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_DEFAULT_API_URL = "http://localhost:8000"
+
+
+@dataclass(slots=True)
+class ProfileConfig:
+    """Configuration declared within a named CLI profile."""
+
+    api_url: str | None = None
+    service_token: str | None = None
+
+
+@dataclass(slots=True)
+class CLISettings:
+    """Resolved CLI configuration after applying precedence rules."""
+
+    api_url: str
+    service_token: str | None
+    profile: str | None
+    config_path: Path
+    cache_dir: Path
+
+
+class ProfileNotFoundError(ValueError):
+    """Raised when a requested profile cannot be located."""
+
+
+def _default_config_path() -> Path:
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return config_home / "orcheo" / "cli.toml"
+
+
+def _default_cache_dir() -> Path:
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_home / "orcheo"
+
+
+def load_profiles(path: Path) -> Mapping[str, ProfileConfig]:
+    """Return profiles defined in the provided configuration file."""
+    if not path.exists():
+        return {}
+
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    raw_profiles = data.get("profiles", {})
+    profiles: dict[str, ProfileConfig] = {}
+    for name, payload in raw_profiles.items():
+        if not isinstance(payload, dict):
+            continue
+        profiles[name] = ProfileConfig(
+            api_url=payload.get("api_url"),
+            service_token=payload.get("service_token"),
+        )
+    return profiles
+
+
+def resolve_settings(
+    *,
+    api_url: str | None,
+    service_token: str | None,
+    profile: str | None,
+    config_path: Path | None,
+    cache_dir: Path | None,
+    env: Mapping[str, str] | None = None,
+) -> CLISettings:
+    """Combine CLI options, environment variables, and profiles."""
+    env = dict(env or {})
+
+    profile_name = profile or env.get("ORCHEO_PROFILE")
+    resolved_config_path = config_path or Path(
+        env.get("ORCHEO_CLI_CONFIG", _default_config_path())
+    )
+    resolved_cache_dir = cache_dir or Path(
+        env.get("ORCHEO_CLI_CACHE", _default_cache_dir())
+    )
+
+    profiles = load_profiles(resolved_config_path)
+    profile_config: ProfileConfig | None = None
+    if profile_name:
+        profile_config = profiles.get(profile_name)
+        if profile_config is None:
+            msg = f"Profile '{profile_name}' not found in {resolved_config_path}"
+            raise ProfileNotFoundError(msg)
+
+    resolved_api_url = (
+        api_url
+        or env.get("ORCHEO_API_URL")
+        or (profile_config.api_url if profile_config else None)
+        or _DEFAULT_API_URL
+    )
+
+    resolved_service_token = (
+        service_token
+        or env.get("ORCHEO_SERVICE_TOKEN")
+        or (profile_config.service_token if profile_config else None)
+    )
+
+    return CLISettings(
+        api_url=resolved_api_url,
+        service_token=resolved_service_token,
+        profile=profile_name,
+        config_path=resolved_config_path,
+        cache_dir=resolved_cache_dir,
+    )
+
+
+__all__ = [
+    "CLISettings",
+    "ProfileConfig",
+    "ProfileNotFoundError",
+    "load_profiles",
+    "resolve_settings",
+]

--- a/packages/sdk/src/orcheo_sdk/cli/credentials.py
+++ b/packages/sdk/src/orcheo_sdk/cli/credentials.py
@@ -1,0 +1,205 @@
+"""Credential management commands."""
+
+from __future__ import annotations
+from typing import Any
+import typer
+from rich.text import Text
+from .api import ApiRequestError, OfflineCacheMissError
+from .render import render_kv_section, render_table
+from .utils import abort_with_error, get_context, show_cache_notice
+
+
+credential_app = typer.Typer(help="Manage Orcheo credentials.")
+
+
+@credential_app.command("list")
+def list_credentials(
+    ctx: typer.Context,
+    workflow_id: str | None = typer.Option(
+        None, help="Filter credentials scoped to a workflow ID."
+    ),
+) -> None:
+    """List credentials visible to the caller."""
+    context = get_context(ctx)
+    params: dict[str, str] = {}
+    if workflow_id:
+        params["workflow_id"] = workflow_id
+
+    try:
+        result = context.client.get_json(
+            "/credentials",
+            params=params or None,
+            offline=context.offline,
+            description="credentials",
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    entries = result.data if isinstance(result.data, list) else []
+    rows: list[tuple[str, str, str, str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        rows.append(
+            (
+                str(entry.get("id", "")),
+                str(entry.get("name", "")),
+                str(entry.get("provider", "")),
+                str(entry.get("access", "")),
+                str(entry.get("status", "")),
+            )
+        )
+
+    if not rows:
+        context.console.print("[yellow]No credentials found.[/yellow]")
+    else:
+        render_table(
+            context.console,
+            title="Credentials",
+            columns=("ID", "Name", "Provider", "Access", "Status"),
+            rows=rows,
+        )
+
+    if result.from_cache:
+        show_cache_notice(context, result.timestamp)
+
+
+@credential_app.command("reference")
+def credential_reference(
+    ctx: typer.Context,
+    credential: str = typer.Argument(..., help="Credential ID or name."),
+) -> None:
+    """Output the [[credential]] reference snippet."""
+    context = get_context(ctx)
+    try:
+        result = context.client.get_json(
+            "/credentials",
+            offline=context.offline,
+            description="credentials",
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    entries = result.data if isinstance(result.data, list) else []
+    match = _find_credential(entries, credential)
+    if match is None:
+        context.console.print(
+            f"[red]Credential '{credential}' not found in the current scope.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    name = str(match.get("name", credential))
+    snippet = f"[[{name}]]"
+    message = Text("Credential reference: ")
+    message.append(snippet, style="bold")
+    context.console.print(message)
+    context.console.print(
+        "Use this snippet in node configurations to reference the credential."
+    )
+
+    if result.from_cache:
+        show_cache_notice(context, result.timestamp)
+
+
+@credential_app.command("create")
+def create_credential(
+    ctx: typer.Context,
+    name: str = typer.Option(..., prompt=True, help="Credential name."),
+    provider: str = typer.Option(..., prompt=True, help="Provider identifier."),
+    secret: str = typer.Option(..., prompt=True, hide_input=True, help="Secret value."),
+    access: str = typer.Option(
+        "private", help="Access level: private, shared, or public."
+    ),
+    scopes: str = typer.Option(
+        "", help="Comma-separated scopes to associate with the credential."
+    ),
+    workflow_id: str | None = typer.Option(
+        None, help="Associate credential with a workflow scope."
+    ),
+    actor: str = typer.Option("cli", help="Actor recorded for audit purposes."),
+    kind: str = typer.Option("secret", help="Credential kind (secret, oauth, token)."),
+) -> None:
+    """Create a credential via the Orcheo API."""
+    context = get_context(ctx)
+
+    payload = {
+        "name": name,
+        "provider": provider,
+        "secret": secret,
+        "access": access,
+        "scopes": _parse_scopes(scopes),
+        "workflow_id": workflow_id,
+        "actor": actor,
+        "kind": kind,
+    }
+
+    try:
+        result = context.client.post_json(
+            "/credentials",
+            json=payload,
+            description="credential",
+        )
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    data = result.data if isinstance(result.data, dict) else {}
+    render_kv_section(
+        context.console,
+        title="Credential Created",
+        pairs=[
+            ("ID", str(data.get("id", ""))),
+            ("Name", str(data.get("name", name))),
+            ("Provider", str(data.get("provider", provider))),
+            ("Access", str(data.get("access", access))),
+        ],
+    )
+
+
+@credential_app.command("delete")
+def delete_credential(
+    ctx: typer.Context,
+    credential_id: str = typer.Argument(..., help="Credential identifier."),
+    workflow_id: str | None = typer.Option(None, help="Workflow scope, if required."),
+) -> None:
+    """Delete a credential from the vault."""
+    context = get_context(ctx)
+    params: dict[str, str] = {}
+    if workflow_id:
+        params["workflow_id"] = workflow_id
+
+    try:
+        context.client.fetch_json(
+            "DELETE",
+            f"/credentials/{credential_id}",
+            params=params or None,
+            description="credential deletion",
+        )
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+    context.console.print(
+        f"[green]Credential {credential_id} deleted successfully.[/green]"
+    )
+
+
+def _find_credential(entries: list[Any], identifier: str) -> dict[str, Any] | None:
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("id")) == identifier:
+            return item
+        if str(item.get("name", "")).lower() == identifier.lower():
+            return item
+    return None
+
+
+def _parse_scopes(raw: str) -> list[str]:
+    return [scope.strip() for scope in raw.split(",") if scope.strip()]
+
+
+__all__ = ["credential_app"]

--- a/packages/sdk/src/orcheo_sdk/cli/credentials.py
+++ b/packages/sdk/src/orcheo_sdk/cli/credentials.py
@@ -9,7 +9,7 @@ from .render import render_kv_section, render_table
 from .utils import abort_with_error, get_context, show_cache_notice
 
 
-credential_app = typer.Typer(help="Manage Orcheo credentials.")
+credential_app = typer.Typer(help="Manage Orcheo credentials.", add_completion=True)
 
 
 @credential_app.command("list")

--- a/packages/sdk/src/orcheo_sdk/cli/nodes.py
+++ b/packages/sdk/src/orcheo_sdk/cli/nodes.py
@@ -1,0 +1,157 @@
+"""Node discovery commands."""
+
+from __future__ import annotations
+from typing import Any
+import typer
+from .api import ApiRequestError, OfflineCacheMissError
+from .render import render_kv_section, render_table
+from .utils import abort_with_error, get_context, show_cache_notice
+
+
+node_app = typer.Typer(help="Inspect available Orcheo nodes.")
+
+
+@node_app.command("list")
+def list_nodes(
+    ctx: typer.Context,
+    tag: str = typer.Option(None, help="Filter nodes by tag."),
+    category: str = typer.Option(None, help="Filter nodes by category."),
+) -> None:
+    """Display the node catalog."""
+    context = get_context(ctx)
+    params: dict[str, str] = {}
+    if tag:
+        params["tag"] = tag
+    if category:
+        params["category"] = category
+
+    try:
+        result = context.client.get_json(
+            "/nodes/catalog",
+            params=params or None,
+            offline=context.offline,
+            description="node catalog",
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    entries = result.data if isinstance(result.data, list) else []
+    rows: list[tuple[str, str, str, str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", ""))
+        type_name = str(entry.get("type", ""))
+        version = str(entry.get("version", ""))
+        category_value = str(entry.get("category", ""))
+        tags_value = ""
+        tags = entry.get("tags")
+        if isinstance(tags, list):
+            tags_value = ", ".join(str(tag) for tag in tags)
+        rows.append((name, type_name, version, category_value, tags_value))
+
+    if not rows:
+        context.console.print("[yellow]No nodes found.[/yellow]")
+    else:
+        render_table(
+            context.console,
+            title="Node Catalog",
+            columns=("Name", "Type", "Version", "Category", "Tags"),
+            rows=rows,
+        )
+
+    if result.from_cache:
+        show_cache_notice(context, result.timestamp)
+
+
+@node_app.command("show")
+def show_node(
+    ctx: typer.Context,
+    node: str = typer.Argument(..., help="Node identifier to inspect."),
+) -> None:
+    """Show metadata for a single node."""
+    context = get_context(ctx)
+
+    try:
+        result = context.client.get_json(
+            f"/nodes/catalog/{node}",
+            offline=context.offline,
+            description="node details",
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    payload = result.data if isinstance(result.data, dict) else {}
+
+    metadata_pairs = [
+        ("Name", str(payload.get("name", node))),
+        ("Type", str(payload.get("type", "unknown"))),
+        ("Version", str(payload.get("version", "n/a"))),
+        ("Category", str(payload.get("category", "general"))),
+        ("Description", str(payload.get("description", ""))),
+    ]
+    render_kv_section(context.console, title="Node", pairs=metadata_pairs)
+
+    inputs = payload.get("inputs")
+    if isinstance(inputs, list) and inputs:
+        input_rows = _schema_rows(inputs)
+        render_table(
+            context.console,
+            title="Inputs",
+            columns=("Name", "Type", "Required", "Description"),
+            rows=input_rows,
+        )
+
+    outputs = payload.get("outputs")
+    if isinstance(outputs, list) and outputs:
+        output_rows = _schema_rows(outputs)
+        render_table(
+            context.console,
+            title="Outputs",
+            columns=("Name", "Type", "Required", "Description"),
+            rows=output_rows,
+        )
+
+    credentials = payload.get("credentials")
+    if isinstance(credentials, list) and credentials:
+        credential_rows: list[tuple[str, str]] = []
+        for cred in credentials:
+            if not isinstance(cred, dict):
+                continue
+            credential_rows.append(
+                (
+                    str(cred.get("name", "")),
+                    str(cred.get("description", "")),
+                )
+            )
+        render_table(
+            context.console,
+            title="Credential Requirements",
+            columns=("Credential", "Description"),
+            rows=credential_rows,
+        )
+
+    if result.from_cache:
+        show_cache_notice(context, result.timestamp)
+
+
+def _schema_rows(items: list[Any]) -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", ""))
+        type_name = str(item.get("type", ""))
+        required_flag = str(item.get("required", False))
+        description = str(item.get("description", ""))
+        rows.append((name, type_name, required_flag, description))
+    return rows
+
+
+__all__ = ["node_app"]

--- a/packages/sdk/src/orcheo_sdk/cli/nodes.py
+++ b/packages/sdk/src/orcheo_sdk/cli/nodes.py
@@ -1,14 +1,25 @@
 """Node discovery commands."""
 
 from __future__ import annotations
-from typing import Any
+import inspect
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 import typer
 from .api import ApiRequestError, OfflineCacheMissError
 from .render import render_kv_section, render_table
 from .utils import abort_with_error, get_context, show_cache_notice
 
 
-node_app = typer.Typer(help="Inspect available Orcheo nodes.")
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from collections.abc import Iterable
+    from orcheo.nodes.registry import NodeMetadata, NodeRegistry
+
+
+class NodeRegistryUnavailableError(RuntimeError):
+    """Raised when the local Orcheo node registry cannot be loaded."""
+
+
+node_app = typer.Typer(help="Inspect available Orcheo nodes.", add_completion=True)
 
 
 @node_app.command("list")
@@ -19,52 +30,135 @@ def list_nodes(
 ) -> None:
     """Display the node catalog."""
     context = get_context(ctx)
-    params: dict[str, str] = {}
-    if tag:
-        params["tag"] = tag
-    if category:
-        params["category"] = category
-
     try:
-        result = context.client.get_json(
-            "/nodes/catalog",
-            params=params or None,
-            offline=context.offline,
-            description="node catalog",
-        )
-    except OfflineCacheMissError as exc:
+        registry = _get_node_registry()
+    except NodeRegistryUnavailableError as exc:  # pragma: no cover - defensive guard
         context.console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
-    except ApiRequestError as exc:
-        abort_with_error(context, exc)
 
-    entries = result.data if isinstance(result.data, list) else []
-    rows: list[tuple[str, str, str, str, str]] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        name = str(entry.get("name", ""))
-        type_name = str(entry.get("type", ""))
-        version = str(entry.get("version", ""))
-        category_value = str(entry.get("category", ""))
-        tags_value = ""
-        tags = entry.get("tags")
-        if isinstance(tags, list):
-            tags_value = ", ".join(str(tag) for tag in tags)
-        rows.append((name, type_name, version, category_value, tags_value))
-
+    rows = _build_node_rows(registry, tag=tag, category=category)
     if not rows:
         context.console.print("[yellow]No nodes found.[/yellow]")
-    else:
-        render_table(
-            context.console,
-            title="Node Catalog",
-            columns=("Name", "Type", "Version", "Category", "Tags"),
-            rows=rows,
-        )
+        return
 
-    if result.from_cache:
-        show_cache_notice(context, result.timestamp)
+    render_table(
+        context.console,
+        title="Node Catalog",
+        columns=("Name", "Kind", "Category", "Description"),
+        rows=rows,
+    )
+
+
+def _get_node_registry() -> NodeRegistry:
+    """Return the active Orcheo node registry instance."""
+    try:
+        import_module("orcheo.nodes")
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        msg = "Orcheo core is not installed."
+        raise NodeRegistryUnavailableError(msg) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard
+        msg = "Failed to import Orcheo nodes."
+        raise NodeRegistryUnavailableError(msg) from exc
+
+    try:
+        from orcheo.nodes.registry import registry as core_registry
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        msg = "Orcheo node registry is unavailable."
+        raise NodeRegistryUnavailableError(msg) from exc
+
+    if not hasattr(core_registry, "iter_metadata"):
+        msg = "Installed Orcheo core version does not expose node metadata."
+        raise NodeRegistryUnavailableError(msg)
+
+    return core_registry
+
+
+def _build_node_rows(
+    registry: NodeRegistry,
+    *,
+    tag: str | None,
+    category: str | None,
+) -> list[tuple[str, str, str, str]]:
+    """Return display rows for the supplied ``registry``."""
+    try:
+        metadata_iter: Iterable[tuple[str, NodeMetadata]] = registry.iter_metadata()
+    except AttributeError as exc:  # pragma: no cover - old registry versions
+        msg = "Node registry does not support metadata iteration."
+        raise NodeRegistryUnavailableError(msg) from exc
+
+    rows: list[tuple[str, str, str, str]] = []
+    category_filter = category.casefold() if category else None
+    for name, metadata in metadata_iter:
+        node_name = str(getattr(metadata, "name", name))
+        node_category = str(getattr(metadata, "category", "general"))
+        if category_filter and node_category.casefold() != category_filter:
+            continue
+        if tag and not _metadata_matches_tag(metadata, tag):
+            continue
+        implementation = registry.get_node(name)
+        kind = _node_kind(implementation)
+        description = str(getattr(metadata, "description", ""))
+        rows.append((node_name, kind, node_category, description))
+
+    rows.sort(key=lambda row: row[0].casefold())
+    return rows
+
+
+def _metadata_matches_tag(metadata: NodeMetadata, tag: str) -> bool:
+    """Return True when ``metadata`` should be included for ``tag``."""
+    needle = tag.casefold()
+    tags = getattr(metadata, "tags", None)
+    if isinstance(tags, list):
+        for candidate in tags:
+            if needle in str(candidate).casefold():
+                return True
+
+    text_fields = (
+        getattr(metadata, "name", ""),
+        getattr(metadata, "description", ""),
+        getattr(metadata, "category", ""),
+    )
+    return any(
+        isinstance(field, str) and needle in field.casefold() for field in text_fields
+    )
+
+
+def _node_kind(implementation: Any) -> str:
+    """Return a friendly type label for ``implementation``."""
+    if implementation is None:
+        return "unknown"
+
+    candidate = (
+        implementation if inspect.isclass(implementation) else implementation.__class__
+    )
+
+    try:
+        triggers_module = import_module("orcheo.nodes.triggers")
+        trigger_node_cls = getattr(triggers_module, "TriggerNode", None)
+    except Exception:  # pragma: no cover - optional dependency safety
+        trigger_node_cls = None
+
+    try:
+        base_module = import_module("orcheo.nodes.base")
+        ai_node_cls = getattr(base_module, "AINode", None)
+        decision_node_cls = getattr(base_module, "DecisionNode", None)
+        task_node_cls = getattr(base_module, "TaskNode", None)
+    except Exception:  # pragma: no cover - optional dependency safety
+        ai_node_cls = decision_node_cls = task_node_cls = None
+
+    try:
+        if trigger_node_cls and issubclass(candidate, trigger_node_cls):
+            return "trigger"
+        if ai_node_cls and issubclass(candidate, ai_node_cls):
+            return "ai"
+        if decision_node_cls and issubclass(candidate, decision_node_cls):
+            return "decision"
+        if task_node_cls and issubclass(candidate, task_node_cls):
+            return "task"
+    except TypeError:  # pragma: no cover - guard for unusual callables
+        pass
+
+    return getattr(candidate, "__name__", type(implementation).__name__)
 
 
 @node_app.command("show")

--- a/packages/sdk/src/orcheo_sdk/cli/render.py
+++ b/packages/sdk/src/orcheo_sdk/cli/render.py
@@ -1,0 +1,84 @@
+"""Rendering helpers for CLI output."""
+
+from __future__ import annotations
+import re
+from collections.abc import Iterable, Sequence
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
+
+
+def render_table(
+    console: Console,
+    *,
+    title: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[str]],
+) -> None:
+    """Render a simple table using :mod:`rich`."""
+    table = Table(title=title, show_lines=False)
+    for column in columns:
+        table.add_column(column)
+    for row in rows:
+        table.add_row(*row)
+    console.print(table)
+
+
+def render_kv_section(
+    console: Console,
+    *,
+    title: str,
+    pairs: Sequence[tuple[str, str]],
+) -> None:
+    """Render key/value pairs in a bordered panel."""
+    lines = [f"[bold]{key}[/]: {value}" for key, value in pairs]
+    panel = Panel("\n".join(lines), title=title, expand=False)
+    console.print(panel)
+
+
+_IDENTIFIER_RE = re.compile(r"[^0-9A-Za-z_]")
+
+
+def _sanitize(identifier: str) -> str:
+    normalized = identifier.strip() or "node"
+    normalized = _IDENTIFIER_RE.sub("_", normalized)
+    if normalized[0].isdigit():
+        normalized = f"_{normalized}"
+    return normalized
+
+
+def graph_to_mermaid(graph: dict[str, object]) -> str:
+    """Convert a workflow graph definition into Mermaid syntax."""
+    nodes = graph.get("nodes")
+    edges = graph.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        return "flowchart TD\n    %% Invalid graph payload"
+
+    lines = ["flowchart TD"]
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        name = str(node.get("name", "node"))
+        type_name = str(node.get("type", ""))
+        label = name
+        if type_name:
+            label = f"{name}\\n[{type_name}]"
+        lines.append(f'    {_sanitize(name)}["{label}"]')
+
+    for edge in edges:
+        if not isinstance(edge, list | tuple) or len(edge) != 2:
+            continue
+        source, target = map(str, edge)
+        lines.append(f"    {_sanitize(source)} --> {_sanitize(target)}")
+    return "\n".join(lines)
+
+
+def render_mermaid(console: Console, *, title: str, mermaid: str) -> None:
+    """Print a Mermaid code block wrapped in a panel."""
+    markdown = Markdown(f"```mermaid\n{mermaid}\n```", code_theme="default")
+    panel = Panel(markdown, title=title, expand=False)
+    console.print(panel)
+
+
+__all__ = ["graph_to_mermaid", "render_kv_section", "render_mermaid", "render_table"]

--- a/packages/sdk/src/orcheo_sdk/cli/state.py
+++ b/packages/sdk/src/orcheo_sdk/cli/state.py
@@ -1,0 +1,22 @@
+"""Runtime state shared across CLI commands."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from rich.console import Console
+from .api import APIClient
+from .cache import CacheStore
+from .config import CLISettings
+
+
+@dataclass(slots=True)
+class CLIContext:
+    """Object stored on :class:`typer.Context` for command access."""
+
+    settings: CLISettings
+    client: APIClient
+    cache: CacheStore
+    console: Console
+    offline: bool = False
+
+
+__all__ = ["CLIContext"]

--- a/packages/sdk/src/orcheo_sdk/cli/utils.py
+++ b/packages/sdk/src/orcheo_sdk/cli/utils.py
@@ -1,0 +1,34 @@
+"""Shared helpers used across CLI command modules."""
+
+from __future__ import annotations
+from datetime import datetime
+import typer
+from .api import ApiRequestError
+from .state import CLIContext
+
+
+def get_context(ctx: typer.Context) -> CLIContext:
+    """Return the CLI context stored on the Typer context object."""
+    obj = ctx.ensure_object(CLIContext)
+    if not isinstance(obj, CLIContext):  # pragma: no cover - defensive branch
+        msg = "CLI context has not been initialised"
+        raise RuntimeError(msg)
+    return obj
+
+
+def abort_with_error(context: CLIContext, exc: ApiRequestError) -> None:
+    """Print an API error and exit the CLI with a non-zero status code."""
+    context.console.print(f"[red]{exc}[/red]")
+    raise typer.Exit(code=1)
+
+
+def show_cache_notice(context: CLIContext, result_timestamp: datetime | None) -> None:
+    """Display a note when cached data is rendered."""
+    if result_timestamp is None:
+        return
+    context.console.print(
+        f"[dim]Served from cache last updated at {result_timestamp.isoformat()}[/dim]"
+    )
+
+
+__all__ = ["abort_with_error", "get_context", "show_cache_notice"]

--- a/packages/sdk/src/orcheo_sdk/cli/workflows.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflows.py
@@ -1,0 +1,246 @@
+"""Workflow management commands."""
+
+from __future__ import annotations
+import json
+from datetime import datetime
+from typing import Any
+import typer
+from .api import ApiRequestError, OfflineCacheMissError
+from .render import graph_to_mermaid, render_kv_section, render_mermaid, render_table
+from .state import CLIContext
+from .utils import abort_with_error, get_context, show_cache_notice
+
+
+workflow_app = typer.Typer(help="Inspect and run workflows.")
+
+
+@workflow_app.command("list")
+def list_workflows(ctx: typer.Context) -> None:
+    """List workflows registered with the Orcheo backend."""
+    context = get_context(ctx)
+
+    try:
+        result = context.client.get_json(
+            "/workflows", offline=context.offline, description="workflows"
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    workflows = result.data if isinstance(result.data, list) else []
+    rows: list[tuple[str, str, str, str]] = []
+    for item in workflows:
+        if not isinstance(item, dict):
+            continue
+        workflow_id = str(item.get("id", ""))
+        name = str(item.get("name", ""))
+        slug = str(item.get("slug", ""))
+        updated_at = _format_datetime(item.get("updated_at"))
+        rows.append((workflow_id, name, slug, updated_at))
+
+    if not rows:
+        context.console.print("[yellow]No workflows found.[/yellow]")
+    else:
+        render_table(
+            context.console,
+            title="Workflows",
+            columns=("ID", "Name", "Slug", "Updated"),
+            rows=rows,
+        )
+
+    if result.from_cache:
+        show_cache_notice(context, result.timestamp)
+
+
+@workflow_app.command("show")
+def show_workflow(
+    ctx: typer.Context,
+    workflow_id: str = typer.Argument(..., help="Workflow identifier or slug."),
+) -> None:
+    """Display workflow metadata, versions, and recent runs."""
+    context = get_context(ctx)
+
+    try:
+        workflow_result = context.client.get_json(
+            f"/workflows/{workflow_id}",
+            offline=context.offline,
+            description="workflow",
+        )
+    except OfflineCacheMissError as exc:
+        context.console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    workflow = workflow_result.data if isinstance(workflow_result.data, dict) else {}
+    tags_value = ""
+    tags_raw = workflow.get("tags")
+    if isinstance(tags_raw, list):
+        tags_value = ", ".join(str(tag) for tag in tags_raw)
+
+    metadata_pairs = [
+        ("ID", str(workflow.get("id", workflow_id))),
+        ("Name", str(workflow.get("name", ""))),
+        ("Slug", str(workflow.get("slug", ""))),
+        ("Description", str(workflow.get("description", ""))),
+        ("Tags", tags_value),
+        ("Updated", _format_datetime(workflow.get("updated_at"))),
+    ]
+    render_kv_section(context.console, title="Workflow", pairs=metadata_pairs)
+
+    versions = _fetch_versions(context, workflow_id)
+    if versions:
+        rows = [
+            (
+                str(item.get("version", "")),
+                str(item.get("id", "")),
+                _format_datetime(item.get("created_at")),
+                str(item.get("created_by", "")),
+            )
+            for item in versions
+        ]
+        render_table(
+            context.console,
+            title="Versions",
+            columns=("Version", "Version ID", "Created", "Author"),
+            rows=rows,
+        )
+
+        latest = max(
+            (v for v in versions if isinstance(v, dict)),
+            key=lambda item: int(item.get("version", 0) or 0),
+            default=None,
+        )
+        if isinstance(latest, dict):
+            graph = latest.get("graph")
+            if isinstance(graph, dict):
+                mermaid = graph_to_mermaid(graph)
+                render_mermaid(context.console, title="Latest Graph", mermaid=mermaid)
+
+    runs = _fetch_runs(context, workflow_id)
+    if runs:
+        rows = [
+            (
+                str(item.get("id", "")),
+                str(item.get("status", "")),
+                _format_datetime(item.get("created_at")),
+                _format_datetime(item.get("completed_at")),
+            )
+            for item in runs[:5]
+        ]
+        render_table(
+            context.console,
+            title="Recent Runs",
+            columns=("Run ID", "Status", "Created", "Completed"),
+            rows=rows,
+        )
+
+    if workflow_result.from_cache:
+        show_cache_notice(context, workflow_result.timestamp)
+
+
+@workflow_app.command("run")
+def run_workflow(
+    ctx: typer.Context,
+    workflow_id: str = typer.Argument(..., help="Workflow identifier."),
+    version_id: str = typer.Option(
+        None, "--version-id", help="Workflow version identifier to execute."
+    ),
+    actor: str = typer.Option("cli", help="Actor recorded for the run."),
+    inputs: str = typer.Option("{}", help="JSON payload passed as workflow inputs."),
+) -> None:
+    """Trigger a workflow execution run."""
+    context = get_context(ctx)
+
+    try:
+        parsed_inputs = json.loads(inputs)
+        if not isinstance(parsed_inputs, dict):
+            raise ValueError
+    except ValueError:
+        context.console.print("[red]Inputs must be a JSON object.[/red]")
+        raise typer.Exit(code=1) from None
+
+    selected_version = version_id
+    if not selected_version:
+        versions = _fetch_versions(context, workflow_id)
+        if not versions:
+            context.console.print(
+                "[red]Unable to determine workflow version; specify --version-id.[/red]"
+            )
+            raise typer.Exit(code=1)
+        latest = max(
+            (v for v in versions if isinstance(v, dict)),
+            key=lambda item: int(item.get("version", 0) or 0),
+        )
+        selected_version = str(latest.get("id"))
+
+    payload = {
+        "workflow_version_id": selected_version,
+        "triggered_by": actor,
+        "input_payload": parsed_inputs,
+    }
+
+    try:
+        result = context.client.post_json(
+            f"/workflows/{workflow_id}/runs",
+            json=payload,
+            description="workflow run",
+        )
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+
+    data = result.data if isinstance(result.data, dict) else {}
+    metadata_pairs = [
+        ("Run ID", str(data.get("id", ""))),
+        ("Status", str(data.get("status", ""))),
+        ("Triggered By", str(data.get("triggered_by", actor))),
+        ("Created", _format_datetime(data.get("created_at"))),
+    ]
+    render_kv_section(context.console, title="Run", pairs=metadata_pairs)
+
+
+def _fetch_versions(context: CLIContext, workflow_id: str) -> list[dict[str, Any]]:
+    try:
+        result = context.client.get_json(
+            f"/workflows/{workflow_id}/versions",
+            offline=context.offline,
+            description="workflow versions",
+        )
+    except OfflineCacheMissError:
+        return []
+    except ApiRequestError as exc:
+        abort_with_error(context, exc)
+    versions = result.data if isinstance(result.data, list) else []
+    return [item for item in versions if isinstance(item, dict)]
+
+
+def _fetch_runs(context: CLIContext, workflow_id: str) -> list[dict[str, Any]]:
+    try:
+        result = context.client.get_json(
+            f"/workflows/{workflow_id}/runs",
+            offline=context.offline,
+            description="workflow runs",
+        )
+    except OfflineCacheMissError:
+        return []
+    except ApiRequestError:
+        return []
+    runs = result.data if isinstance(result.data, list) else []
+    return [item for item in runs if isinstance(item, dict)]
+
+
+def _format_datetime(value: Any) -> str:
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed.isoformat()
+        except ValueError:  # pragma: no cover - defensive fallback
+            return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return ""
+
+
+__all__ = ["workflow_app"]

--- a/packages/sdk/src/orcheo_sdk/cli/workflows.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflows.py
@@ -11,7 +11,7 @@ from .state import CLIContext
 from .utils import abort_with_error, get_context, show_cache_notice
 
 
-workflow_app = typer.Typer(help="Inspect and run workflows.")
+workflow_app = typer.Typer(help="Inspect and run workflows.", add_completion=True)
 
 
 @workflow_app.command("list")

--- a/src/orcheo/nodes/registry.py
+++ b/src/orcheo/nodes/registry.py
@@ -1,6 +1,6 @@
 """Registry implementation for Orcheo nodes."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pydantic import BaseModel
 
 
@@ -65,6 +65,14 @@ class NodeRegistry:
             if isinstance(registered, type) and isinstance(obj, registered):
                 return self._metadata.get(name)
         return None
+
+    def iter_metadata(self) -> Iterable[tuple[str, NodeMetadata]]:
+        """Yield ``(name, metadata)`` pairs for registered nodes."""
+        return self._metadata.items()
+
+    def list_metadata(self) -> list[NodeMetadata]:
+        """Return a snapshot of all registered node metadata."""
+        return list(self._metadata.values())
 
 
 # Global registry instance

--- a/tests/nodes/test_registry.py
+++ b/tests/nodes/test_registry.py
@@ -60,3 +60,19 @@ def test_get_metadata_by_callable_no_match() -> None:
 
     result = registry.get_metadata_by_callable(unregistered_node)
     assert result is None
+
+
+def test_list_metadata_returns_copy() -> None:
+    """list_metadata returns all registered metadata entries."""
+
+    registry = NodeRegistry()
+    metadata = NodeMetadata(
+        name="demo",
+        description="Demo node",
+        category="test",
+    )
+
+    registry.register(metadata)(lambda state: state)
+
+    snapshot = registry.list_metadata()
+    assert snapshot == [metadata]

--- a/tests/sdk/test_cli.py
+++ b/tests/sdk/test_cli.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from orcheo_sdk.cli import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def client_stub(monkeypatch):
+    responses: dict[tuple[str, str], tuple[int, object]] = {}
+    clients: list["DummyClient"] = []
+
+    class DummyClient:
+        def __init__(
+            self, *, base_url: str, timeout: float | None = None, headers=None
+        ):
+            self.base_url = base_url.rstrip("/")
+            self.headers = headers or {}
+            self.timeout = timeout
+            self.requests: list[
+                tuple[str, str, dict[str, object] | None, object | None]
+            ] = []
+            clients.append(self)
+
+        def request(self, method: str, url: str, params=None, json=None):
+            if not url.startswith("http"):
+                full_url = f"{self.base_url}{url}"
+            else:
+                full_url = url
+            key = (method.upper(), full_url)
+            self.requests.append((method.upper(), full_url, params, json))
+            if key not in responses:
+                request = httpx.Request(method, full_url)
+                raise httpx.RequestError("No response registered", request=request)
+            status, payload = responses[key]
+            request = httpx.Request(method, full_url)
+            return httpx.Response(status, request=request, json=payload)
+
+        def close(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    monkeypatch.setattr("orcheo_sdk.cli.api.httpx.Client", DummyClient)
+    return responses, clients
+
+
+def _api_url(base: str) -> str:
+    return f"{base.rstrip('/')}/api"
+
+
+def test_node_list_and_cache(runner: CliRunner, client_stub, tmp_path: Path) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    responses[("GET", f"{_api_url(base)}/nodes/catalog")] = (
+        200,
+        [
+            {
+                "name": "http_request",
+                "type": "http",
+                "version": "1.0.0",
+                "category": "data",
+                "tags": ["http", "data"],
+            }
+        ],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "node",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "http_request" in result.output
+    # Simulate offline by clearing responses and relying on cache
+    responses.clear()
+    offline_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "--offline",
+            "node",
+            "list",
+        ],
+    )
+    assert offline_result.exit_code == 0
+    assert "Served from cache" in offline_result.output
+
+
+def test_workflow_show_and_run(runner: CliRunner, client_stub, tmp_path: Path) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    workflow_id = "11111111-1111-1111-1111-111111111111"
+    responses[("GET", f"{_api_url(base)}/workflows")] = (200, [])
+    responses[("GET", f"{_api_url(base)}/workflows/{workflow_id}")] = (
+        200,
+        {
+            "id": workflow_id,
+            "name": "Demo",
+            "slug": "demo",
+            "description": "Demo workflow",
+            "tags": ["demo"],
+            "updated_at": "2025-01-01T00:00:00+00:00",
+        },
+    )
+    responses[("GET", f"{_api_url(base)}/workflows/{workflow_id}/versions")] = (
+        200,
+        [
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "version": 1,
+                "created_at": "2025-01-01T00:00:00+00:00",
+                "created_by": "cli",
+                "graph": {
+                    "nodes": [
+                        {"name": "start", "type": "trigger"},
+                        {"name": "task", "type": "action"},
+                    ],
+                    "edges": [["START", "start"], ["start", "task"], ["task", "END"]],
+                },
+            }
+        ],
+    )
+    responses[("GET", f"{_api_url(base)}/workflows/{workflow_id}/runs")] = (
+        200,
+        [
+            {
+                "id": "33333333-3333-3333-3333-333333333333",
+                "status": "succeeded",
+                "created_at": "2025-01-02T00:00:00+00:00",
+                "completed_at": "2025-01-02T00:01:00+00:00",
+            }
+        ],
+    )
+    responses[("POST", f"{_api_url(base)}/workflows/{workflow_id}/runs")] = (
+        201,
+        {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "status": "pending",
+            "triggered_by": "cli",
+            "created_at": "2025-01-03T00:00:00+00:00",
+        },
+    )
+
+    show_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "workflow",
+            "show",
+            workflow_id,
+        ],
+    )
+    assert show_result.exit_code == 0
+    assert "flowchart TD" in show_result.output
+
+    run_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "workflow",
+            "run",
+            workflow_id,
+        ],
+    )
+    assert run_result.exit_code == 0
+    assert "Run ID" in run_result.output
+
+
+def test_credential_reference_and_create(
+    runner: CliRunner, client_stub, tmp_path: Path
+) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    credentials_payload = [
+        {
+            "id": "cred-1",
+            "name": "demo_credential",
+            "provider": "http",
+            "access": "private",
+            "status": "healthy",
+        }
+    ]
+    responses[("GET", f"{_api_url(base)}/credentials")] = (200, credentials_payload)
+    responses[("POST", f"{_api_url(base)}/credentials")] = (
+        201,
+        {
+            "id": "cred-2",
+            "name": "new_credential",
+            "provider": "slack",
+            "access": "shared",
+        },
+    )
+    responses[("DELETE", f"{_api_url(base)}/credentials/cred-1")] = (204, None)
+
+    reference_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "credential",
+            "reference",
+            "demo_credential",
+        ],
+    )
+    assert reference_result.exit_code == 0
+    assert "[[demo_credential]]" in reference_result.output
+
+    create_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "credential",
+            "create",
+            "--name",
+            "new_credential",
+            "--provider",
+            "slack",
+            "--secret",
+            "secret",
+            "--access",
+            "shared",
+            "--scopes",
+            "chat:write",
+        ],
+    )
+    assert create_result.exit_code == 0
+    assert "Credential Created" in create_result.output
+
+    delete_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "credential",
+            "delete",
+            "cred-1",
+        ],
+    )
+    assert delete_result.exit_code == 0
+    assert "deleted successfully" in delete_result.output
+
+
+def test_node_show_displays_details(
+    runner: CliRunner, client_stub, tmp_path: Path
+) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    responses[("GET", f"{_api_url(base)}/nodes/catalog/example")] = (
+        200,
+        {
+            "name": "example",
+            "type": "utility",
+            "version": "1.2.3",
+            "category": "utility",
+            "description": "Example node",
+            "inputs": [
+                {
+                    "name": "query",
+                    "type": "string",
+                    "required": True,
+                    "description": "Search query",
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "results",
+                    "type": "list",
+                    "required": False,
+                    "description": "Result set",
+                }
+            ],
+            "credentials": [{"name": "search_api", "description": "Search API key"}],
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "node",
+            "show",
+            "example",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Search API key" in result.output
+    assert "Inputs" in result.output
+    assert "Outputs" in result.output
+
+
+def test_workflow_list_and_invalid_inputs(
+    runner: CliRunner, client_stub, tmp_path: Path
+) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    responses[("GET", f"{_api_url(base)}/workflows")] = (
+        200,
+        [
+            {
+                "id": "wf-1",
+                "name": "Workflow One",
+                "slug": "workflow-one",
+                "updated_at": "2025-02-02T00:00:00+00:00",
+            }
+        ],
+    )
+
+    list_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "workflow",
+            "list",
+        ],
+    )
+    assert list_result.exit_code == 0
+    assert "Workflow One" in list_result.output
+
+    invalid_result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "workflow",
+            "run",
+            "wf-1",
+            "--inputs",
+            "[]",
+        ],
+    )
+    assert invalid_result.exit_code == 1
+    assert "Inputs must be a JSON object" in invalid_result.output
+
+
+def test_credential_list_command(
+    runner: CliRunner, client_stub, tmp_path: Path
+) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    responses[("GET", f"{_api_url(base)}/credentials")] = (
+        200,
+        [
+            {
+                "id": "cred-1",
+                "name": "first",
+                "provider": "http",
+                "access": "shared",
+                "status": "healthy",
+            }
+        ],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "credential",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "first" in result.output
+
+
+def test_code_scaffold(runner: CliRunner, client_stub, tmp_path: Path) -> None:
+    responses, _ = client_stub
+    base = "https://api.orcheo.test"
+    workflow_id = "55555555-5555-5555-5555-555555555555"
+    responses[("GET", f"{_api_url(base)}/workflows/{workflow_id}/versions")] = (
+        200,
+        [
+            {
+                "id": "66666666-6666-6666-6666-666666666666",
+                "version": 2,
+                "created_at": "2025-01-01T00:00:00+00:00",
+                "created_by": "cli",
+            }
+        ],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            base,
+            "--cache-dir",
+            str(tmp_path),
+            "code",
+            "scaffold",
+            workflow_id,
+        ],
+    )
+    assert result.exit_code == 0
+    assert "HttpWorkflowExecutor" in result.output
+
+
+def test_profile_configuration_precedence(
+    runner: CliRunner, client_stub, tmp_path: Path
+) -> None:
+    responses, clients = client_stub
+    config_path = tmp_path / "cli.toml"
+    config_path.write_text(
+        """
+[profiles.dev]
+api_url = "https://profile.orcheo.test"
+service_token = "profile-token"
+        """.strip()
+    )
+    base = "https://profile.orcheo.test"
+    responses[("GET", f"{_api_url(base)}/nodes/catalog")] = (
+        200,
+        [
+            {
+                "name": "storage",
+                "type": "db",
+                "version": "1.0.0",
+                "category": "storage",
+                "tags": [],
+            }
+        ],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--profile",
+            "dev",
+            "--config-path",
+            str(config_path),
+            "--cache-dir",
+            str(tmp_path),
+            "node",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "storage" in result.output
+    assert clients, "No HTTP client was created"
+    assert clients[0].headers.get("Authorization") == "Bearer profile-token"

--- a/tests/sdk/test_cli_additional.py
+++ b/tests/sdk/test_cli_additional.py
@@ -1,0 +1,1358 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+import importlib
+
+app_module = importlib.import_module("orcheo_sdk.cli.app")
+from orcheo_sdk.cli import app as cli_app
+from orcheo_sdk.cli.api import (
+    APIClient,
+    ApiRequestError,
+    FetchResult,
+    OfflineCacheMissError,
+)
+from orcheo_sdk.cli.cache import CacheStore
+from orcheo_sdk.cli.code import code_app
+from orcheo_sdk.cli.config import (
+    CLISettings,
+    ProfileNotFoundError,
+    load_profiles,
+    resolve_settings,
+)
+from orcheo_sdk.cli.credentials import _find_credential, credential_app
+from orcheo_sdk.cli.nodes import _schema_rows, node_app
+from orcheo_sdk.cli.render import graph_to_mermaid
+from orcheo_sdk.cli.state import CLIContext
+from orcheo_sdk.cli.utils import show_cache_notice
+from orcheo_sdk.cli.workflows import _format_datetime, workflow_app
+
+
+def test_api_client_offline_and_http_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = CacheStore(tmp_path)
+    cache.ensure()
+
+    class DummyClient:
+        def __init__(self, *, base_url: str, timeout: float, headers: dict[str, str]):
+            self.base_url = base_url
+
+        def request(self, method: str, path: str, params=None, json=None):  # noqa: ANN001
+            request = httpx.Request(method, f"{self.base_url}{path}")
+            if path.endswith("/missing"):
+                return httpx.Response(404, request=request)
+            raise AssertionError("Unexpected path")
+
+        def close(self) -> None:  # pragma: no cover - nothing to clean up
+            return None
+
+    monkeypatch.setattr("orcheo_sdk.cli.api.httpx.Client", DummyClient)
+    client = APIClient(base_url="https://api.test/api", service_token=None, cache=cache)
+
+    with pytest.raises(OfflineCacheMissError):
+        client.get_json("/missing", offline=True, description="demo")
+
+    with pytest.raises(ApiRequestError) as excinfo:
+        client.get_json("/missing", description="demo")
+    assert "status 404" in str(excinfo.value)
+
+
+def test_app_callback_configures_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cache_dir = tmp_path / "cache"
+    responses_dir = cache_dir / "responses"
+    settings = CLISettings(
+        api_url="https://service.example",
+        service_token="token-123",
+        profile="dev",
+        config_path=tmp_path / "cli.toml",
+        cache_dir=cache_dir,
+    )
+
+    created_clients: list[DummyClient] = []
+
+    class DummyClient:
+        def __init__(
+            self,
+            *,
+            base_url: str,
+            service_token: str | None,
+            cache: CacheStore,
+            timeout: float = 30.0,
+        ) -> None:
+            self.base_url = base_url
+            self.service_token = service_token
+            self.cache = cache
+            self.timeout = timeout
+            self.closed = False
+            self.last_offline: bool | None = None
+            created_clients.append(self)
+
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            self.last_offline = offline
+            return FetchResult(data=[], from_cache=False, timestamp=None)
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(app_module, "resolve_settings", lambda **_: settings)
+    monkeypatch.setattr(app_module, "APIClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_app,
+        ["--offline", "node", "list"],
+    )
+
+    assert result.exit_code == 0
+    assert "No nodes found." in result.output
+    assert responses_dir.exists(), "Cache directory was not created"
+    assert created_clients, "Client was not constructed"
+    client = created_clients[0]
+    assert client.base_url == "https://service.example/api"
+    assert client.service_token == "token-123"
+    assert client.closed, "Client.close was not invoked"
+    assert client.last_offline is True
+
+
+def test_app_callback_profile_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error(**_: Any) -> CLISettings:  # noqa: ANN401
+        raise ProfileNotFoundError("missing profile")
+
+    monkeypatch.setattr(app_module, "resolve_settings", raise_error)
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["--profile", "missing", "node", "list"])
+    assert result.exit_code != 0
+    assert "missing profile" in result.output
+
+
+def test_app_main_invokes_typer(monkeypatch: pytest.MonkeyPatch) -> None:
+    invoked: dict[str, bool] = {}
+
+    def fake_app() -> None:
+        invoked["called"] = True
+
+    monkeypatch.setattr(app_module, "app", fake_app)
+    app_module.main()
+    assert invoked.get("called") is True
+
+
+def test_cache_store_invalid_timestamp(tmp_path: Path) -> None:
+    store = CacheStore(tmp_path)
+    store.ensure()
+    key = store.build_key("GET", "/nodes")
+    entry_path = tmp_path / "responses" / f"{key}.json"
+    payload = {"timestamp": 12345, "data": {"value": 9}}
+    entry_path.write_text(json.dumps(payload))
+
+    entry = store.read(key)
+    assert entry is not None
+    assert entry.data == {"value": 9}
+    assert isinstance(entry.timestamp, datetime)
+
+
+def _build_context(
+    *,
+    tmp_path: Path,
+    api_url: str = "https://api.example/api",
+    service_token: str | None = None,
+    offline: bool = False,
+    client: Any,
+) -> CLIContext:
+    settings = CLISettings(
+        api_url=api_url,
+        service_token=service_token,
+        profile=None,
+        config_path=tmp_path / "cli.toml",
+        cache_dir=tmp_path,
+    )
+    return CLIContext(
+        settings=settings,
+        client=client,
+        cache=CacheStore(tmp_path),
+        console=Console(record=True),
+        offline=offline,
+    )
+
+
+def test_code_scaffold_trims_api_suffix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    settings = CLISettings(
+        api_url="https://api.demo/api",
+        service_token=None,
+        profile=None,
+        config_path=tmp_path / "cli.toml",
+        cache_dir=tmp_path,
+    )
+
+    class DummyClient:
+        def __init__(
+            self,
+            *,
+            base_url: str,
+            service_token: str | None,
+            cache: CacheStore,
+            timeout: float = 30.0,
+        ) -> None:  # noqa: ANN001
+            self.base_url = base_url
+            self.service_token = service_token
+            self.cache = cache
+            self.timeout = timeout
+
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            assert path.endswith("/versions")
+            return FetchResult(
+                data=[{"id": "ver-1", "version": 1}],
+                from_cache=False,
+                timestamp=None,
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(app_module, "resolve_settings", lambda **_: settings)
+    monkeypatch.setattr(app_module, "APIClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_app,
+        [
+            "--api-url",
+            "https://api.demo/api",
+            "--cache-dir",
+            str(tmp_path),
+            "code",
+            "scaffold",
+            "wf-1",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "https://api.demo" in result.output
+    assert "wf-1" in result.output
+
+
+def test_code_scaffold_handles_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    settings = CLISettings(
+        api_url="https://api.demo",
+        service_token=None,
+        profile=None,
+        config_path=tmp_path / "cli.toml",
+        cache_dir=tmp_path,
+    )
+
+    class FailingClient:
+        def __init__(
+            self,
+            *,
+            base_url: str,
+            service_token: str | None,
+            cache: CacheStore,
+            timeout: float = 30.0,
+        ) -> None:  # noqa: ANN001
+            self.base_url = base_url
+            self.service_token = service_token
+            self.cache = cache
+
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("boom")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(app_module, "resolve_settings", lambda **_: settings)
+    monkeypatch.setattr(app_module, "APIClient", FailingClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_app,
+        [
+            "--api-url",
+            "https://api.demo",
+            "--cache-dir",
+            str(tmp_path),
+            "code",
+            "scaffold",
+            "wf-2",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "boom" in result.output
+
+
+def test_resolve_settings_prefers_environment(tmp_path: Path) -> None:
+    config_path = tmp_path / "cli.toml"
+    config_path.write_text(
+        """
+[profiles.prod]
+api_url = "https://profile.example"
+service_token = "profile-token"
+        """.strip()
+    )
+    cache_dir = tmp_path / "cache"
+    env = {
+        "ORCHEO_PROFILE": "prod",
+        "ORCHEO_API_URL": "https://env.example",
+        "ORCHEO_SERVICE_TOKEN": "env-token",
+        "ORCHEO_CLI_CONFIG": str(config_path),
+        "ORCHEO_CLI_CACHE": str(cache_dir),
+    }
+
+    settings = resolve_settings(
+        api_url=None,
+        service_token=None,
+        profile=None,
+        config_path=None,
+        cache_dir=None,
+        env=env,
+    )
+
+    assert settings.api_url == "https://env.example"
+    assert settings.service_token == "env-token"
+    assert settings.profile == "prod"
+    assert settings.config_path == config_path
+    assert settings.cache_dir == cache_dir
+
+
+def test_load_profiles_skips_invalid_entries(tmp_path: Path) -> None:
+    config_path = tmp_path / "cli.toml"
+    config_path.write_text(
+        """
+[profiles]
+invalid = "ignored"
+
+[profiles.valid]
+api_url = "https://valid.example"
+        """.strip()
+    )
+    profiles = load_profiles(config_path)
+    assert "invalid" not in profiles
+    assert profiles["valid"].api_url == "https://valid.example"
+
+
+def test_credential_list_handles_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            assert params == {"workflow_id": "wf-1"}
+            data = [
+                {
+                    "id": "cred-1",
+                    "name": "alpha",
+                    "provider": "http",
+                    "access": "private",
+                    "status": "ok",
+                },
+                "invalid",
+            ]
+            return FetchResult(data=data, from_cache=True, timestamp=timestamp)
+
+    context = _build_context(
+        tmp_path=tmp_path,
+        client=DummyClient(),
+        offline=True,
+    )
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        credential_app,
+        ["list", "--workflow-id", "wf-1"],
+    )
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "alpha" in output
+    assert "Served from cache" in output
+
+
+def test_credential_list_offline_cache_miss(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("no cache")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["list"])
+    assert result.exit_code == 1
+    assert "no cache" in result.output
+
+
+def test_credential_list_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("failure")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["list"])
+    assert result.exit_code == 1
+    assert "failure" in result.output
+
+
+def test_credential_list_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(data=[], from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["list"])
+    assert result.exit_code == 0
+    assert "No credentials found" in result.output
+
+
+def test_credential_reference_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(
+                data=[{"name": "other"}], from_cache=False, timestamp=None
+            )
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["reference", "missing"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_credential_reference_cache_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    timestamp = datetime(2024, 4, 4, tzinfo=UTC)
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(
+                data=[{"id": "cred-5", "name": "alpha"}],
+                from_cache=True,
+                timestamp=timestamp,
+            )
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["reference", "cred-5"])
+    assert result.exit_code == 0
+    assert "Served from cache" in context.console.export_text()
+
+
+def test_credential_reference_offline_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("reference cache missing")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["reference", "cred"])
+    assert result.exit_code == 1
+    assert "reference cache missing" in result.output
+
+
+def test_credential_reference_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("reference failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["reference", "cred"])
+    assert result.exit_code == 1
+    assert "reference failed" in result.output
+
+
+def test_credential_create_parses_scopes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class DummyClient:
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            captured.update(json or {})
+            return FetchResult(data=json or {}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        credential_app,
+        [
+            "create",
+            "--name",
+            "demo",
+            "--provider",
+            "http",
+            "--secret",
+            "sekrit",
+            "--scopes",
+            "read, write , ,admin",
+        ],
+        input="sekrit\n",
+    )
+    assert result.exit_code == 0
+    assert captured["scopes"] == ["read", "write", "admin"]
+
+
+def test_credential_create_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("create failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        credential_app,
+        [
+            "create",
+            "--name",
+            "demo",
+            "--provider",
+            "http",
+            "--secret",
+            "sekrit",
+        ],
+        input="sekrit\n",
+    )
+    assert result.exit_code == 1
+    assert "create failed" in result.output
+
+
+def test_credential_delete_uses_workflow_scope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    recorded: dict[str, Any] = {}
+
+    class DummyClient:
+        def fetch_json(
+            self,
+            method: str,
+            path: str,
+            *,
+            params=None,
+            json=None,
+            offline=False,
+            description="resource",
+        ) -> FetchResult:  # noqa: ANN001
+            recorded.update({"method": method, "path": path, "params": params})
+            return FetchResult(data=None, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        credential_app,
+        ["delete", "cred-1", "--workflow-id", "wf-9"],
+    )
+    assert result.exit_code == 0
+    assert recorded == {
+        "method": "DELETE",
+        "path": "/credentials/cred-1",
+        "params": {"workflow_id": "wf-9"},
+    }
+
+
+def test_credential_delete_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def fetch_json(
+            self,
+            method: str,
+            path: str,
+            *,
+            params=None,
+            json=None,
+            offline=False,
+            description="resource",
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("delete failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.credentials.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(credential_app, ["delete", "cred-2"])
+    assert result.exit_code == 1
+    assert "delete failed" in result.output
+
+
+def test_find_credential_helper() -> None:
+    entries = [
+        {"id": "cred-1", "name": "Alpha"},
+        {"id": "cred-2", "name": "beta"},
+        "invalid",
+    ]
+    assert _find_credential(entries, "cred-1") == entries[0]
+    assert _find_credential(entries, "Beta") == entries[1]
+    assert _find_credential(entries, "missing") is None
+
+
+def test_node_list_offline_cache_miss(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("no node cache")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["list"])
+    assert result.exit_code == 1
+    assert "no node cache" in result.output
+
+
+def test_node_list_filters_and_skip_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    recorded: dict[str, Any] = {}
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            recorded.update(params or {})
+            data = [
+                {
+                    "name": "http_request",
+                    "type": "http",
+                    "version": "1",
+                    "category": "net",
+                    "tags": ["http"],
+                },
+                "invalid",
+            ]
+            return FetchResult(data=data, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=False)
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["list", "--tag", "http", "--category", "network"])
+    assert result.exit_code == 0
+    assert recorded == {"tag": "http", "category": "network"}
+    assert "http_request" in result.output
+    assert "http" in result.output
+    assert "invalid" not in result.output
+
+
+def test_node_list_api_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("node failure")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["list"])
+    assert result.exit_code == 1
+    assert "node failure" in result.output
+
+
+def test_node_list_without_tags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            data = [
+                {
+                    "name": "simple",
+                    "type": "utility",
+                    "version": "1",
+                    "category": "general",
+                }
+            ]
+            return FetchResult(data=data, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["list"])
+    assert result.exit_code == 0
+    assert "simple" in result.output
+
+
+def test_node_show_uses_cache_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    timestamp = datetime(2024, 2, 2, tzinfo=UTC)
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            payload = {
+                "name": "simple",
+                "type": "tool",
+                "version": "1",
+                "credentials": [
+                    {"name": "cred", "description": "desc"},
+                    "invalid",
+                ],
+            }
+            return FetchResult(data=payload, from_cache=True, timestamp=timestamp)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["show", "simple"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "Served from cache" in output
+    assert "Credential Requirements" in output
+
+
+def test_node_show_offline_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("no detail cache")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["show", "sample"])
+    assert result.exit_code == 1
+    assert "no detail cache" in result.output
+
+
+def test_node_show_api_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("node detail failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["show", "sample"])
+    assert result.exit_code == 1
+    assert "node detail failed" in result.output
+
+
+def test_node_show_without_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            payload = {
+                "name": "bare",
+                "type": "tool",
+                "version": "1",
+                "credentials": [],
+            }
+            return FetchResult(data=payload, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.nodes.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(node_app, ["show", "bare"])
+    assert result.exit_code == 0
+    assert "Credential Requirements" not in result.output
+
+
+def test_schema_rows_skips_non_dict() -> None:
+    rows = _schema_rows(
+        [
+            {"name": "x", "type": "int", "required": True, "description": "num"},
+            "invalid",
+        ]
+    )
+    assert rows == [("x", "int", "True", "num")]
+
+
+def test_show_cache_notice_ignores_missing_timestamp(tmp_path: Path) -> None:
+    context = _build_context(
+        tmp_path=tmp_path,
+        client=object(),  # type: ignore[arg-type]
+    )
+    show_cache_notice(context, None)
+    assert "Served from cache" not in context.console.export_text()
+
+
+def test_graph_to_mermaid_sanitises_identifiers() -> None:
+    graph = {
+        "nodes": [
+            {"name": " 1st node", "type": "trigger"},
+            {"name": "B&C", "type": "task"},
+        ],
+        "edges": [[" 1st node", "B&C"], ["invalid"]],
+    }
+    mermaid = graph_to_mermaid(graph)
+    assert "_1st_node" in mermaid
+    assert "B_C" in mermaid
+    assert "invalid" not in mermaid.splitlines()[-1]
+
+
+def test_graph_to_mermaid_invalid_payload() -> None:
+    graph = {"nodes": {}, "edges": []}
+    mermaid = graph_to_mermaid(graph)
+    assert "Invalid" in mermaid
+
+
+def test_graph_to_mermaid_skips_non_dict_node() -> None:
+    graph = {"nodes": [{"name": "A"}, "bad"], "edges": []}
+    mermaid = graph_to_mermaid(graph)
+    assert "bad" not in mermaid
+
+
+def test_workflow_list_offline_cache_miss(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("workflow cache missing")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["list"])
+    assert result.exit_code == 1
+    assert "workflow cache missing" in result.output
+
+
+def test_workflow_list_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("list failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["list"])
+    assert result.exit_code == 1
+    assert "list failed" in result.output
+
+
+def test_workflow_list_cached_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    timestamp = datetime(2024, 5, 5, tzinfo=UTC)
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            data = [
+                {
+                    "id": "wf-1",
+                    "name": "Flow",
+                    "slug": "flow",
+                    "updated_at": "2024-05-05T00:00:00+00:00",
+                }
+            ]
+            return FetchResult(data=data, from_cache=True, timestamp=timestamp)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["list"])
+    assert result.exit_code == 0
+    assert "Served from cache" in context.console.export_text()
+
+
+def test_workflow_list_handles_invalid_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(data=["invalid"], from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["list"])
+    assert result.exit_code == 0
+    assert "No workflows found" in result.output
+
+
+def test_workflow_show_with_cached_data(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    timestamp = datetime(2024, 3, 3, tzinfo=UTC)
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/runs"):
+                data = [
+                    {
+                        "id": "run-1",
+                        "status": "succeeded",
+                        "created_at": "2024-03-02T10:00:00+00:00",
+                        "completed_at": "2024-03-02T10:05:00+00:00",
+                    }
+                ]
+                return FetchResult(data=data, from_cache=False, timestamp=None)
+            if path.endswith("/versions"):
+                data = [
+                    {
+                        "id": "ver-2",
+                        "version": 2,
+                        "created_at": "2024-03-01T12:00:00+00:00",
+                        "created_by": "tester",
+                        "graph": {
+                            "nodes": [
+                                {"name": "start", "type": "trigger"},
+                                {"name": "end", "type": "action"},
+                            ],
+                            "edges": [["start", "end"]],
+                        },
+                    }
+                ]
+                return FetchResult(data=data, from_cache=False, timestamp=None)
+            if path.endswith("/workflow-1"):
+                data = {
+                    "id": "workflow-1",
+                    "name": "Example",
+                    "slug": "example",
+                    "description": "Demo",
+                    "tags": ["demo"],
+                    "updated_at": "2024-03-01T00:00:00+00:00",
+                }
+                return FetchResult(data=data, from_cache=True, timestamp=timestamp)
+            raise AssertionError(path)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=False)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "workflow-1"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "flowchart TD" in output
+    assert "Recent Runs" in output
+    assert "Served from cache" in output
+    assert "Tags" in output
+
+
+def test_workflow_show_offline_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("no workflow cache")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "wf-err"])
+    assert result.exit_code == 1
+    assert "no workflow cache" in result.output
+
+
+def test_workflow_show_without_tags_and_versions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/versions"):
+                return FetchResult(data=[], from_cache=False, timestamp=None)
+            if path.endswith("/runs"):
+                return FetchResult(data=[], from_cache=False, timestamp=None)
+            return FetchResult(
+                data={"id": "wf", "name": "WF", "slug": "wf", "tags": "not-a-list"},
+                from_cache=False,
+                timestamp=None,
+            )
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "wf"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "Workflow" in output
+    assert "Versions" not in output
+    assert "Recent Runs" not in output
+
+
+def test_workflow_show_versions_without_graph(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/versions"):
+                data = [{"id": "ver", "version": 1, "graph": "not-dict"}]
+                return FetchResult(data=data, from_cache=False, timestamp=None)
+            return FetchResult(data={}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "wf"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "Latest Graph" not in output
+
+
+def test_workflow_show_versions_latest_not_dict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/runs"):
+                return FetchResult(data=[], from_cache=False, timestamp=None)
+            return FetchResult(
+                data={
+                    "id": "wf",
+                    "name": "Workflow",
+                    "slug": "wf",
+                    "description": "Demo",
+                },
+                from_cache=False,
+                timestamp=None,
+            )
+
+    class RowLike:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def get(self, key: str, default: Any = "") -> Any:
+            return self._payload.get(key, default)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+
+    def fake_fetch_versions(context: CLIContext, workflow_id: str) -> list[RowLike]:
+        assert context is not None  # exercise argument usage
+        assert workflow_id == "wf"
+        return [
+            RowLike(
+                {
+                    "version": 1,
+                    "id": "ver-1",
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "created_by": "tester",
+                    "graph": {"nodes": []},
+                }
+            )
+        ]
+
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows._fetch_versions", fake_fetch_versions)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "wf"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "Latest Graph" not in output
+
+
+def test_workflow_show_versions_all_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/versions"):
+                return FetchResult(data=["bad"], from_cache=False, timestamp=None)
+            return FetchResult(data={}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "wf"])
+    assert result.exit_code == 0
+    output = context.console.export_text()
+    assert "Latest Graph" not in output
+
+
+def test_workflow_show_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/workflows/bad"):
+                raise ApiRequestError("workflow failed")
+            return FetchResult(data={}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["show", "bad"])
+    assert result.exit_code == 1
+    assert "workflow failed" in result.output
+
+
+def test_workflow_run_requires_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("no versions")
+
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise AssertionError("post_json should not be called")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["run", "workflow-2"])
+    assert result.exit_code == 1
+    assert "Unable to determine workflow version" in result.output
+
+
+def test_workflow_run_with_version_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise AssertionError("get_json should not be called")
+
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(data=json or {}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=False)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        workflow_app,
+        ["run", "workflow", "--version-id", "ver-1", "--inputs", "{}"],
+    )
+    assert result.exit_code == 0
+    assert "Run ID" in result.output
+
+
+def test_workflow_run_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            return FetchResult(
+                data=[{"id": "ver-1", "version": 1}], from_cache=False, timestamp=None
+            )
+
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("run failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=False)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(workflow_app, ["run", "workflow-err"])
+    assert result.exit_code == 1
+    assert "run failed" in result.output
+
+
+def test_workflow_run_posts_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    versions = [
+        {"id": "ver-1", "version": 1},
+        {"id": "ver-2", "version": 2},
+    ]
+    captured: dict[str, Any] = {}
+
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            if path.endswith("/versions"):
+                return FetchResult(data=versions, from_cache=False, timestamp=None)
+            raise AssertionError(path)
+
+        def post_json(
+            self, path: str, *, params=None, json=None, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            captured.update(json or {})
+            return FetchResult(data=json or {}, from_cache=False, timestamp=None)
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=False)
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.get_context", lambda _: context)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        workflow_app,
+        ["run", "workflow-3", "--inputs", '{"foo": "bar"}', "--actor", "cli-user"],
+    )
+    assert result.exit_code == 0
+    assert captured["workflow_version_id"] == "ver-2"
+    assert captured["triggered_by"] == "cli-user"
+    assert captured["input_payload"] == {"foo": "bar"}
+
+
+def test_fetch_versions_handles_api_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("versions failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+
+    def fake_abort(ctx: CLIContext, exc: ApiRequestError) -> None:
+        raise RuntimeError(str(exc))
+
+    monkeypatch.setattr("orcheo_sdk.cli.workflows.abort_with_error", fake_abort)
+    from orcheo_sdk.cli.workflows import _fetch_versions
+
+    with pytest.raises(RuntimeError, match="versions failed"):
+        _fetch_versions(context, "wf-err")
+
+
+def test_fetch_runs_offline_error(tmp_path: Path) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise OfflineCacheMissError("offline")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient(), offline=True)
+    from orcheo_sdk.cli.workflows import _fetch_runs
+
+    runs = _fetch_runs(context, "wf")
+    assert runs == []
+
+
+def test_fetch_runs_api_error(tmp_path: Path) -> None:
+    class DummyClient:
+        def get_json(
+            self, path: str, *, params=None, offline=False, description="resource"
+        ) -> FetchResult:  # noqa: ANN001
+            raise ApiRequestError("runs failed")
+
+    context = _build_context(tmp_path=tmp_path, client=DummyClient())
+    from orcheo_sdk.cli.workflows import _fetch_runs
+
+    runs = _fetch_runs(context, "wf")
+    assert runs == []
+
+
+def test_format_datetime_helpers() -> None:
+    assert _format_datetime("2024-01-01T00:00:00Z").startswith("2024-01-01T00:00:00+")
+    now = datetime(2024, 1, 1)
+    assert _format_datetime(now) == now.isoformat()
+    assert _format_datetime(123) == ""

--- a/tests/sdk/test_cli_internals.py
+++ b/tests/sdk/test_cli_internals.py
@@ -7,7 +7,10 @@ import pytest
 from orcheo_sdk.cli import app as cli_app
 from orcheo_sdk.cli.api import APIClient, ApiRequestError
 from orcheo_sdk.cli.cache import CacheStore
+from orcheo_sdk.cli.code import code_app
 from orcheo_sdk.cli.config import CLISettings, ProfileNotFoundError, resolve_settings
+from orcheo_sdk.cli.credentials import credential_app
+from orcheo_sdk.cli.nodes import _get_node_registry, node_app
 from orcheo_sdk.cli.render import (
     graph_to_mermaid,
     render_kv_section,
@@ -15,9 +18,29 @@ from orcheo_sdk.cli.render import (
     render_table,
 )
 from orcheo_sdk.cli.state import CLIContext
+from orcheo_sdk.cli.workflows import workflow_app
 from orcheo_sdk.cli.utils import get_context, show_cache_notice
 from rich.console import Console
 from typer.testing import CliRunner
+
+
+def test_cli_apps_enable_completion() -> None:
+    """All CLI entrypoints should expose shell completion commands."""
+
+    assert cli_app._add_completion is True
+    assert node_app._add_completion is True
+    assert workflow_app._add_completion is True
+    assert credential_app._add_completion is True
+    assert code_app._add_completion is True
+
+
+def test_get_node_registry_success() -> None:
+    """_get_node_registry returns the global Orcheo node registry."""
+
+    from orcheo.nodes.registry import registry as global_registry
+
+    registry = _get_node_registry()
+    assert registry is global_registry
 
 
 def test_cache_store_roundtrip(tmp_path: Path) -> None:

--- a/tests/sdk/test_cli_internals.py
+++ b/tests/sdk/test_cli_internals.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+import httpx
+import pytest
+from orcheo_sdk.cli import app as cli_app
+from orcheo_sdk.cli.api import APIClient, ApiRequestError
+from orcheo_sdk.cli.cache import CacheStore
+from orcheo_sdk.cli.config import CLISettings, ProfileNotFoundError, resolve_settings
+from orcheo_sdk.cli.render import (
+    graph_to_mermaid,
+    render_kv_section,
+    render_mermaid,
+    render_table,
+)
+from orcheo_sdk.cli.state import CLIContext
+from orcheo_sdk.cli.utils import get_context, show_cache_notice
+from rich.console import Console
+from typer.testing import CliRunner
+
+
+def test_cache_store_roundtrip(tmp_path: Path) -> None:
+    store = CacheStore(tmp_path)
+    store.ensure()
+    key = store.build_key("GET", "/nodes", {"tag": "ai"})
+    store.write(key, {"value": 1})
+    cached = store.read(key)
+    assert cached is not None
+    assert cached.data == {"value": 1}
+
+
+def test_api_client_offline_and_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    responses: dict[tuple[str, str], httpx.Response | Exception] = {}
+
+    class DummyHttpxClient:
+        def __init__(self, *, base_url: str, timeout: float, headers: dict[str, str]):
+            self.base_url = base_url
+
+        def request(self, method: str, path: str, params=None, json=None):
+            key = (method.upper(), path)
+            response = responses.get(key)
+            if response is None:
+                request = httpx.Request(method, f"{self.base_url}{path}")
+                raise httpx.RequestError("missing", request=request)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        def close(self) -> None:  # pragma: no cover - no resources to release
+            return None
+
+    monkeypatch.setattr("orcheo_sdk.cli.api.httpx.Client", DummyHttpxClient)
+
+    cache = CacheStore(tmp_path)
+    cache.ensure()
+    client = APIClient(
+        base_url="https://api.example/api", service_token=None, cache=cache
+    )
+
+    ok_response = httpx.Response(
+        200,
+        request=httpx.Request("GET", "https://api.example/api/data"),
+        json={"value": 42},
+    )
+    responses[("GET", "/data")] = ok_response
+    result = client.get_json("/data")
+    assert result.data == {"value": 42}
+
+    cached = client.get_json("/data", offline=True)
+    assert cached.from_cache and cached.data == {"value": 42}
+
+    error_response = httpx.Response(
+        500,
+        request=httpx.Request("GET", "https://api.example/api/data"),
+    )
+    responses[("GET", "/data")] = error_response
+    fallback = client.get_json("/data")
+    assert fallback.from_cache and fallback.data == {"value": 42}
+
+    failing_request = httpx.Request("GET", "https://api.example/api/data")
+    responses[("GET", "/data")] = httpx.RequestError("down", request=failing_request)
+    recovered = client.get_json("/data")
+    assert recovered.from_cache and recovered.data == {"value": 42}
+
+    other_request = httpx.Request("GET", "https://api.example/api/other")
+    responses[("GET", "/other")] = httpx.RequestError("boom", request=other_request)
+    with pytest.raises(ApiRequestError):
+        client.get_json("/other")
+
+
+def test_config_resolve_and_profile(tmp_path: Path) -> None:
+    config_path = tmp_path / "cli.toml"
+    config_path.write_text(
+        """
+[profiles.dev]
+api_url = "https://dev.example"
+service_token = "dev-token"
+        """.strip()
+    )
+    settings = resolve_settings(
+        api_url=None,
+        service_token=None,
+        profile="dev",
+        config_path=config_path,
+        cache_dir=tmp_path,
+        env={},
+    )
+    assert settings.api_url == "https://dev.example"
+    assert settings.service_token == "dev-token"
+
+    with pytest.raises(ProfileNotFoundError):
+        resolve_settings(
+            api_url=None,
+            service_token=None,
+            profile="missing",
+            config_path=config_path,
+            cache_dir=tmp_path,
+            env={},
+        )
+
+    env_settings = resolve_settings(
+        api_url=None,
+        service_token=None,
+        profile=None,
+        config_path=config_path,
+        cache_dir=tmp_path,
+        env={"ORCHEO_API_URL": "https://env.example"},
+    )
+    assert env_settings.api_url == "https://env.example"
+
+
+def test_render_helpers(tmp_path: Path) -> None:
+    console = Console(record=True)
+    render_table(
+        console,
+        title="Sample",
+        columns=("Name", "Value"),
+        rows=[("alpha", "beta")],
+    )
+    render_kv_section(
+        console,
+        title="Metadata",
+        pairs=[("Status", "ok")],
+    )
+    mermaid = graph_to_mermaid(
+        {
+            "nodes": [{"name": "A", "type": "start"}, {"name": "B", "type": "end"}],
+            "edges": [["A", "B"]],
+        }
+    )
+    render_mermaid(console, title="Graph", mermaid=mermaid)
+    output = console.export_text()
+    assert "flowchart" in output
+    assert "Status" in output
+
+
+def test_utils_helpers(tmp_path: Path) -> None:
+    dummy_ctx = SimpleNamespace(ensure_object=lambda _: object())
+    with pytest.raises(RuntimeError):
+        get_context(dummy_ctx)  # type: ignore[arg-type]
+
+    console = Console(record=True)
+    settings = CLISettings(
+        api_url="https://api.example",
+        service_token="token",
+        profile="dev",
+        config_path=tmp_path,
+        cache_dir=tmp_path,
+    )
+    context = CLIContext(
+        settings=settings,
+        client=object(),  # type: ignore[arg-type]
+        cache=CacheStore(tmp_path),
+        console=console,
+    )
+    show_cache_notice(context, datetime.now(tz=UTC))
+    assert "Served from cache" in console.export_text()
+
+
+def test_code_scaffold_requires_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    responses: dict[tuple[str, str], httpx.Response] = {}
+
+    class DummyHttpxClient:
+        def __init__(self, *, base_url: str, timeout: float, headers: dict[str, str]):
+            self.base_url = base_url
+
+        def request(self, method: str, path: str, params=None, json=None):
+            key = (method.upper(), path)
+            response = responses.get(key)
+            if response is None:
+                request = httpx.Request(method, f"{self.base_url}{path}")
+                raise httpx.RequestError("missing", request=request)
+            return response
+
+        def close(self) -> None:  # pragma: no cover - no resources to release
+            return None
+
+    monkeypatch.setattr("orcheo_sdk.cli.api.httpx.Client", DummyHttpxClient)
+
+    workflow_id = "no-versions"
+    responses[("GET", f"/workflows/{workflow_id}/versions")] = httpx.Response(
+        200,
+        request=httpx.Request(
+            "GET", f"https://api.orcheo.test/api/workflows/{workflow_id}/versions"
+        ),
+        json=[],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_app,
+        [
+            "--api-url",
+            "https://api.orcheo.test",
+            "--cache-dir",
+            str(tmp_path),
+            "code",
+            "scaffold",
+            workflow_id,
+        ],
+    )
+    assert result.exit_code == 1
+    assert "deploy a version" in result.output
+
+
+def _api_url(base: str) -> str:
+    return f"{base.rstrip('/')}/api"

--- a/uv.lock
+++ b/uv.lock
@@ -1950,6 +1950,8 @@ version = "0.4.0"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "httpx" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1966,7 +1968,9 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "typer", specifier = ">=0.12.3" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- implement a Typer-based Orcheo CLI with modules for API access, caching, credentials, nodes, workflows, and rendering utilities
- add comprehensive CLI tests covering configuration, API error handling, caching behaviour, command flows, and rendering helpers
- register the CLI entry point and update dependencies for typing stubs

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6900961d0480832785e2baedf5dcb081