### PR TITLE
Add Orcheo CLI implementation

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,24 @@
 
 The Python SDK offers a strongly typed way to generate Orcheo workflow requests without forcing a specific HTTP client dependency.
 
+## Command line interface
+
+The SDK now ships with the `orcheo` CLI for inspecting nodes, workflows, and credentials from the terminal. Once the package is installed you can invoke the CLI via `uv run` (or any Python environment where the package is available):
+
+```bash
+uv run orcheo --help
+```
+
+Configuration mirrors the Python SDK: set `ORCHEO_API_URL` and `ORCHEO_SERVICE_TOKEN` in your shell or define profiles in `~/.config/orcheo/cli.toml`. A simple invocation to list workflows looks like this:
+
+```bash
+ORCHEO_API_URL=https://orcheo.example.com \
+ORCHEO_SERVICE_TOKEN=secret-token \
+uv run orcheo workflow list
+```
+
+Offline-friendly commands (such as `orcheo node list`) will transparently fall back to cached data when the `--offline` flag is supplied. Run `uv run orcheo --help` for the full command surface.
+
 ## Server-side workflow execution
 
 > **Breaking change:** The SDK no longer supports executing workflows locally within the client process. All executions now run on the

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -4,7 +4,9 @@ requires = ["hatchling"]
 
 [project]
 dependencies = [
-  "httpx>=0.27.0"
+  "httpx>=0.27.0",
+  "rich>=13.7.1",
+  "typer>=0.12.3",
 ]
 description = "Client helpers for the Orcheo workflow orchestration platform"
 name = "orcheo-sdk"
@@ -22,3 +24,6 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/orcheo_sdk"]
+
+[project.scripts]
+orcheo = "orcheo_sdk.cli:main"

--- a/packages/sdk/src/orcheo_sdk/cli/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/__init__.py
@@ -1,0 +1,7 @@
+"""Orcheo command line interface."""
+
+from __future__ import annotations
+from orcheo_sdk.cli.app import app, main
+
+
+__all__ = ["app", "main"]

--- a/packages/sdk/src/orcheo_sdk/cli/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/app.py
@@ -1,0 +1,94 @@
+"""Typer application wiring the Orcheo CLI."""
+
+from __future__ import annotations
+import typer
+from orcheo_sdk.cli.commands.code import code_app
+from orcheo_sdk.cli.commands.credentials import credential_app
+from orcheo_sdk.cli.commands.nodes import node_app
+from orcheo_sdk.cli.commands.workflows import workflow_app
+from orcheo_sdk.cli.runtime import (
+    ApiClient,
+    CacheStore,
+    CliError,
+    CliRuntime,
+    build_console,
+    default_cache_path,
+    render_error,
+    resolve_settings,
+)
+
+
+app = typer.Typer(help="Command line tooling for the Orcheo platform")
+app.add_typer(node_app, name="node")
+app.add_typer(workflow_app, name="workflow")
+app.add_typer(credential_app, name="credential")
+app.add_typer(code_app, name="code")
+
+
+@app.callback()
+def _configure(
+    ctx: typer.Context,
+    api_url: str | None = typer.Option(
+        None,
+        "--api-url",
+        help="Override the Orcheo API URL",
+    ),
+    service_token: str | None = typer.Option(
+        None,
+        "--service-token",
+        help="Service token used for API authentication",
+    ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help="Named profile to load from the CLI configuration file",
+    ),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Run commands without network access when supported",
+    ),
+    timeout: float = typer.Option(
+        30.0,
+        "--timeout",
+        help="HTTP request timeout in seconds",
+    ),
+) -> None:
+    """Initialise shared runtime objects for downstream commands."""
+    try:
+        settings = resolve_settings(
+            api_url=api_url,
+            service_token=service_token,
+            profile=profile,
+            timeout=timeout,
+        )
+    except CliError as exc:
+        console = build_console()
+        render_error(console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    console = build_console()
+    cache_dir = default_cache_path()
+    cache = CacheStore(cache_dir)
+    runtime = CliRuntime(
+        settings=settings,
+        console=console,
+        cache=cache,
+        offline=offline,
+    )
+
+    if not offline:
+        api_client = ApiClient(
+            settings.api_url,
+            service_token=settings.service_token,
+            timeout=settings.timeout,
+        )
+        runtime.api = api_client
+        ctx.call_on_close(api_client.close)
+
+    ctx.obj = runtime
+
+
+def main() -> None:
+    """Console script entry point."""
+    app()

--- a/packages/sdk/src/orcheo_sdk/cli/commands/code.py
+++ b/packages/sdk/src/orcheo_sdk/cli/commands/code.py
@@ -1,0 +1,82 @@
+"""Code generation helpers for the CLI."""
+
+from __future__ import annotations
+import typer
+from orcheo_sdk.cli.commands.workflows import _select_version
+from orcheo_sdk.cli.runtime import CliError, CliRuntime, render_error, render_warning
+from orcheo_sdk.cli.services import fetch_workflow_detail
+
+
+code_app = typer.Typer(help="Generate workflow reference snippets")
+
+
+def _runtime(ctx: typer.Context) -> CliRuntime:
+    runtime = ctx.obj
+    if not isinstance(runtime, CliRuntime):  # pragma: no cover
+        raise typer.Exit(code=1)
+    return runtime
+
+
+@code_app.command("scaffold", help="Generate a Python snippet for running a workflow")
+def scaffold(
+    ctx: typer.Context,
+    workflow_id: str,
+    version: int | None = typer.Option(
+        None,
+        "--version",
+        help="Workflow version to target",
+    ),
+    actor: str = typer.Option(
+        "cli",
+        "--actor",
+        help="Actor used in the snippet",
+    ),
+) -> None:
+    """Emit a Python scaffold for triggering a workflow run."""
+    runtime = _runtime(ctx)
+    try:
+        _detail, versions, cache_entry = fetch_workflow_detail(runtime, workflow_id)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    try:
+        selected_version = _select_version(versions, version)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    if runtime.offline and cache_entry and runtime.cache.is_stale(cache_entry):
+        render_warning(
+            runtime.console,
+            (
+                "Workflow scaffold data is older than 24 hours; "
+                "refresh online for the latest version."
+            ),
+        )
+
+    api_url = runtime.settings.api_url
+    snippet = [
+        "import os",
+        "",
+        "from orcheo_sdk import HttpWorkflowExecutor, OrcheoClient",
+        "",
+        f'client = OrcheoClient(base_url="{api_url}")',
+        (
+            "executor = HttpWorkflowExecutor("
+            'client, auth_token=os.getenv("ORCHEO_SERVICE_TOKEN"))'
+        ),
+        "response = executor.trigger_run(",
+        f'    workflow_id="{workflow_id}",',
+        f'    workflow_version_id="{selected_version.id}",',
+        f'    triggered_by="{actor}",',
+        "    inputs={},",
+        ")",
+        "print(response)",
+    ]
+
+    runtime.console.print("Python scaffold:")
+    runtime.console.print("```python")
+    for line in snippet:
+        runtime.console.print(line)
+    runtime.console.print("```")

--- a/packages/sdk/src/orcheo_sdk/cli/commands/credentials.py
+++ b/packages/sdk/src/orcheo_sdk/cli/commands/credentials.py
@@ -1,0 +1,215 @@
+"""Credential management commands."""
+
+from __future__ import annotations
+import typer
+from orcheo_sdk.cli import render as renderers
+from orcheo_sdk.cli.runtime import CliError, CliRuntime, render_error
+from orcheo_sdk.cli.services import (
+    CredentialRecord,
+    CredentialTemplateRecord,
+    delete_credential,
+    fetch_credential_templates,
+    fetch_credentials,
+    issue_credential,
+)
+
+
+credential_app = typer.Typer(help="Inspect and manage credential metadata")
+
+
+def _runtime(ctx: typer.Context) -> CliRuntime:
+    runtime = ctx.obj
+    if not isinstance(runtime, CliRuntime):  # pragma: no cover
+        raise typer.Exit(code=1)
+    return runtime
+
+
+def _resolve_template(
+    templates: list[CredentialTemplateRecord],
+    name_or_id: str,
+) -> CredentialTemplateRecord:
+    for template in templates:
+        if template.id == name_or_id or template.name.lower() == name_or_id.lower():
+            return template
+    msg = f"Credential template '{name_or_id}' was not found"
+    raise CliError(msg)
+
+
+def _resolve_credential(
+    credentials: list[CredentialRecord],
+    candidate: str,
+) -> CredentialRecord:
+    for credential in credentials:
+        if credential.id == candidate or credential.name.lower() == candidate.lower():
+            return credential
+    msg = f"Credential '{candidate}' was not found"
+    raise CliError(msg)
+
+
+@credential_app.command("list", help="List credentials visible to the caller")
+def list_credentials(
+    ctx: typer.Context,
+    workflow_id: str | None = typer.Option(
+        None,
+        "--workflow-id",
+        help="Scope results to a workflow",
+    ),
+) -> None:
+    """Render a table of credentials returned by the API."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(runtime.console, "Listing credentials requires network access")
+        raise typer.Exit(code=1)
+    try:
+        credentials = fetch_credentials(runtime, workflow_id=workflow_id)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+    renderers.render_credentials(runtime.console, credentials)
+
+
+@credential_app.command("create", help="Issue a credential from a template")
+def create_credential(
+    ctx: typer.Context,
+    template: str,
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        help="Override credential name",
+    ),
+    secret: str | None = typer.Option(
+        None,
+        "--secret",
+        help="Secret value for the credential (prompted if omitted)",
+    ),
+    scope: str | None = typer.Option(
+        None,
+        "--scope",
+        help="Override template scopes (comma-separated values)",
+    ),
+    workflow_id: str | None = typer.Option(
+        None,
+        "--workflow-id",
+        help="Scope results to a workflow",
+    ),
+    actor: str = typer.Option(
+        "cli",
+        "--actor",
+        help="Actor recorded with the issuance",
+    ),
+) -> None:
+    """Issue a credential from a stored template."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(runtime.console, "Creating credentials requires network access")
+        raise typer.Exit(code=1)
+
+    try:
+        templates = fetch_credential_templates(runtime)
+        selected = _resolve_template(templates, template)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    secret_value = secret or typer.prompt(
+        "Secret",
+        hide_input=True,
+        confirmation_prompt=True,
+    )
+    scopes = None
+    if scope:
+        scopes = [
+            candidate.strip() for candidate in scope.split(",") if candidate.strip()
+        ]
+
+    try:
+        response = issue_credential(
+            runtime,
+            template_id=selected.id,
+            secret=secret_value,
+            actor=actor,
+            name=name,
+            scopes=scopes,
+            workflow_id=workflow_id,
+        )
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    runtime.console.print("Credential issued successfully:")
+    runtime.console.print(f"Credential ID: {response.get('credential_id')}")
+    runtime.console.print(f"Name: {response.get('name', name or selected.name)}")
+    runtime.console.print(f"Provider: {response.get('provider', selected.provider)}")
+
+
+@credential_app.command("delete", help="Delete a credential entry")
+def delete_credential_command(
+    ctx: typer.Context,
+    credential: str,
+    workflow_id: str | None = typer.Option(
+        None,
+        "--workflow-id",
+        help="Scope results to a workflow",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation",
+        is_flag=True,
+    ),
+) -> None:
+    """Delete a credential entry from the vault."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(runtime.console, "Deleting credentials requires network access")
+        raise typer.Exit(code=1)
+
+    if not yes:
+        confirm = typer.confirm(f"Delete credential '{credential}'?", default=False)
+        if not confirm:
+            runtime.console.print("Aborted.")
+            return
+
+    try:
+        delete_credential(runtime, credential, workflow_id=workflow_id)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    runtime.console.print("Credential deleted.")
+
+
+@credential_app.command("reference", help="Emit a [[credential]] reference snippet")
+def credential_reference(
+    ctx: typer.Context,
+    credential: str,
+    workflow_id: str | None = typer.Option(
+        None,
+        "--workflow-id",
+        help="Scope results to a workflow",
+    ),
+) -> None:
+    """Print the [[credential]] reference snippet for a credential."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(
+            runtime.console,
+            "Fetching credential references requires network access",
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        credentials = fetch_credentials(runtime, workflow_id=workflow_id)
+        selected = _resolve_credential(credentials, credential)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    runtime.console.print(f"[[{selected.name}]]")
+    runtime.console.print(
+        (
+            "Use this reference in workflow configurations to inject the "
+            "credential at runtime."
+        ),
+    )

--- a/packages/sdk/src/orcheo_sdk/cli/commands/nodes.py
+++ b/packages/sdk/src/orcheo_sdk/cli/commands/nodes.py
@@ -1,0 +1,93 @@
+"""Node catalog commands."""
+
+from __future__ import annotations
+import typer
+from orcheo_sdk.cli import render as renderers
+from orcheo_sdk.cli.runtime import CliError, CliRuntime, render_error, render_warning
+from orcheo_sdk.cli.services import NodeRecord, fetch_node_catalog
+
+
+node_app = typer.Typer(help="Discover available Orcheo nodes")
+
+
+def _runtime(ctx: typer.Context) -> CliRuntime:
+    runtime = ctx.obj
+    if not isinstance(runtime, CliRuntime):  # pragma: no cover - defensive
+        raise typer.Exit(code=1)
+    return runtime
+
+
+def _matches_tag(node: NodeRecord, candidate: str) -> bool:
+    needle = candidate.strip().lower()
+    if not needle:
+        return True
+    if node.category.lower() == needle:
+        return True
+    return any(tag.lower() == needle for tag in node.tags)
+
+
+@node_app.command("list", help="List nodes available to the CLI")
+def list_nodes(
+    ctx: typer.Context,
+    tag: str | None = typer.Option(
+        None,
+        "--tag",
+        "-t",
+        help="Filter nodes by tag or category",
+    ),
+) -> None:
+    """Render the node catalog in a tabular format."""
+    runtime = _runtime(ctx)
+    try:
+        nodes, _from_cache, cache_entry = fetch_node_catalog(runtime)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    if tag:
+        filtered = [node for node in nodes if _matches_tag(node, tag)]
+        if not filtered:
+            runtime.console.print("No nodes match the requested filter.")
+            return
+        nodes = filtered
+
+    if cache_entry and runtime.cache.is_stale(cache_entry):
+        render_warning(
+            runtime.console,
+            (
+                "Node catalog cached data is older than 24 hours; "
+                "refresh online for the latest metadata."
+            ),
+        )
+
+    renderers.render_node_table(runtime.console, nodes)
+
+
+@node_app.command("show", help="Display details for a specific node")
+def show_node(ctx: typer.Context, name: str) -> None:
+    """Display metadata for a single node."""
+    runtime = _runtime(ctx)
+    try:
+        nodes, _from_cache, cache_entry = fetch_node_catalog(runtime)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    target = next((node for node in nodes if node.name.lower() == name.lower()), None)
+    if target is None:
+        render_error(runtime.console, f"Node '{name}' was not found")
+        raise typer.Exit(code=1)
+
+    if cache_entry and runtime.cache.is_stale(cache_entry):
+        render_warning(
+            runtime.console,
+            (
+                "Node metadata is served from a cache older than 24 hours; "
+                "refresh online to update."
+            ),
+        )
+
+    runtime.console.print(f"Name: {target.name}")
+    runtime.console.print(f"Category: {target.category}")
+    runtime.console.print(f"Description: {target.description or '—'}")
+    runtime.console.print(f"Tags: {', '.join(target.tags) if target.tags else '—'}")

--- a/packages/sdk/src/orcheo_sdk/cli/commands/workflows.py
+++ b/packages/sdk/src/orcheo_sdk/cli/commands/workflows.py
@@ -1,0 +1,224 @@
+"""Workflow management commands."""
+
+from __future__ import annotations
+import json
+import re
+from typing import Any
+import typer
+from orcheo_sdk.cli import render as renderers
+from orcheo_sdk.cli.runtime import CliError, CliRuntime, render_error
+from orcheo_sdk.cli.services import (
+    WorkflowRunInfo,
+    WorkflowVersionInfo,
+    fetch_workflow_detail,
+    fetch_workflow_runs,
+    fetch_workflows,
+    trigger_workflow_run,
+)
+
+
+workflow_app = typer.Typer(help="Inspect and run workflows")
+
+
+def _runtime(ctx: typer.Context) -> CliRuntime:
+    runtime = ctx.obj
+    if not isinstance(runtime, CliRuntime):  # pragma: no cover
+        raise typer.Exit(code=1)
+    return runtime
+
+
+def _select_version(
+    versions: list[WorkflowVersionInfo],
+    requested: int | None,
+) -> WorkflowVersionInfo:
+    if not versions:
+        raise CliError("Workflow has no versions to select from")
+    if requested is None:
+        return max(versions, key=lambda version: version.version)
+    for version in versions:
+        if version.version == requested:
+            return version
+    raise CliError(f"Workflow version {requested} was not found")
+
+
+def _normalise_identifier(value: str) -> str:
+    slug = re.sub(r"[^0-9A-Za-z_]", "_", value)
+    return slug or "node"
+
+
+def _label_for_node(node: dict[str, Any]) -> str:
+    node_type = str(node.get("type", "")) or "node"
+    node_name = str(node.get("name", ""))
+    label = node_type
+    if node_name and node_name != node_type:
+        label = f"{node_type}: {node_name}"
+    return label.replace('"', '"')
+
+
+def build_mermaid(graph: dict[str, Any]) -> str:
+    """Return a Mermaid diagram representing the supplied graph."""
+    nodes = graph.get("nodes", [])
+    edges = graph.get("edges", [])
+    conditionals = graph.get("conditional_edges", [])
+
+    lines: list[str] = ["flowchart TD"]
+    declared: set[str] = set()
+
+    for node in nodes:
+        name = str(node.get("name", "")) or "node"
+        identifier = _normalise_identifier(name)
+        declared.add(identifier)
+        label = _label_for_node(node)
+        lines.append(f'    {identifier}["{label}"]')
+
+    for source, target in edges:
+        src_id = _normalise_identifier(str(source))
+        tgt_id = _normalise_identifier(str(target))
+        lines.append(f"    {src_id} --> {tgt_id}")
+
+    for branch in conditionals:
+        source = branch.get("source")
+        if not source:
+            continue
+        src_id = _normalise_identifier(str(source))
+        mapping = branch.get("mapping", {})
+        for key, target in mapping.items():
+            tgt_id = _normalise_identifier(str(target))
+            label = str(key).replace('"', '"')
+            lines.append(f'    {src_id} -- "{label}" --> {tgt_id}')
+        default = branch.get("default")
+        if default:
+            tgt_id = _normalise_identifier(str(default))
+            lines.append(f'    {src_id} -- "default" --> {tgt_id}')
+
+    if len(lines) == 1:
+        lines.append("    %% No nodes defined in workflow")
+    return "\n".join(lines)
+
+
+@workflow_app.command("list", help="List workflows in the connected workspace")
+def list_workflows(ctx: typer.Context) -> None:
+    """Render a table of workflows available via the API."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(runtime.console, "Workflow listing requires network access")
+        raise typer.Exit(code=1)
+    try:
+        workflows = fetch_workflows(runtime)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+    renderers.render_workflow_table(runtime.console, workflows)
+
+
+@workflow_app.command("show", help="Show workflow metadata and latest runs")
+def show_workflow(
+    ctx: typer.Context,
+    workflow_id: str,
+    version: int | None = typer.Option(
+        None,
+        "--version",
+        help="Select a specific workflow version",
+    ),
+) -> None:
+    """Display workflow metadata, latest runs, and a Mermaid representation."""
+    runtime = _runtime(ctx)
+    try:
+        detail, versions, cache_entry = fetch_workflow_detail(runtime, workflow_id)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    try:
+        selected_version = _select_version(versions, version)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    mermaid = build_mermaid(selected_version.graph)
+    runs: list[WorkflowRunInfo]
+    try:
+        runs = fetch_workflow_runs(runtime, workflow_id)
+    except CliError:
+        runs = []
+
+    cache_warning: str | None = None
+    if cache_entry and runtime.cache.is_stale(cache_entry):
+        cache_warning = (
+            "Workflow data is older than 24 hours; refresh online to update."
+        )
+
+    renderers.render_workflow_detail(
+        runtime.console,
+        detail,
+        latest_version=selected_version,
+        runs=runs,
+        mermaid=mermaid,
+        cache_warning=cache_warning,
+    )
+
+
+@workflow_app.command("run", help="Trigger a workflow execution")
+def run_workflow(
+    ctx: typer.Context,
+    workflow_id: str,
+    version: int | None = typer.Option(
+        None,
+        "--version",
+        help="Workflow version to execute",
+    ),
+    actor: str = typer.Option("cli", "--actor", help="Actor recorded for the run"),
+    inputs: str | None = typer.Option(
+        None,
+        "--inputs",
+        help="JSON payload to pass as workflow inputs",
+    ),
+) -> None:
+    """Trigger a workflow run using the latest or requested version."""
+    runtime = _runtime(ctx)
+    if runtime.offline:
+        render_error(runtime.console, "Running workflows is unavailable offline")
+        raise typer.Exit(code=1)
+
+    try:
+        detail, versions, _cache_entry = fetch_workflow_detail(runtime, workflow_id)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    try:
+        selected_version = _select_version(versions, version)
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    payload: dict[str, Any] | None = None
+    if inputs:
+        try:
+            candidate = json.loads(inputs)
+        except json.JSONDecodeError as exc:
+            render_error(runtime.console, f"Invalid JSON for --inputs: {exc}")
+            raise typer.Exit(code=1) from exc
+        if not isinstance(candidate, dict):
+            render_error(runtime.console, "Workflow inputs must be a JSON object")
+            raise typer.Exit(code=1)
+        payload = candidate
+
+    try:
+        run = trigger_workflow_run(
+            runtime,
+            workflow_id=workflow_id,
+            workflow_version_id=selected_version.id,
+            actor=actor,
+            inputs=payload,
+        )
+    except CliError as exc:
+        render_error(runtime.console, str(exc))
+        raise typer.Exit(code=1) from exc
+
+    runtime.console.print(
+        "Dispatched workflow run "
+        f"for '{detail.name}' (version {selected_version.version})"
+    )
+    runtime.console.print(f"Run ID: {run.id}")
+    runtime.console.print(f"Status: {run.status}")

--- a/packages/sdk/src/orcheo_sdk/cli/render.py
+++ b/packages/sdk/src/orcheo_sdk/cli/render.py
@@ -1,0 +1,141 @@
+"""Rendering helpers for CLI output."""
+
+from __future__ import annotations
+from collections.abc import Iterable
+from datetime import datetime
+from rich.console import Console
+from rich.table import Table
+from orcheo_sdk.cli.services import (
+    CredentialRecord,
+    NodeRecord,
+    WorkflowDetail,
+    WorkflowRunInfo,
+    WorkflowSummary,
+    WorkflowVersionInfo,
+)
+
+
+def _format_datetime(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    return value.isoformat(timespec="seconds")
+
+
+def render_node_table(console: Console, nodes: Iterable[NodeRecord]) -> None:
+    """Render the node catalog in a Rich table."""
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Category", no_wrap=True)
+    table.add_column("Description")
+    table.add_column("Tags")
+    for node in nodes:
+        tags = ", ".join(sorted(node.tags)) if node.tags else "—"
+        table.add_row(node.name, node.category, node.description, tags)
+    console.print(table)
+
+
+def render_workflow_table(
+    console: Console,
+    workflows: Iterable[WorkflowSummary],
+) -> None:
+    """Render workflow summaries in a table."""
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", no_wrap=True)
+    table.add_column("Name")
+    table.add_column("Tags")
+    table.add_column("Archived", no_wrap=True)
+    table.add_column("Updated")
+    for workflow in workflows:
+        tags = ", ".join(workflow.tags) if workflow.tags else "—"
+        table.add_row(
+            workflow.id,
+            workflow.name,
+            tags,
+            "yes" if workflow.is_archived else "no",
+            _format_datetime(workflow.updated_at),
+        )
+    console.print(table)
+
+
+def render_workflow_detail(
+    console: Console,
+    detail: WorkflowDetail,
+    *,
+    latest_version: WorkflowVersionInfo | None,
+    runs: Iterable[WorkflowRunInfo],
+    mermaid: str | None = None,
+    cache_warning: str | None = None,
+) -> None:
+    """Render detailed workflow information including Mermaid output."""
+    console.print(f"Workflow: {detail.name} ({detail.id})")
+    console.print(f"Slug: {detail.slug}")
+    console.print(f"Description: {detail.description or '—'}")
+    console.print(f"Tags: {', '.join(detail.tags) if detail.tags else '—'}")
+    console.print(f"Archived: {'yes' if detail.is_archived else 'no'}")
+    console.print(f"Created: {_format_datetime(detail.created_at)}")
+    console.print(f"Updated: {_format_datetime(detail.updated_at)}")
+    if cache_warning:
+        console.print(f"Warning: {cache_warning}")
+    console.print("")
+    if latest_version is not None:
+        console.print(
+            "Latest version: "
+            f"v{latest_version.version} ({_format_datetime(latest_version.created_at)})"
+        )
+        console.print(f"Notes: {latest_version.notes or '—'}")
+    else:
+        console.print("Latest version: —")
+    console.print("")
+    if mermaid:
+        console.print("Mermaid diagram:")
+        console.print("```mermaid")
+        console.print(mermaid)
+        console.print("```")
+        console.print("")
+    run_table = Table(show_header=True, header_style="bold")
+    run_table.add_column("Run ID", no_wrap=True)
+    run_table.add_column("Status", no_wrap=True)
+    run_table.add_column("Triggered By", no_wrap=True)
+    run_table.add_column("Created")
+    run_table.add_column("Started")
+    run_table.add_column("Completed")
+    rows_added = False
+    for run in runs:
+        rows_added = True
+        run_table.add_row(
+            run.id,
+            run.status,
+            run.triggered_by,
+            _format_datetime(run.created_at),
+            _format_datetime(run.started_at),
+            _format_datetime(run.completed_at),
+        )
+    if rows_added:
+        console.print("Recent runs:")
+        console.print(run_table)
+    else:
+        console.print("Recent runs: none available")
+
+
+def render_credentials(
+    console: Console,
+    credentials: Iterable[CredentialRecord],
+) -> None:
+    """Render credential metadata in a table."""
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", no_wrap=True)
+    table.add_column("Name")
+    table.add_column("Provider", no_wrap=True)
+    table.add_column("Access", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Kind", no_wrap=True)
+    for credential in credentials:
+        table.add_row(
+            credential.id,
+            credential.name,
+            credential.provider,
+            credential.access,
+            credential.status,
+            credential.kind,
+        )
+    console.print(table)

--- a/packages/sdk/src/orcheo_sdk/cli/runtime.py
+++ b/packages/sdk/src/orcheo_sdk/cli/runtime.py
@@ -1,0 +1,301 @@
+"""Runtime helpers shared across CLI commands."""
+
+from __future__ import annotations
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+import httpx
+from rich.console import Console
+
+
+DEFAULT_API_URL = "http://localhost:8000"
+CONFIG_ENV_VAR = "ORCHEO_PROFILE"
+CACHE_ENV_VAR = "ORCHEO_CACHE_DIR"
+CONFIG_PATH_ENV_VAR = "ORCHEO_CONFIG_PATH"
+CACHE_DEFAULT_TTL = timedelta(hours=24)
+USER_AGENT = "orcheo-cli/0.1"
+
+
+class CliError(RuntimeError):
+    """Raised when the CLI cannot complete an operation."""
+
+
+@dataclass(slots=True)
+class CliSettings:
+    """Resolved configuration for a CLI invocation."""
+
+    api_url: str = DEFAULT_API_URL
+    service_token: str | None = None
+    profile: str | None = None
+    timeout: float = 30.0
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    """Entry read from the on-disk cache."""
+
+    data: Any
+    cached_at: datetime
+
+    @property
+    def age(self) -> timedelta:
+        """Return how long ago the cache entry was stored."""
+        return datetime.now(tz=UTC) - self.cached_at
+
+
+class CacheStore:
+    """Simple JSON cache used for offline mode."""
+
+    def __init__(self, base_path: Path, *, ttl: timedelta = CACHE_DEFAULT_TTL) -> None:
+        """Create a cache store backed by ``base_path``."""
+        self.base_path = base_path
+        self.ttl = ttl
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _entry_path(self, key: str) -> Path:
+        """Return the filesystem path for ``key``."""
+        slug = key.replace("/", "_").replace("::", "_")
+        return self.base_path / f"{slug}.json"
+
+    def load(self, key: str) -> CacheEntry | None:
+        """Load and deserialize a cache entry for ``key`` if present."""
+        path = self._entry_path(key)
+        if not path.exists():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        timestamp = payload.get("cached_at")
+        if not timestamp:
+            return None
+        try:
+            cached_at = datetime.fromisoformat(timestamp)
+        except ValueError:
+            return None
+        if cached_at.tzinfo is None:
+            cached_at = cached_at.replace(tzinfo=UTC)
+        return CacheEntry(data=payload.get("data"), cached_at=cached_at)
+
+    def store(self, key: str, data: Any) -> None:
+        """Persist ``data`` in the cache under ``key``."""
+        path = self._entry_path(key)
+        payload = {
+            "cached_at": datetime.now(tz=UTC).isoformat(),
+            "data": data,
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    def is_stale(self, entry: CacheEntry) -> bool:
+        """Return ``True`` if ``entry`` exceeded the configured TTL."""
+        return entry.age > self.ttl
+
+
+class ApiError(RuntimeError):
+    """Raised when an HTTP request fails."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        payload: Any | None = None,
+    ) -> None:
+        """Store HTTP error context for later reporting."""
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+class ApiClient:
+    """Thin wrapper around ``httpx.Client`` with Orcheo defaults."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        service_token: str | None,
+        timeout: float,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        """Create a configured HTTP client for the Orcheo API."""
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+        if service_token:
+            headers["Authorization"] = f"Bearer {service_token}"
+        self._client = httpx.Client(
+            base_url=base_url,
+            timeout=timeout,
+            headers=headers,
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        """Release the underlying HTTP resources."""
+        self._client.close()
+
+    def request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue an HTTP request and raise :class:`ApiError` on failure."""
+        try:
+            response = self._client.request(method, path, **kwargs)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as exc:
+            payload: Any | None
+            try:
+                payload = exc.response.json()
+            except ValueError:
+                payload = exc.response.text
+            raise ApiError(
+                f"Request failed with status {exc.response.status_code}",
+                status_code=exc.response.status_code,
+                payload=payload,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ApiError(f"HTTP error: {exc}") from exc
+
+    def get_json(self, path: str, *, params: Mapping[str, Any] | None = None) -> Any:
+        """Return the decoded JSON payload for a ``GET`` request."""
+        response = self.request("GET", path, params=params)
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise ApiError("Unexpected response payload") from exc
+
+    def post_json(self, path: str, *, json_payload: Any) -> Any:
+        """Return the decoded JSON payload for a ``POST`` request."""
+        response = self.request("POST", path, json=json_payload)
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+    def delete(self, path: str) -> None:
+        """Issue a ``DELETE`` request and ignore the response body."""
+        self.request("DELETE", path)
+
+
+@dataclass(slots=True)
+class CliRuntime:
+    """Container shared across command handlers."""
+
+    settings: CliSettings
+    console: Console
+    cache: CacheStore
+    offline: bool
+    api: ApiClient | None = None
+
+    def require_api(self) -> ApiClient:
+        """Return the active API client or raise if offline."""
+        if self.api is None:
+            raise CliError(
+                "This command requires network access; re-run without --offline",
+            )
+        return self.api
+
+
+def build_console() -> Console:
+    """Return a console configured for deterministic CLI output."""
+    return Console(
+        force_terminal=False,
+        color_system=None,
+        markup=False,
+        highlight=False,
+        width=100,
+    )
+
+
+def default_config_path() -> Path:
+    """Return the default configuration file path for the CLI."""
+    explicit = os.getenv(CONFIG_PATH_ENV_VAR)
+    if explicit:
+        return Path(explicit).expanduser()
+    if os.name == "nt":
+        base = Path(os.getenv("APPDATA", Path.home() / "AppData" / "Roaming"))
+        return base / "Orcheo" / "cli.toml"
+    return Path.home() / ".config" / "orcheo" / "cli.toml"
+
+
+def default_cache_path() -> Path:
+    """Return the default cache directory used by the CLI."""
+    explicit = os.getenv(CACHE_ENV_VAR)
+    if explicit:
+        return Path(explicit).expanduser()
+    if os.name == "nt":
+        base = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "Orcheo" / "Cache"
+    return Path.home() / ".cache" / "orcheo"
+
+
+def load_profiles(path: Path) -> Mapping[str, Mapping[str, Any]]:
+    """Return the profile mapping defined in the CLI configuration file."""
+    if not path.exists():
+        return {}
+    try:
+        import tomllib
+    except ModuleNotFoundError as exc:  # pragma: no cover - Python <3.11 safeguard
+        raise CliError("Python 3.11+ is required for profile support") from exc
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise CliError(f"Invalid CLI configuration file: {path}") from exc
+    profiles = payload.get("profiles", {})
+    if not isinstance(profiles, Mapping):
+        return {}
+    return profiles
+
+
+def resolve_settings(
+    *,
+    api_url: str | None,
+    service_token: str | None,
+    profile: str | None,
+    timeout: float,
+) -> CliSettings:
+    """Resolve CLI settings from command line, environment, and profiles."""
+    profile_name = profile or os.getenv(CONFIG_ENV_VAR)
+    config_path = default_config_path()
+    profiles = load_profiles(config_path)
+    profile_data: Mapping[str, Any] = profiles.get(profile_name or "", {})
+
+    env_api_url = os.getenv("ORCHEO_API_URL")
+    env_token = os.getenv("ORCHEO_SERVICE_TOKEN")
+
+    resolved_api_url = (
+        api_url
+        or (env_api_url.strip() if env_api_url else None)
+        or (str(profile_data.get("api_url")).strip() if profile_data else None)
+        or DEFAULT_API_URL
+    )
+
+    resolved_token = (
+        service_token
+        or (env_token.strip() if env_token else None)
+        or (str(profile_data.get("service_token")).strip() if profile_data else None)
+    )
+
+    if not resolved_api_url:
+        raise CliError("Unable to determine the Orcheo API URL")
+
+    return CliSettings(
+        api_url=resolved_api_url,
+        service_token=resolved_token,
+        profile=profile_name,
+        timeout=timeout,
+    )
+
+
+def render_warning(console: Console, message: str) -> None:
+    """Print a warning message to the console."""
+    console.print(f"Warning: {message}")
+
+
+def render_error(console: Console, message: str) -> None:
+    """Print an error message to the console."""
+    console.print(f"Error: {message}")

--- a/packages/sdk/src/orcheo_sdk/cli/services.py
+++ b/packages/sdk/src/orcheo_sdk/cli/services.py
@@ -1,0 +1,475 @@
+"""Service layer bridging CLI commands and the Orcheo API."""
+
+from __future__ import annotations
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from orcheo_sdk.cli.runtime import ApiError, CacheEntry, CliError, CliRuntime
+
+
+@dataclass(slots=True)
+class NodeRecord:
+    """Node catalog entry."""
+
+    name: str
+    description: str
+    category: str
+    tags: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the node metadata for cache storage."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> NodeRecord:
+        """Create a node record from an API payload."""
+        return cls(
+            name=str(payload.get("name", "")),
+            description=str(payload.get("description", "")),
+            category=str(payload.get("category", "general")),
+            tags=tuple(str(tag) for tag in payload.get("tags", []) if tag),
+        )
+
+
+@dataclass(slots=True)
+class WorkflowSummary:
+    """Summary metadata for a workflow returned by the API."""
+
+    id: str
+    name: str
+    slug: str
+    tags: tuple[str, ...]
+    is_archived: bool
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> WorkflowSummary:
+        """Instantiate a summary object from an API payload."""
+        return cls(
+            id=str(payload.get("id")),
+            name=str(payload.get("name", "")),
+            slug=str(payload.get("slug", "")),
+            tags=tuple(str(tag) for tag in payload.get("tags", []) if tag),
+            is_archived=bool(payload.get("is_archived", False)),
+            created_at=_parse_datetime(payload.get("created_at")),
+            updated_at=_parse_datetime(payload.get("updated_at")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the summary for cache storage."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "slug": self.slug,
+            "tags": list(self.tags),
+            "is_archived": self.is_archived,
+            "created_at": _iso_or_none(self.created_at),
+            "updated_at": _iso_or_none(self.updated_at),
+        }
+
+
+@dataclass(slots=True)
+class WorkflowDetail(WorkflowSummary):
+    """Detailed workflow metadata including description."""
+
+    description: str | None = None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> WorkflowDetail:
+        """Create a detail instance from an API payload."""
+        summary = WorkflowSummary.from_mapping(payload)
+        return cls(
+            id=summary.id,
+            name=summary.name,
+            slug=summary.slug,
+            tags=summary.tags,
+            is_archived=summary.is_archived,
+            created_at=summary.created_at,
+            updated_at=summary.updated_at,
+            description=payload.get("description"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the detail for cache storage."""
+        payload = super().to_dict()
+        payload["description"] = self.description
+        return payload
+
+
+@dataclass(slots=True)
+class WorkflowVersionInfo:
+    """Metadata describing a workflow version."""
+
+    id: str
+    version: int
+    created_at: datetime | None
+    notes: str | None
+    graph: dict[str, Any]
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> WorkflowVersionInfo:
+        """Return a version record from an API payload."""
+        graph = payload.get("graph")
+        if not isinstance(graph, Mapping):
+            graph = {}
+        return cls(
+            id=str(payload.get("id")),
+            version=int(payload.get("version", 0)),
+            created_at=_parse_datetime(payload.get("created_at")),
+            notes=payload.get("notes"),
+            graph=dict(graph),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the version for cache storage."""
+        return {
+            "id": self.id,
+            "version": self.version,
+            "created_at": _iso_or_none(self.created_at),
+            "notes": self.notes,
+            "graph": self.graph,
+        }
+
+
+@dataclass(slots=True)
+class WorkflowRunInfo:
+    """Metadata describing an individual workflow run."""
+
+    id: str
+    status: str
+    triggered_by: str
+    created_at: datetime | None
+    started_at: datetime | None
+    completed_at: datetime | None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> WorkflowRunInfo:
+        """Create a run record from an API payload."""
+        return cls(
+            id=str(payload.get("id")),
+            status=str(payload.get("status", "")),
+            triggered_by=str(payload.get("triggered_by", "")),
+            created_at=_parse_datetime(payload.get("created_at")),
+            started_at=_parse_datetime(payload.get("started_at")),
+            completed_at=_parse_datetime(payload.get("completed_at")),
+        )
+
+
+@dataclass(slots=True)
+class CredentialRecord:
+    """Rendered representation of a stored credential."""
+
+    id: str
+    name: str
+    provider: str
+    access: str
+    status: str
+    kind: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> CredentialRecord:
+        """Instantiate a credential record from an API payload."""
+        return cls(
+            id=str(payload.get("id")),
+            name=str(payload.get("name", "")),
+            provider=str(payload.get("provider", "")),
+            access=str(payload.get("access", "private")),
+            status=str(payload.get("status", "unknown")),
+            kind=str(payload.get("kind", "secret")),
+        )
+
+
+@dataclass(slots=True)
+class CredentialTemplateRecord:
+    """Representation of a credential template."""
+
+    id: str
+    name: str
+    provider: str
+    description: str | None
+    scopes: tuple[str, ...]
+    kind: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> CredentialTemplateRecord:
+        """Return a template record from an API payload."""
+        return cls(
+            id=str(payload.get("id")),
+            name=str(payload.get("name", "")),
+            provider=str(payload.get("provider", "")),
+            description=payload.get("description"),
+            scopes=tuple(str(scope) for scope in payload.get("scopes", []) if scope),
+            kind=str(payload.get("kind", "secret")),
+        )
+
+
+NODE_CACHE_KEY = "node_catalog"
+WORKFLOW_CACHE_KEY = "workflow::{workflow_id}"
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse an ISO timestamp, returning ``None`` on failure."""
+    if value in (None, ""):
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    """Return the ISO string for ``value`` or ``None`` if absent."""
+    if value is None:
+        return None
+    return value.astimezone(UTC).isoformat()
+
+
+def _load_node_catalog_from_registry() -> list[NodeRecord]:
+    """Load node metadata from the local registry for offline usage."""
+    try:
+        from orcheo.nodes.registry import registry
+    except Exception:  # pragma: no cover - optional dependency
+        return []
+
+    records: list[NodeRecord] = []
+    try:
+        metadata_iter: Iterable[Any] = registry.iter_metadata()  # type: ignore[attr-defined]
+    except AttributeError:  # pragma: no cover - fallback for older registry versions
+        metadata_iter = getattr(registry, "_metadata", {}).values()  # type: ignore[attr-defined]
+    for metadata in metadata_iter:
+        tags = getattr(metadata, "tags", []) or []
+        records.append(
+            NodeRecord(
+                name=getattr(metadata, "name", ""),
+                description=getattr(metadata, "description", ""),
+                category=getattr(metadata, "category", "general"),
+                tags=tuple(str(tag) for tag in tags if tag),
+            )
+        )
+    return sorted(records, key=lambda record: record.name.lower())
+
+
+def fetch_node_catalog(
+    runtime: CliRuntime,
+) -> tuple[list[NodeRecord], bool, CacheEntry | None]:
+    """Return the node catalog, optionally sourced from cache."""
+    cache = runtime.cache
+    cached_entry = cache.load(NODE_CACHE_KEY)
+    from_cache = runtime.offline
+
+    if runtime.offline:
+        if cached_entry is not None and isinstance(cached_entry.data, list):
+            return (
+                [NodeRecord.from_mapping(item) for item in cached_entry.data],
+                True,
+                cached_entry,
+            )
+        return (_load_node_catalog_from_registry(), True, None)
+
+    api = runtime.require_api()
+    payload: Any | None = None
+    try:
+        payload = api.get_json("/api/nodes/catalog")
+    except ApiError as exc:
+        if exc.status_code not in {404, 501}:
+            raise
+        payload = None
+
+    records: list[NodeRecord]
+    if isinstance(payload, list):
+        records = [NodeRecord.from_mapping(item) for item in payload]
+    else:
+        records = _load_node_catalog_from_registry()
+
+    cache.store(NODE_CACHE_KEY, [record.to_dict() for record in records])
+    return (records, from_cache, cached_entry)
+
+
+def fetch_workflows(runtime: CliRuntime) -> list[WorkflowSummary]:
+    """Return the list of workflows available to the caller."""
+    api = runtime.require_api()
+    try:
+        payload = api.get_json("/api/workflows")
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(payload, list):
+        raise CliError("Unexpected response from the workflows endpoint")
+    return [WorkflowSummary.from_mapping(item) for item in payload]
+
+
+def fetch_workflow_detail(
+    runtime: CliRuntime, workflow_id: str
+) -> tuple[WorkflowDetail, list[WorkflowVersionInfo], CacheEntry | None]:
+    """Return workflow detail, associated versions, and cached metadata."""
+    cache_key = WORKFLOW_CACHE_KEY.format(workflow_id=workflow_id)
+    cache = runtime.cache
+    cached_entry = cache.load(cache_key)
+
+    if runtime.offline:
+        if cached_entry is None or not isinstance(cached_entry.data, Mapping):
+            raise CliError(
+                "Workflow details are not cached locally; "
+                "re-run while online to prime the cache",
+            )
+        detail_payload = cached_entry.data.get("detail")
+        if not isinstance(detail_payload, Mapping):
+            raise CliError("Cached workflow detail payload is invalid")
+        versions_payload = cached_entry.data.get("versions", [])
+        if not isinstance(versions_payload, Iterable):
+            raise CliError("Cached workflow versions payload is invalid")
+        detail = WorkflowDetail.from_mapping(detail_payload)
+        versions = [WorkflowVersionInfo.from_mapping(item) for item in versions_payload]
+        return detail, versions, cached_entry
+
+    api = runtime.require_api()
+    try:
+        detail_payload = api.get_json(f"/api/workflows/{workflow_id}")
+        versions_payload = api.get_json(f"/api/workflows/{workflow_id}/versions")
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(detail_payload, Mapping):
+        raise CliError("Unexpected workflow detail payload")
+    if not isinstance(versions_payload, list):
+        raise CliError("Unexpected workflow version payload")
+    detail = WorkflowDetail.from_mapping(detail_payload)
+    versions = [WorkflowVersionInfo.from_mapping(item) for item in versions_payload]
+    cache.store(
+        cache_key,
+        {
+            "detail": detail.to_dict(),
+            "versions": [version.to_dict() for version in versions],
+        },
+    )
+    return detail, versions, cached_entry
+
+
+def fetch_workflow_runs(runtime: CliRuntime, workflow_id: str) -> list[WorkflowRunInfo]:
+    """Return workflow run metadata, or ``[]`` when offline."""
+    if runtime.offline:
+        return []
+    api = runtime.require_api()
+    try:
+        payload = api.get_json(f"/api/workflows/{workflow_id}/runs")
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(payload, list):
+        raise CliError("Unexpected workflow run payload")
+    return [WorkflowRunInfo.from_mapping(item) for item in payload]
+
+
+def trigger_workflow_run(
+    runtime: CliRuntime,
+    *,
+    workflow_id: str,
+    workflow_version_id: str,
+    actor: str,
+    inputs: Mapping[str, Any] | None = None,
+) -> WorkflowRunInfo:
+    """Trigger a workflow run and return its metadata."""
+    api = runtime.require_api()
+    payload = {
+        "workflow_version_id": workflow_version_id,
+        "triggered_by": actor,
+        "input_payload": dict(inputs or {}),
+    }
+    try:
+        response = api.post_json(
+            f"/api/workflows/{workflow_id}/runs",
+            json_payload=payload,
+        )
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(response, Mapping):
+        raise CliError("Unexpected workflow run response")
+    return WorkflowRunInfo.from_mapping(response)
+
+
+def fetch_credentials(
+    runtime: CliRuntime,
+    *,
+    workflow_id: str | None = None,
+) -> list[CredentialRecord]:
+    """Return credential metadata optionally filtered by workflow."""
+    api = runtime.require_api()
+    params = {"workflow_id": workflow_id} if workflow_id else None
+    try:
+        payload = api.get_json("/api/credentials", params=params)
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(payload, list):
+        raise CliError("Unexpected credential response")
+    return [CredentialRecord.from_mapping(item) for item in payload]
+
+
+def fetch_credential_templates(runtime: CliRuntime) -> list[CredentialTemplateRecord]:
+    """Return credential templates available to the caller."""
+    api = runtime.require_api()
+    try:
+        payload = api.get_json("/api/credentials/templates")
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(payload, list):
+        raise CliError("Unexpected credential template response")
+    return [CredentialTemplateRecord.from_mapping(item) for item in payload]
+
+
+def issue_credential(
+    runtime: CliRuntime,
+    *,
+    template_id: str,
+    secret: str,
+    actor: str,
+    name: str | None = None,
+    scopes: list[str] | None = None,
+    workflow_id: str | None = None,
+) -> Mapping[str, Any]:
+    """Issue a credential from a stored template."""
+    api = runtime.require_api()
+    payload: dict[str, Any] = {
+        "template_id": template_id,
+        "secret": secret,
+        "actor": actor,
+    }
+    if name:
+        payload["name"] = name
+    if scopes is not None:
+        payload["scopes"] = scopes
+    if workflow_id:
+        payload["workflow_id"] = workflow_id
+    try:
+        response = api.post_json(
+            f"/api/credentials/templates/{template_id}/issue",
+            json_payload=payload,
+        )
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc
+    if not isinstance(response, Mapping):
+        raise CliError("Unexpected response while issuing credential")
+    return response
+
+
+def delete_credential(
+    runtime: CliRuntime,
+    credential_id: str,
+    *,
+    workflow_id: str | None = None,
+) -> None:
+    """Delete a credential from the vault."""
+    api = runtime.require_api()
+    path = f"/api/credentials/{credential_id}"
+    if workflow_id:
+        path = f"{path}?workflow_id={workflow_id}"
+    try:
+        api.delete(path)
+    except ApiError as exc:  # pragma: no cover - passthrough to CLI
+        raise CliError(str(exc)) from exc

--- a/src/orcheo/nodes/registry.py
+++ b/src/orcheo/nodes/registry.py
@@ -1,7 +1,8 @@
 """Registry implementation for Orcheo nodes."""
 
-from collections.abc import Callable
-from pydantic import BaseModel
+from __future__ import annotations
+from collections.abc import Callable, Iterable
+from pydantic import BaseModel, Field
 
 
 class NodeMetadata(BaseModel):
@@ -19,6 +20,8 @@ class NodeMetadata(BaseModel):
     """Human-readable description of the node's purpose."""
     category: str = "general"
     """Node category, defaults to "general"."""
+    tags: list[str] = Field(default_factory=list)
+    """Optional set of discoverability tags for the node."""
 
 
 class NodeRegistry:
@@ -47,15 +50,34 @@ class NodeRegistry:
         return decorator
 
     def get_node(self, name: str) -> Callable | None:
-        """Get a node implementation by name.
+        """Return a node implementation by name.
 
         Args:
             name: Name of the node to retrieve
 
         Returns:
-            Node implementation function or None if not found
+            Node implementation function or ``None`` if not found
         """
         return self._nodes.get(name)
+
+    def get_metadata(self, name: str) -> NodeMetadata | None:
+        """Return the metadata associated with a registered node.
+
+        Args:
+            name: Name of the node to retrieve metadata for
+
+        Returns:
+            Node metadata instance if the node is registered, otherwise ``None``
+        """
+        return self._metadata.get(name)
+
+    def list_metadata(self) -> list[NodeMetadata]:
+        """Return metadata for all registered nodes."""
+        return list(self._metadata.values())
+
+    def iter_metadata(self) -> Iterable[NodeMetadata]:
+        """Yield metadata objects for registered nodes."""
+        yield from self._metadata.values()
 
     def get_metadata_by_callable(self, obj: Callable) -> NodeMetadata | None:
         """Return metadata associated with a registered callable."""

--- a/tests/sdk/test_cli.py
+++ b/tests/sdk/test_cli.py
@@ -1,0 +1,211 @@
+"""Tests for the Orcheo CLI entry point."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from orcheo_sdk.cli import app as cli_app
+from orcheo_sdk.cli.runtime import CacheEntry
+from orcheo_sdk.cli.services import (
+    CredentialRecord,
+    NodeRecord,
+    WorkflowDetail,
+    WorkflowRunInfo,
+    WorkflowVersionInfo,
+)
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("ORCHEO_CACHE_DIR", str(tmp_path / "cache"))
+
+
+def _fresh_entry(data: object | None = None) -> CacheEntry:
+    return CacheEntry(data=data, cached_at=datetime.now(tz=UTC))
+
+
+def test_node_list_uses_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = NodeRecord(
+        name="Agent",
+        description="Execute AI agents",
+        category="ai",
+        tags=("ai", "llm"),
+    )
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.nodes.fetch_node_catalog",
+        lambda runtime: ([record], True, _fresh_entry([record.to_dict()])),
+    )
+
+    result = runner.invoke(cli_app, ["--offline", "node", "list"])
+    assert result.exit_code == 0
+    assert "Agent" in result.stdout
+    assert "ai" in result.stdout
+
+
+def test_workflow_show_renders_mermaid(monkeypatch: pytest.MonkeyPatch) -> None:
+    detail = WorkflowDetail(
+        id="wf-1",
+        name="Test Workflow",
+        slug="test-workflow",
+        tags=("demo",),
+        is_archived=False,
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+        description="Demo",
+    )
+    version = WorkflowVersionInfo(
+        id="ver-1",
+        version=1,
+        created_at=datetime.now(tz=UTC),
+        notes=None,
+        graph={
+            "nodes": [
+                {"name": "start", "type": "Trigger"},
+                {"name": "end", "type": "Action"},
+            ],
+            "edges": [("start", "end")],
+            "conditional_edges": [],
+        },
+    )
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.workflows.fetch_workflow_detail",
+        lambda runtime, workflow_id: (detail, [version], _fresh_entry()),
+    )
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.workflows.fetch_workflow_runs",
+        lambda runtime, workflow_id: [
+            WorkflowRunInfo(
+                id="run-1",
+                status="succeeded",
+                triggered_by="tester",
+                created_at=datetime.now(tz=UTC),
+                started_at=datetime.now(tz=UTC),
+                completed_at=datetime.now(tz=UTC),
+            )
+        ],
+    )
+
+    result = runner.invoke(cli_app, ["--offline", "workflow", "show", "wf-1"])
+    assert result.exit_code == 0
+    assert "Workflow: Test Workflow" in result.stdout
+    assert "Mermaid diagram" in result.stdout
+    assert "run-1" in result.stdout
+
+
+def test_workflow_run_triggers_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    detail = WorkflowDetail(
+        id="wf-2",
+        name="Another Workflow",
+        slug="another",
+        tags=(),
+        is_archived=False,
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+        description=None,
+    )
+    version = WorkflowVersionInfo(
+        id="ver-2",
+        version=2,
+        created_at=datetime.now(tz=UTC),
+        notes=None,
+        graph={"nodes": [], "edges": [], "conditional_edges": []},
+    )
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.workflows.fetch_workflow_detail",
+        lambda runtime, workflow_id: (detail, [version], None),
+    )
+
+    captured: dict[str, object] = {}
+
+    def _trigger(runtime, *, workflow_id, workflow_version_id, actor, inputs):
+        captured.update(
+            {
+                "workflow_id": workflow_id,
+                "workflow_version_id": workflow_version_id,
+                "actor": actor,
+                "inputs": inputs,
+            }
+        )
+        return WorkflowRunInfo(
+            id="run-42",
+            status="pending",
+            triggered_by=actor,
+            created_at=datetime.now(tz=UTC),
+            started_at=None,
+            completed_at=None,
+        )
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.workflows.trigger_workflow_run",
+        _trigger,
+    )
+
+    result = runner.invoke(
+        cli_app,
+        ["workflow", "run", "wf-2", "--version", "2", "--inputs", '{"key": "value"}'],
+    )
+    assert result.exit_code == 0
+    assert captured["workflow_id"] == "wf-2"
+    assert captured["workflow_version_id"] == "ver-2"
+    assert captured["inputs"] == {"key": "value"}
+    assert "run-42" in result.stdout
+
+
+def test_credential_reference_outputs_snippet(monkeypatch: pytest.MonkeyPatch) -> None:
+    credential = CredentialRecord(
+        id="cred-1",
+        name="Prod API",
+        provider="example",
+        access="private",
+        status="healthy",
+        kind="secret",
+    )
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.credentials.fetch_credentials",
+        lambda runtime, workflow_id=None: [credential],
+    )
+
+    result = runner.invoke(cli_app, ["credential", "reference", "Prod API"])
+    assert result.exit_code == 0
+    assert "[[Prod API]]" in result.stdout
+
+
+def test_code_scaffold_uses_cached_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    detail = WorkflowDetail(
+        id="wf-3",
+        name="Scaffold Workflow",
+        slug="scaffold",
+        tags=(),
+        is_archived=False,
+        created_at=datetime.now(tz=UTC),
+        updated_at=datetime.now(tz=UTC),
+        description=None,
+    )
+    version = WorkflowVersionInfo(
+        id="ver-3",
+        version=3,
+        created_at=datetime.now(tz=UTC),
+        notes=None,
+        graph={"nodes": [], "edges": [], "conditional_edges": []},
+    )
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.commands.code.fetch_workflow_detail",
+        lambda runtime, workflow_id: (detail, [version], _fresh_entry()),
+    )
+
+    result = runner.invoke(
+        cli_app, ["--offline", "code", "scaffold", "wf-3", "--version", "3"]
+    )
+    assert result.exit_code == 0
+    assert 'workflow_version_id="ver-3"' in result.stdout
+    assert "ORCHEO_SERVICE_TOKEN" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1950,6 +1950,8 @@ version = "0.4.0"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "httpx" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1966,7 +1968,9 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "rich", specifier = ">=13.7.1" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "typer", specifier = ">=0.12.3" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- add a Typer-based `orcheo` CLI with commands for nodes, workflows, credentials, and code scaffolds
- implement reusable runtime, rendering, and service helpers to support offline cache usage and API calls
- document CLI usage in the SDK README, wire the entry point in `pyproject.toml`, and expand tests for CLI behaviour

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6900a70e3ee483279c49634ad7597838