### PR TITLE
Persist token storage

### DIFF
--- a/apps/backend/src/orcheo_backend/app/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/__init__.py
@@ -142,6 +142,9 @@ from orcheo_backend.app.schemas import (
     WorkflowVersionDiffResponse,
     WorkflowVersionIngestRequest,
 )
+from orcheo_backend.app.service_token_endpoints import (
+    router as service_token_router,
+)
 
 
 # Configure logging for the backend module once on import.
@@ -332,6 +335,7 @@ load_dotenv()
 
 _ws_router = APIRouter()
 _http_router = APIRouter(prefix="/api", dependencies=[Depends(authenticate_request)])
+_http_router.include_router(service_token_router)
 _repository: WorkflowRepository
 _history_store_ref: dict[str, RunHistoryStore] = {"store": InMemoryRunHistoryStore()}
 _credential_service_ref: dict[str, OAuthCredentialService | None] = {"service": None}

--- a/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
@@ -100,8 +100,8 @@ def _record_to_response(
         workspace_ids=sorted(record.workspace_ids),
         issued_at=record.issued_at,
         expires_at=record.expires_at,
-        last_used_at=None,  # Will be populated from audit log if needed
-        use_count=None,
+        last_used_at=record.last_used_at,
+        use_count=record.use_count,
         revoked_at=record.revoked_at,
         revocation_reason=record.revocation_reason,
         rotated_to=record.rotated_to,

--- a/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_endpoints.py
@@ -1,0 +1,256 @@
+"""FastAPI endpoints for service token management."""
+
+from __future__ import annotations
+from datetime import datetime
+from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from orcheo_backend.app.authentication import (
+    AuthorizationPolicy,
+    ServiceTokenRecord,
+    get_authorization_policy,
+    get_service_token_manager,
+)
+
+
+class CreateServiceTokenRequest(BaseModel):
+    """Request to create a new service token."""
+
+    identifier: str | None = Field(
+        None,
+        description="Optional identifier for the token (auto-generated if omitted)",
+    )
+    scopes: list[str] = Field(
+        default_factory=list,
+        description="Scopes/permissions granted to the token",
+    )
+    workspace_ids: list[str] = Field(
+        default_factory=list,
+        description="Workspace IDs the token can access",
+    )
+    expires_in_seconds: int | None = Field(
+        None,
+        ge=60,
+        description="Optional expiration time in seconds (no expiration if omitted)",
+    )
+
+
+class ServiceTokenResponse(BaseModel):
+    """Response containing service token details."""
+
+    identifier: str = Field(description="Unique identifier for the token")
+    secret: str | None = Field(
+        None,
+        description="Raw token secret (only shown once on creation)",
+    )
+    scopes: list[str] = Field(description="Scopes granted to the token")
+    workspace_ids: list[str] = Field(description="Workspaces the token can access")
+    issued_at: datetime | None = Field(description="Token issuance timestamp")
+    expires_at: datetime | None = Field(description="Token expiration timestamp")
+    last_used_at: datetime | None = Field(None, description="Last usage timestamp")
+    use_count: int | None = Field(None, description="Number of times token was used")
+    revoked_at: datetime | None = Field(None, description="Revocation timestamp")
+    revocation_reason: str | None = Field(None, description="Reason for revocation")
+    rotated_to: str | None = Field(None, description="Identifier of replacement token")
+    message: str | None = Field(None, description="Additional information")
+
+
+class RotateServiceTokenRequest(BaseModel):
+    """Request to rotate a service token."""
+
+    overlap_seconds: int = Field(
+        default=300,
+        ge=0,
+        description="Grace period where both old and new tokens are valid",
+    )
+    expires_in_seconds: int | None = Field(
+        None,
+        ge=60,
+        description="Optional expiration time for new token in seconds",
+    )
+
+
+class RevokeServiceTokenRequest(BaseModel):
+    """Request to revoke a service token."""
+
+    reason: str = Field(description="Reason for revoking the token")
+
+
+class ServiceTokenListResponse(BaseModel):
+    """Response containing list of service tokens."""
+
+    tokens: list[ServiceTokenResponse] = Field(description="List of service tokens")
+    total: int = Field(description="Total number of tokens")
+
+
+router = APIRouter(prefix="/admin/service-tokens", tags=["admin", "tokens"])
+
+
+def _record_to_response(
+    record: ServiceTokenRecord,
+    *,
+    secret: str | None = None,
+    message: str | None = None,
+) -> ServiceTokenResponse:
+    """Convert ServiceTokenRecord to API response."""
+    return ServiceTokenResponse(
+        identifier=record.identifier,
+        secret=secret,
+        scopes=sorted(record.scopes),
+        workspace_ids=sorted(record.workspace_ids),
+        issued_at=record.issued_at,
+        expires_at=record.expires_at,
+        last_used_at=None,  # Will be populated from audit log if needed
+        use_count=None,
+        revoked_at=record.revoked_at,
+        revocation_reason=record.revocation_reason,
+        rotated_to=record.rotated_to,
+        message=message,
+    )
+
+
+@router.post(
+    "", response_model=ServiceTokenResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_service_token(
+    request: CreateServiceTokenRequest,
+    policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+) -> ServiceTokenResponse:
+    """Create a new service token.
+
+    Requires 'admin:tokens:write' scope.
+    The secret is only shown once in the response and cannot be retrieved later.
+    """
+    policy.require_authenticated()
+    policy.require_scopes("admin:tokens:write")
+
+    token_manager = get_service_token_manager()
+
+    secret, record = await token_manager.mint(
+        identifier=request.identifier,
+        scopes=request.scopes,
+        workspace_ids=request.workspace_ids,
+        expires_in=request.expires_in_seconds,
+    )
+
+    return _record_to_response(
+        record,
+        secret=secret,
+        message="Store this token securely. It will not be shown again.",
+    )
+
+
+@router.get("", response_model=ServiceTokenListResponse)
+async def list_service_tokens(
+    policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+) -> ServiceTokenListResponse:
+    """List all service tokens.
+
+    Requires 'admin:tokens:read' scope.
+    Secrets are never returned in the list.
+    """
+    policy.require_authenticated()
+    policy.require_scopes("admin:tokens:read")
+
+    token_manager = get_service_token_manager()
+    records = await token_manager.all()
+
+    tokens = [_record_to_response(record) for record in records]
+    return ServiceTokenListResponse(tokens=tokens, total=len(tokens))
+
+
+@router.get("/{token_id}", response_model=ServiceTokenResponse)
+async def get_service_token(
+    token_id: str,
+    policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+) -> ServiceTokenResponse:
+    """Get details for a specific service token.
+
+    Requires 'admin:tokens:read' scope.
+    """
+    policy.require_authenticated()
+    policy.require_scopes("admin:tokens:read")
+
+    token_manager = get_service_token_manager()
+    record = await token_manager._repository.find_by_id(token_id)
+
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "message": f"Service token '{token_id}' not found",
+                "code": "token.not_found",
+            },
+        )
+
+    return _record_to_response(record)
+
+
+@router.post("/{token_id}/rotate", response_model=ServiceTokenResponse)
+async def rotate_service_token(
+    token_id: str,
+    request: RotateServiceTokenRequest,
+    policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+) -> ServiceTokenResponse:
+    """Rotate a service token, generating a new secret.
+
+    Requires 'admin:tokens:write' scope.
+    The old token remains valid during the overlap period.
+    The new secret is only shown once.
+    """
+    policy.require_authenticated()
+    policy.require_scopes("admin:tokens:write")
+
+    token_manager = get_service_token_manager()
+
+    try:
+        secret, new_record = await token_manager.rotate(
+            token_id,
+            overlap_seconds=request.overlap_seconds,
+            expires_in=request.expires_in_seconds,
+        )
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "message": f"Service token '{token_id}' not found",
+                "code": "token.not_found",
+            },
+        ) from None
+
+    message = (
+        f"New token created. Old token '{token_id}' "
+        f"valid for {request.overlap_seconds}s."
+    )
+    return _record_to_response(new_record, secret=secret, message=message)
+
+
+@router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_service_token(
+    token_id: str,
+    request: RevokeServiceTokenRequest,
+    policy: Annotated[AuthorizationPolicy, Depends(get_authorization_policy)],
+) -> None:
+    """Revoke a service token immediately.
+
+    Requires 'admin:tokens:write' scope.
+    The token will no longer be usable for authentication.
+    """
+    policy.require_authenticated()
+    policy.require_scopes("admin:tokens:write")
+
+    token_manager = get_service_token_manager()
+
+    try:
+        await token_manager.revoke(token_id, reason=request.reason)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "message": f"Service token '{token_id}' not found",
+                "code": "token.not_found",
+            },
+        ) from None
+
+
+__all__ = ["router"]

--- a/apps/backend/src/orcheo_backend/app/service_token_repository.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_repository.py
@@ -1,0 +1,469 @@
+"""Repository for managing service tokens in persistent storage."""
+
+from __future__ import annotations
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+from orcheo_backend.app.authentication import ServiceTokenRecord
+
+
+class ServiceTokenRepository(Protocol):
+    """Abstract interface for service token persistence."""
+
+    async def list_all(self) -> list[ServiceTokenRecord]:
+        """Return all service token records (including revoked/expired)."""
+        ...
+
+    async def list_active(
+        self, *, now: datetime | None = None
+    ) -> list[ServiceTokenRecord]:
+        """Return all active (non-revoked, non-expired) service token records."""
+        ...
+
+    async def find_by_id(self, identifier: str) -> ServiceTokenRecord | None:
+        """Look up a service token by its identifier."""
+        ...
+
+    async def find_by_hash(self, secret_hash: str) -> ServiceTokenRecord | None:
+        """Look up a service token by its SHA256 hash."""
+        ...
+
+    async def create(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Store a new service token record."""
+        ...
+
+    async def update(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Update an existing service token record."""
+        ...
+
+    async def delete(self, identifier: str) -> None:
+        """Remove a service token record from storage."""
+        ...
+
+    async def record_usage(
+        self,
+        token_id: str,
+        *,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        """Track token usage for analytics and audit."""
+        ...
+
+    async def get_audit_log(
+        self, token_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Retrieve audit log entries for a token."""
+        ...
+
+
+class SqliteServiceTokenRepository:
+    """SQLite-backed implementation of ServiceTokenRepository."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        """Initialize the repository with the database path."""
+        self._db_path = Path(db_path).expanduser()
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        """Create tables if they don't exist."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS service_tokens (
+                    identifier TEXT PRIMARY KEY,
+                    secret_hash TEXT NOT NULL,
+                    scopes TEXT,
+                    workspace_ids TEXT,
+                    created_at TEXT NOT NULL,
+                    created_by TEXT,
+                    issued_at TEXT,
+                    expires_at TEXT,
+                    last_used_at TEXT,
+                    use_count INTEGER DEFAULT 0,
+                    rotation_expires_at TEXT,
+                    rotated_to TEXT,
+                    rotated_from TEXT,
+                    revoked_at TEXT,
+                    revoked_by TEXT,
+                    revocation_reason TEXT,
+                    allowed_ip_ranges TEXT,
+                    rate_limit_override INTEGER,
+                    FOREIGN KEY (rotated_to) REFERENCES service_tokens(identifier)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_service_tokens_hash
+                    ON service_tokens(secret_hash);
+                CREATE INDEX IF NOT EXISTS idx_service_tokens_expires
+                    ON service_tokens(expires_at);
+                CREATE INDEX IF NOT EXISTS idx_service_tokens_active
+                    ON service_tokens(revoked_at) WHERE revoked_at IS NULL;
+
+                CREATE TABLE IF NOT EXISTS service_token_audit_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    token_id TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    actor TEXT,
+                    ip_address TEXT,
+                    user_agent TEXT,
+                    timestamp TEXT NOT NULL,
+                    details TEXT,
+                    FOREIGN KEY (token_id) REFERENCES service_tokens(identifier)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_audit_log_token
+                    ON service_token_audit_log(token_id);
+                CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp
+                    ON service_token_audit_log(timestamp);
+                """
+            )
+
+    async def list_all(self) -> list[ServiceTokenRecord]:
+        """Return all service token records."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT * FROM service_tokens ORDER BY created_at DESC"
+            )
+            rows = cursor.fetchall()
+            return [self._row_to_record(row) for row in rows]
+
+    async def list_active(
+        self, *, now: datetime | None = None
+    ) -> list[ServiceTokenRecord]:
+        """Return all active service token records."""
+        reference = (now or datetime.now(tz=UTC)).isoformat()
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT * FROM service_tokens
+                WHERE revoked_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > ?)
+                ORDER BY created_at DESC
+                """,
+                (reference,),
+            )
+            rows = cursor.fetchall()
+            return [self._row_to_record(row) for row in rows]
+
+    async def find_by_id(self, identifier: str) -> ServiceTokenRecord | None:
+        """Look up a service token by identifier."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT * FROM service_tokens WHERE identifier = ?", (identifier,)
+            )
+            row = cursor.fetchone()
+            return self._row_to_record(row) if row else None
+
+    async def find_by_hash(self, secret_hash: str) -> ServiceTokenRecord | None:
+        """Look up a service token by its SHA256 hash."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT * FROM service_tokens WHERE secret_hash = ?", (secret_hash,)
+            )
+            row = cursor.fetchone()
+            return self._row_to_record(row) if row else None
+
+    async def create(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Store a new service token record."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO service_tokens (
+                    identifier, secret_hash, scopes, workspace_ids,
+                    created_at, created_by, issued_at, expires_at,
+                    rotation_expires_at, rotated_to, revoked_at,
+                    revoked_by, revocation_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.identifier,
+                    record.secret_hash,
+                    json.dumps(sorted(record.scopes)) if record.scopes else None,
+                    json.dumps(sorted(record.workspace_ids))
+                    if record.workspace_ids
+                    else None,
+                    datetime.now(tz=UTC).isoformat(),
+                    None,  # created_by will be set via audit context
+                    record.issued_at.isoformat() if record.issued_at else None,
+                    record.expires_at.isoformat() if record.expires_at else None,
+                    record.rotation_expires_at.isoformat()
+                    if record.rotation_expires_at
+                    else None,
+                    record.rotated_to,
+                    record.revoked_at.isoformat() if record.revoked_at else None,
+                    None,  # revoked_by will be set via audit context
+                    record.revocation_reason,
+                ),
+            )
+            conn.commit()
+        return record
+
+    async def update(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Update an existing service token record."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                UPDATE service_tokens
+                SET secret_hash = ?,
+                    scopes = ?,
+                    workspace_ids = ?,
+                    issued_at = ?,
+                    expires_at = ?,
+                    rotation_expires_at = ?,
+                    rotated_to = ?,
+                    revoked_at = ?,
+                    revocation_reason = ?
+                WHERE identifier = ?
+                """,
+                (
+                    record.secret_hash,
+                    json.dumps(sorted(record.scopes)) if record.scopes else None,
+                    json.dumps(sorted(record.workspace_ids))
+                    if record.workspace_ids
+                    else None,
+                    record.issued_at.isoformat() if record.issued_at else None,
+                    record.expires_at.isoformat() if record.expires_at else None,
+                    record.rotation_expires_at.isoformat()
+                    if record.rotation_expires_at
+                    else None,
+                    record.rotated_to,
+                    record.revoked_at.isoformat() if record.revoked_at else None,
+                    record.revocation_reason,
+                    record.identifier,
+                ),
+            )
+            conn.commit()
+        return record
+
+    async def delete(self, identifier: str) -> None:
+        """Remove a service token from storage."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                "DELETE FROM service_tokens WHERE identifier = ?", (identifier,)
+            )
+            conn.commit()
+
+    async def record_usage(
+        self,
+        token_id: str,
+        *,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        """Track token usage."""
+        now = datetime.now(tz=UTC).isoformat()
+        with sqlite3.connect(self._db_path) as conn:
+            # Update last_used_at and use_count
+            conn.execute(
+                """
+                UPDATE service_tokens
+                SET last_used_at = ?,
+                    use_count = use_count + 1
+                WHERE identifier = ?
+                """,
+                (now, token_id),
+            )
+            # Record audit log entry
+            details = {}
+            if ip:
+                details["ip"] = ip
+            if user_agent:
+                details["user_agent"] = user_agent
+            conn.execute(
+                """
+                INSERT INTO service_token_audit_log
+                    (token_id, action, ip_address, user_agent, timestamp, details)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    token_id,
+                    "used",
+                    ip,
+                    user_agent,
+                    now,
+                    json.dumps(details) if details else None,
+                ),
+            )
+            conn.commit()
+
+    async def get_audit_log(
+        self, token_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Retrieve audit log entries for a token."""
+        with sqlite3.connect(self._db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT * FROM service_token_audit_log
+                WHERE token_id = ?
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """,
+                (token_id, limit),
+            )
+            rows = cursor.fetchall()
+            return [dict(row) for row in rows]
+
+    async def record_audit_event(
+        self,
+        token_id: str,
+        action: str,
+        *,
+        actor: str | None = None,
+        ip: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Record an audit event for a token."""
+        now = datetime.now(tz=UTC).isoformat()
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO service_token_audit_log
+                    (token_id, action, actor, ip_address, timestamp, details)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    token_id,
+                    action,
+                    actor,
+                    ip,
+                    now,
+                    json.dumps(details) if details else None,
+                ),
+            )
+            conn.commit()
+
+    def _row_to_record(self, row: sqlite3.Row) -> ServiceTokenRecord:
+        """Convert a database row to a ServiceTokenRecord."""
+        scopes_json = row["scopes"]
+        workspace_ids_json = row["workspace_ids"]
+        return ServiceTokenRecord(
+            identifier=row["identifier"],
+            secret_hash=row["secret_hash"],
+            scopes=frozenset(json.loads(scopes_json)) if scopes_json else frozenset(),
+            workspace_ids=frozenset(json.loads(workspace_ids_json))
+            if workspace_ids_json
+            else frozenset(),
+            issued_at=self._parse_timestamp(row["issued_at"]),
+            expires_at=self._parse_timestamp(row["expires_at"]),
+            rotation_expires_at=self._parse_timestamp(row["rotation_expires_at"]),
+            revoked_at=self._parse_timestamp(row["revoked_at"]),
+            revocation_reason=row["revocation_reason"],
+            rotated_to=row["rotated_to"],
+        )
+
+    @staticmethod
+    def _parse_timestamp(value: str | None) -> datetime | None:
+        """Parse ISO timestamp string to datetime."""
+        if not value:
+            return None
+        return datetime.fromisoformat(value)
+
+
+class InMemoryServiceTokenRepository:
+    """In-memory implementation for testing."""
+
+    def __init__(self) -> None:
+        """Initialize empty in-memory storage."""
+        self._tokens: dict[str, ServiceTokenRecord] = {}
+        self._audit_log: list[dict[str, Any]] = []
+
+    async def list_all(self) -> list[ServiceTokenRecord]:
+        """Return all service token records."""
+        return list(self._tokens.values())
+
+    async def list_active(
+        self, *, now: datetime | None = None
+    ) -> list[ServiceTokenRecord]:
+        """Return all active service token records."""
+        reference = now or datetime.now(tz=UTC)
+        return [
+            record
+            for record in self._tokens.values()
+            if not record.is_revoked() and not record.is_expired(now=reference)
+        ]
+
+    async def find_by_id(self, identifier: str) -> ServiceTokenRecord | None:
+        """Look up a service token by identifier."""
+        return self._tokens.get(identifier)
+
+    async def find_by_hash(self, secret_hash: str) -> ServiceTokenRecord | None:
+        """Look up a service token by its SHA256 hash."""
+        for record in self._tokens.values():
+            if record.secret_hash == secret_hash:
+                return record
+        return None
+
+    async def create(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Store a new service token record."""
+        self._tokens[record.identifier] = record
+        return record
+
+    async def update(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
+        """Update an existing service token record."""
+        self._tokens[record.identifier] = record
+        return record
+
+    async def delete(self, identifier: str) -> None:
+        """Remove a service token from storage."""
+        self._tokens.pop(identifier, None)
+
+    async def record_usage(
+        self,
+        token_id: str,
+        *,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        """Track token usage."""
+        self._audit_log.append(
+            {
+                "token_id": token_id,
+                "action": "used",
+                "ip_address": ip,
+                "user_agent": user_agent,
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+            }
+        )
+
+    async def get_audit_log(
+        self, token_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Retrieve audit log entries for a token."""
+        entries = [e for e in self._audit_log if e["token_id"] == token_id]
+        return entries[-limit:]
+
+    async def record_audit_event(
+        self,
+        token_id: str,
+        action: str,
+        *,
+        actor: str | None = None,
+        ip: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Record an audit event for a token."""
+        self._audit_log.append(
+            {
+                "token_id": token_id,
+                "action": action,
+                "actor": actor,
+                "ip_address": ip,
+                "timestamp": datetime.now(tz=UTC).isoformat(),
+                "details": details,
+            }
+        )
+
+
+__all__ = [
+    "ServiceTokenRepository",
+    "SqliteServiceTokenRepository",
+    "InMemoryServiceTokenRepository",
+]

--- a/apps/backend/src/orcheo_backend/app/service_token_repository.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_repository.py
@@ -15,33 +15,33 @@ class ServiceTokenRepository(Protocol):
 
     async def list_all(self) -> list[ServiceTokenRecord]:
         """Return all service token records (including revoked/expired)."""
-        ...
+        ...  # pragma: no cover
 
     async def list_active(
         self, *, now: datetime | None = None
     ) -> list[ServiceTokenRecord]:
         """Return all active (non-revoked, non-expired) service token records."""
-        ...
+        ...  # pragma: no cover
 
     async def find_by_id(self, identifier: str) -> ServiceTokenRecord | None:
         """Look up a service token by its identifier."""
-        ...
+        ...  # pragma: no cover
 
     async def find_by_hash(self, secret_hash: str) -> ServiceTokenRecord | None:
         """Look up a service token by its SHA256 hash."""
-        ...
+        ...  # pragma: no cover
 
     async def create(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
         """Store a new service token record."""
-        ...
+        ...  # pragma: no cover
 
     async def update(self, record: ServiceTokenRecord) -> ServiceTokenRecord:
         """Update an existing service token record."""
-        ...
+        ...  # pragma: no cover
 
     async def delete(self, identifier: str) -> None:
         """Remove a service token record from storage."""
-        ...
+        ...  # pragma: no cover
 
     async def record_usage(
         self,
@@ -51,13 +51,13 @@ class ServiceTokenRepository(Protocol):
         user_agent: str | None = None,
     ) -> None:
         """Track token usage for analytics and audit."""
-        ...
+        ...  # pragma: no cover
 
     async def get_audit_log(
         self, token_id: str, *, limit: int = 100
     ) -> list[dict[str, Any]]:
         """Retrieve audit log entries for a token."""
-        ...
+        ...  # pragma: no cover
 
 
 class SqliteServiceTokenRepository:

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -43,10 +43,19 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_AUTH_ALLOWED_ALGORITHMS` | `RS256, HS256` | Restricts acceptable JWT algorithms; defaults to both RS256 and HS256. See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
 | `ORCHEO_AUTH_AUDIENCE` | _none_ | Expected JWT audience values (comma or JSON-delimited). See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
 | `ORCHEO_AUTH_ISSUER` | _none_ | Expected JWT issuer claim used during validation. See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
-| `ORCHEO_AUTH_SERVICE_TOKENS` | _none_ | JSON, comma-delimited, or plaintext list of service token secrets/hashes for machine access. See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
+| `ORCHEO_AUTH_SERVICE_TOKEN_DB_PATH` | `~/.orcheo/service_tokens.sqlite` | Path to the SQLite database storing service tokens. Defaults to the same directory as `ORCHEO_REPOSITORY_SQLITE_PATH`. Service tokens are now managed via the CLI (`orcheo token`) or API endpoints (`/api/admin/service-tokens`) and stored in the database with full audit logging. See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py) and [service_token_repository.py](../apps/backend/src/orcheo_backend/app/service_token_repository.py). |
 | `ORCHEO_AUTH_RATE_LIMIT_IP` | `0` | Maximum authentication failures per IP before temporary blocking (0 disables the limit). See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
 | `ORCHEO_AUTH_RATE_LIMIT_IDENTITY` | `0` | Maximum failures per identity before rate limiting (0 disables the limit). See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
 | `ORCHEO_AUTH_RATE_LIMIT_INTERVAL` | `60` | Sliding-window interval (seconds) for rate-limit counters. See [authentication.py](../apps/backend/src/orcheo_backend/app/authentication.py). |
+
+### Service token management
+
+Service tokens are no longer configured via environment variables. Instead, they are managed dynamically through:
+
+- **CLI commands**: `orcheo token create`, `orcheo token list`, `orcheo token rotate`, `orcheo token revoke`
+- **API endpoints**: `/api/admin/service-tokens` (requires `admin:tokens:read` or `admin:tokens:write` scopes)
+
+All service tokens are stored in a SQLite database with SHA256-hashed secrets, never plaintext. The database includes full audit logging of token creation, usage, rotation, and revocation events. See [service_token_endpoints.py](../apps/backend/src/orcheo_backend/app/service_token_endpoints.py) for API details and [cli/service_token.py](../packages/sdk/src/orcheo_sdk/cli/service_token.py) for CLI usage.
 
 ## ChatKit session tokens
 
@@ -83,4 +92,3 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `LOG_LEVEL` | `INFO` | Controls the log level applied to FastAPI, Uvicorn, and Orcheo loggers. See [apps/backend/app/__init__.py](../apps/backend/src/orcheo_backend/app/__init__.py). |
 | `ORCHEO_ENV` / `ENVIRONMENT` / `NODE_ENV` | `production` | Determine whether the backend treats the environment as development for sensitive debugging output. See [apps/backend/app/__init__.py](../apps/backend/src/orcheo_backend/app/__init__.py). |
 | `LOG_SENSITIVE_DEBUG` | `0` | When set to `1`, enables detailed debug logging even outside development environments. See [apps/backend/app/__init__.py](../apps/backend/src/orcheo_backend/app/__init__.py). |
-

--- a/packages/sdk/src/orcheo_sdk/cli/http.py
+++ b/packages/sdk/src/orcheo_sdk/cli/http.py
@@ -78,17 +78,33 @@ class ApiClient:
         return response.json()
 
     def delete(
-        self, path: str, *, params: Mapping[str, Any] | None = None
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json_body: Mapping[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Issue a DELETE request."""
         url = f"{self._base_url}{path}"
         try:
-            response = httpx.delete(
-                url,
-                params=params,
-                headers=self._headers(),
-                timeout=self._timeout,
-            )
+            # Use httpx.request for DELETE with JSON body
+            # (httpx.delete doesn't support JSON bodies)
+            if json_body is not None:
+                response = httpx.request(
+                    "DELETE",
+                    url,
+                    params=params,
+                    json=json_body,
+                    headers=self._headers(),
+                    timeout=self._timeout,
+                )
+            else:
+                response = httpx.delete(
+                    url,
+                    params=params,
+                    headers=self._headers(),
+                    timeout=self._timeout,
+                )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             message = self._format_error(exc.response)

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -16,6 +16,7 @@ from orcheo_sdk.cli.credential import credential_app
 from orcheo_sdk.cli.errors import CLIConfigurationError, CLIError
 from orcheo_sdk.cli.http import ApiClient
 from orcheo_sdk.cli.node import node_app
+from orcheo_sdk.cli.service_token import app as service_token_app
 from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.cli.workflow import workflow_app
 
@@ -34,6 +35,7 @@ app.add_typer(workflow_app, name="workflow")
 app.add_typer(credential_app, name="credential")
 app.add_typer(code_app, name="code")
 app.add_typer(agent_tool_app, name="agent-tool")
+app.add_typer(service_token_app, name="token")
 
 
 @app.callback()

--- a/packages/sdk/src/orcheo_sdk/cli/output.py
+++ b/packages/sdk/src/orcheo_sdk/cli/output.py
@@ -1,6 +1,7 @@
 """Output helpers for rendering data in the CLI."""
 
 from __future__ import annotations
+from datetime import datetime
 from typing import Any
 from rich.console import Console
 from rich.pretty import Pretty
@@ -29,3 +30,24 @@ def render_json(console: Console, payload: Any, *, title: str | None = None) -> 
     if title:
         console.print(Text(title, style="bold"))
     console.print(Pretty(payload, indent_guides=True))
+
+
+def format_datetime(iso_string: str) -> str:
+    """Format an ISO datetime string for display."""
+    try:
+        dt = datetime.fromisoformat(iso_string.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+    except (ValueError, AttributeError):
+        return iso_string
+
+
+def success(message: str) -> None:
+    """Print a success message."""
+    console = Console()
+    console.print(f"[green]✓ {message}[/green]")
+
+
+def warning(message: str) -> None:
+    """Print a warning message."""
+    console = Console()
+    console.print(f"[yellow]⚠ {message}[/yellow]")

--- a/packages/sdk/src/orcheo_sdk/cli/service_token.py
+++ b/packages/sdk/src/orcheo_sdk/cli/service_token.py
@@ -3,31 +3,32 @@
 from __future__ import annotations
 from typing import Annotated
 import typer
-from rich.console import Console
 from rich.table import Table
-from orcheo_sdk.cli.config import require_config
-from orcheo_sdk.cli.errors import handle_http_error
-from orcheo_sdk.cli.http import http_client
-from orcheo_sdk.cli.output import console_print, format_datetime, success, warning
+from orcheo_sdk.cli.output import format_datetime, success, warning
+from orcheo_sdk.cli.state import CLIState
 
 
 app = typer.Typer(name="token", help="Manage service tokens for authentication")
-console = Console()
+
+
+def _state(ctx: typer.Context) -> CLIState:
+    return ctx.ensure_object(CLIState)
 
 
 @app.command("create")
 def create_token(
+    ctx: typer.Context,
     identifier: Annotated[
-        str, typer.Option("--id", help="Optional identifier for the token")
+        str | None, typer.Option("--id", help="Optional identifier for the token")
     ] = None,
     scopes: Annotated[
-        list[str],
+        list[str] | None,
         typer.Option(
             "--scope", "-s", help="Scopes to grant (can be specified multiple times)"
         ),
     ] = None,
     workspaces: Annotated[
-        list[str],
+        list[str] | None,
         typer.Option(
             "--workspace",
             "-w",
@@ -35,7 +36,7 @@ def create_token(
         ),
     ] = None,
     expires_in: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--expires-in",
             help="Expiration time in seconds (no expiration if omitted)",
@@ -48,9 +49,9 @@ def create_token(
     The token secret is displayed once and cannot be retrieved later.
     Store it securely.
     """
-    config = require_config()
+    state = _state(ctx)
 
-    payload = {}
+    payload: dict[str, str | list[str] | int] = {}
     if identifier:
         payload["identifier"] = identifier
     if scopes:
@@ -60,166 +61,141 @@ def create_token(
     if expires_in:
         payload["expires_in_seconds"] = expires_in
 
-    with http_client(config) as client:
-        try:
-            response = client.post("/api/admin/service-tokens", json=payload)
-            response.raise_for_status()
-            data = response.json()
+    data = state.client.post("/api/admin/service-tokens", json_body=payload)
 
-            console.print()
-            console.print(
-                "[bold green]Service token created successfully![/]",
-                style="green",
-            )
-            console.print()
-            console.print(f"[bold]ID:[/] {data['identifier']}")
-            console.print(
-                f"[bold yellow]Secret:[/] [reverse]{data['secret']}[/]",
-                style="yellow",
-            )
-            console.print()
-            warning("Store this secret securely. It will not be shown again.")
-            console.print()
+    state.console.print()
+    state.console.print(
+        "[bold green]Service token created successfully![/]",
+        style="green",
+    )
+    state.console.print()
+    state.console.print(f"[bold]ID:[/] {data['identifier']}")
+    state.console.print(
+        f"[bold yellow]Secret:[/] [reverse]{data['secret']}[/]",
+        style="yellow",
+    )
+    state.console.print()
+    warning("Store this secret securely. It will not be shown again.")
+    state.console.print()
 
-            if data.get("scopes"):
-                console.print(f"[bold]Scopes:[/] {', '.join(data['scopes'])}")
-            if data.get("workspace_ids"):
-                console.print(
-                    f"[bold]Workspaces:[/] {', '.join(data['workspace_ids'])}"
-                )
-            if data.get("expires_at"):
-                console.print(
-                    f"[bold]Expires:[/] {format_datetime(data['expires_at'])}"
-                )
-
-        except Exception as exc:
-            handle_http_error(exc, "create service token")
+    if data.get("scopes"):
+        state.console.print(f"[bold]Scopes:[/] {', '.join(data['scopes'])}")
+    if data.get("workspace_ids"):
+        state.console.print(f"[bold]Workspaces:[/] {', '.join(data['workspace_ids'])}")
+    if data.get("expires_at"):
+        state.console.print(f"[bold]Expires:[/] {format_datetime(data['expires_at'])}")
 
 
 @app.command("list")
-def list_tokens() -> None:
+def list_tokens(ctx: typer.Context) -> None:
     """List all service tokens."""
-    config = require_config()
+    state = _state(ctx)
 
-    with http_client(config) as client:
-        try:
-            response = client.get("/api/admin/service-tokens")
-            response.raise_for_status()
-            data = response.json()
+    data = state.client.get("/api/admin/service-tokens")
 
-            tokens = data.get("tokens", [])
-            if not tokens:
-                console_print("No service tokens found.")
-                return
+    tokens = data.get("tokens", [])
+    if not tokens:
+        state.console.print("No service tokens found.")
+        return
 
-            table = Table(title=f"Service Tokens ({data['total']} total)")
-            table.add_column("ID", style="cyan")
-            table.add_column("Scopes", style="green")
-            table.add_column("Workspaces", style="blue")
-            table.add_column("Issued", style="dim")
-            table.add_column("Expires", style="yellow")
-            table.add_column("Status", style="magenta")
+    table = Table(title=f"Service Tokens ({data['total']} total)")
+    table.add_column("ID", style="cyan")
+    table.add_column("Scopes", style="green")
+    table.add_column("Workspaces", style="blue")
+    table.add_column("Issued", style="dim")
+    table.add_column("Expires", style="yellow")
+    table.add_column("Status", style="magenta")
 
-            for token in tokens:
-                scopes_str = ", ".join(token.get("scopes", [])) or "-"
-                workspaces_str = ", ".join(token.get("workspace_ids", [])) or "-"
-                issued_str = (
-                    format_datetime(token["issued_at"])
-                    if token.get("issued_at")
-                    else "-"
-                )
-                expires_str = (
-                    format_datetime(token["expires_at"])
-                    if token.get("expires_at")
-                    else "Never"
-                )
+    for token in tokens:
+        scopes_str = ", ".join(token.get("scopes", [])) or "-"
+        workspaces_str = ", ".join(token.get("workspace_ids", [])) or "-"
+        issued_str = (
+            format_datetime(token["issued_at"]) if token.get("issued_at") else "-"
+        )
+        expires_str = (
+            format_datetime(token["expires_at"]) if token.get("expires_at") else "Never"
+        )
 
-                if token.get("revoked_at"):
-                    status = "[red]Revoked[/]"
-                elif token.get("rotated_to"):
-                    status = "[yellow]Rotated[/]"
-                else:
-                    status = "[green]Active[/]"
+        if token.get("revoked_at"):
+            status = "[red]Revoked[/]"
+        elif token.get("rotated_to"):
+            status = "[yellow]Rotated[/]"
+        else:
+            status = "[green]Active[/]"
 
-                table.add_row(
-                    token["identifier"],
-                    scopes_str,
-                    workspaces_str,
-                    issued_str,
-                    expires_str,
-                    status,
-                )
+        table.add_row(
+            token["identifier"],
+            scopes_str,
+            workspaces_str,
+            issued_str,
+            expires_str,
+            status,
+        )
 
-            console.print(table)
-
-        except Exception as exc:
-            handle_http_error(exc, "list service tokens")
+    state.console.print(table)
 
 
 @app.command("show")
-def show_token(token_id: str = typer.Argument(..., help="Token identifier")) -> None:
+def show_token(
+    ctx: typer.Context,
+    token_id: str = typer.Argument(..., help="Token identifier"),
+) -> None:
     """Show details for a specific service token."""
-    config = require_config()
+    state = _state(ctx)
 
-    with http_client(config) as client:
-        try:
-            response = client.get(f"/api/admin/service-tokens/{token_id}")
-            response.raise_for_status()
-            data = response.json()
+    data = state.client.get(f"/api/admin/service-tokens/{token_id}")
 
-            console.print()
-            console.print(f"[bold]Service Token: {data['identifier']}[/]")
-            console.print()
+    state.console.print()
+    state.console.print(f"[bold]Service Token: {data['identifier']}[/]")
+    state.console.print()
 
-            table = Table(show_header=False, box=None)
-            table.add_column("Field", style="bold")
-            table.add_column("Value")
+    table = Table(show_header=False, box=None)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
 
-            table.add_row("ID", data["identifier"])
+    table.add_row("ID", data["identifier"])
 
-            if data.get("scopes"):
-                table.add_row("Scopes", ", ".join(data["scopes"]))
-            else:
-                table.add_row("Scopes", "[dim]-[/]")
+    if data.get("scopes"):
+        table.add_row("Scopes", ", ".join(data["scopes"]))
+    else:
+        table.add_row("Scopes", "[dim]-[/]")
 
-            if data.get("workspace_ids"):
-                table.add_row("Workspaces", ", ".join(data["workspace_ids"]))
-            else:
-                table.add_row("Workspaces", "[dim]-[/]")
+    if data.get("workspace_ids"):
+        table.add_row("Workspaces", ", ".join(data["workspace_ids"]))
+    else:
+        table.add_row("Workspaces", "[dim]-[/]")
 
-            if data.get("issued_at"):
-                table.add_row("Issued", format_datetime(data["issued_at"]))
+    if data.get("issued_at"):
+        table.add_row("Issued", format_datetime(data["issued_at"]))
 
-            if data.get("expires_at"):
-                table.add_row("Expires", format_datetime(data["expires_at"]))
-            else:
-                table.add_row("Expires", "[dim]Never[/]")
+    if data.get("expires_at"):
+        table.add_row("Expires", format_datetime(data["expires_at"]))
+    else:
+        table.add_row("Expires", "[dim]Never[/]")
 
-            if data.get("revoked_at"):
-                table.add_row(
-                    "Revoked",
-                    f"[red]{format_datetime(data['revoked_at'])}[/]",
-                )
-                if data.get("revocation_reason"):
-                    table.add_row("Reason", data["revocation_reason"])
+    if data.get("revoked_at"):
+        table.add_row(
+            "Revoked",
+            f"[red]{format_datetime(data['revoked_at'])}[/]",
+        )
+        if data.get("revocation_reason"):
+            table.add_row("Reason", data["revocation_reason"])
 
-            if data.get("rotated_to"):
-                table.add_row("Rotated To", data["rotated_to"])
+    if data.get("rotated_to"):
+        table.add_row("Rotated To", data["rotated_to"])
 
-            console.print(table)
-            console.print()
-
-        except Exception as exc:
-            handle_http_error(exc, "show service token")
+    state.console.print(table)
+    state.console.print()
 
 
 @app.command("rotate")
 def rotate_token(
+    ctx: typer.Context,
     token_id: str = typer.Argument(..., help="Token identifier to rotate"),
     overlap: int = typer.Option(
         300, "--overlap", help="Grace period in seconds where both tokens are valid"
     ),
-    expires_in: int = typer.Option(
+    expires_in: int | None = typer.Option(
         None,
         "--expires-in",
         help="Expiration time for new token in seconds",
@@ -230,59 +206,47 @@ def rotate_token(
 
     The old token remains valid during the overlap period.
     """
-    config = require_config()
+    state = _state(ctx)
 
-    payload = {"overlap_seconds": overlap}
+    payload: dict[str, int] = {"overlap_seconds": overlap}
     if expires_in:
         payload["expires_in_seconds"] = expires_in
 
-    with http_client(config) as client:
-        try:
-            response = client.post(
-                f"/api/admin/service-tokens/{token_id}/rotate", json=payload
-            )
-            response.raise_for_status()
-            data = response.json()
+    data = state.client.post(
+        f"/api/admin/service-tokens/{token_id}/rotate", json_body=payload
+    )
 
-            console.print()
-            console.print("[bold green]Token rotated successfully![/]", style="green")
-            console.print()
-            console.print(f"[bold]New Token ID:[/] {data['identifier']}")
-            console.print(
-                f"[bold yellow]New Secret:[/] [reverse]{data['secret']}[/]",
-                style="yellow",
-            )
-            console.print()
-            warning("Store this secret securely. It will not be shown again.")
-            console.print()
+    state.console.print()
+    state.console.print("[bold green]Token rotated successfully![/]", style="green")
+    state.console.print()
+    state.console.print(f"[bold]New Token ID:[/] {data['identifier']}")
+    state.console.print(
+        f"[bold yellow]New Secret:[/] [reverse]{data['secret']}[/]",
+        style="yellow",
+    )
+    state.console.print()
+    warning("Store this secret securely. It will not be shown again.")
+    state.console.print()
 
-            if data.get("message"):
-                console.print(f"[dim]{data['message']}[/]")
-
-        except Exception as exc:
-            handle_http_error(exc, "rotate service token")
+    if data.get("message"):
+        state.console.print(f"[dim]{data['message']}[/]")
 
 
 @app.command("revoke")
 def revoke_token(
+    ctx: typer.Context,
     token_id: str = typer.Argument(..., help="Token identifier to revoke"),
     reason: str = typer.Option(..., "--reason", "-r", help="Reason for revocation"),
 ) -> None:
     """Revoke a service token immediately."""
-    config = require_config()
+    state = _state(ctx)
 
-    with http_client(config) as client:
-        try:
-            response = client.delete(
-                f"/api/admin/service-tokens/{token_id}", json={"reason": reason}
-            )
-            response.raise_for_status()
+    state.client.delete(
+        f"/api/admin/service-tokens/{token_id}", json_body={"reason": reason}
+    )
 
-            success(f"Service token '{token_id}' revoked successfully")
-            console.print(f"[dim]Reason: {reason}[/]")
-
-        except Exception as exc:
-            handle_http_error(exc, "revoke service token")
+    success(f"Service token '{token_id}' revoked successfully")
+    state.console.print(f"[dim]Reason: {reason}[/]")
 
 
 __all__ = ["app"]

--- a/packages/sdk/src/orcheo_sdk/cli/service_token.py
+++ b/packages/sdk/src/orcheo_sdk/cli/service_token.py
@@ -1,0 +1,288 @@
+"""CLI commands for managing service tokens."""
+
+from __future__ import annotations
+from typing import Annotated
+import typer
+from rich.console import Console
+from rich.table import Table
+from orcheo_sdk.cli.config import require_config
+from orcheo_sdk.cli.errors import handle_http_error
+from orcheo_sdk.cli.http import http_client
+from orcheo_sdk.cli.output import console_print, format_datetime, success, warning
+
+
+app = typer.Typer(name="token", help="Manage service tokens for authentication")
+console = Console()
+
+
+@app.command("create")
+def create_token(
+    identifier: Annotated[
+        str, typer.Option("--id", help="Optional identifier for the token")
+    ] = None,
+    scopes: Annotated[
+        list[str],
+        typer.Option(
+            "--scope", "-s", help="Scopes to grant (can be specified multiple times)"
+        ),
+    ] = None,
+    workspaces: Annotated[
+        list[str],
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Workspace IDs the token can access (can be specified multiple times)",
+        ),
+    ] = None,
+    expires_in: Annotated[
+        int,
+        typer.Option(
+            "--expires-in",
+            help="Expiration time in seconds (no expiration if omitted)",
+            min=60,
+        ),
+    ] = None,
+) -> None:
+    """Create a new service token.
+
+    The token secret is displayed once and cannot be retrieved later.
+    Store it securely.
+    """
+    config = require_config()
+
+    payload = {}
+    if identifier:
+        payload["identifier"] = identifier
+    if scopes:
+        payload["scopes"] = scopes
+    if workspaces:
+        payload["workspace_ids"] = workspaces
+    if expires_in:
+        payload["expires_in_seconds"] = expires_in
+
+    with http_client(config) as client:
+        try:
+            response = client.post("/api/admin/service-tokens", json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+            console.print()
+            console.print(
+                "[bold green]Service token created successfully![/]",
+                style="green",
+            )
+            console.print()
+            console.print(f"[bold]ID:[/] {data['identifier']}")
+            console.print(
+                f"[bold yellow]Secret:[/] [reverse]{data['secret']}[/]",
+                style="yellow",
+            )
+            console.print()
+            warning("Store this secret securely. It will not be shown again.")
+            console.print()
+
+            if data.get("scopes"):
+                console.print(f"[bold]Scopes:[/] {', '.join(data['scopes'])}")
+            if data.get("workspace_ids"):
+                console.print(
+                    f"[bold]Workspaces:[/] {', '.join(data['workspace_ids'])}"
+                )
+            if data.get("expires_at"):
+                console.print(
+                    f"[bold]Expires:[/] {format_datetime(data['expires_at'])}"
+                )
+
+        except Exception as exc:
+            handle_http_error(exc, "create service token")
+
+
+@app.command("list")
+def list_tokens() -> None:
+    """List all service tokens."""
+    config = require_config()
+
+    with http_client(config) as client:
+        try:
+            response = client.get("/api/admin/service-tokens")
+            response.raise_for_status()
+            data = response.json()
+
+            tokens = data.get("tokens", [])
+            if not tokens:
+                console_print("No service tokens found.")
+                return
+
+            table = Table(title=f"Service Tokens ({data['total']} total)")
+            table.add_column("ID", style="cyan")
+            table.add_column("Scopes", style="green")
+            table.add_column("Workspaces", style="blue")
+            table.add_column("Issued", style="dim")
+            table.add_column("Expires", style="yellow")
+            table.add_column("Status", style="magenta")
+
+            for token in tokens:
+                scopes_str = ", ".join(token.get("scopes", [])) or "-"
+                workspaces_str = ", ".join(token.get("workspace_ids", [])) or "-"
+                issued_str = (
+                    format_datetime(token["issued_at"])
+                    if token.get("issued_at")
+                    else "-"
+                )
+                expires_str = (
+                    format_datetime(token["expires_at"])
+                    if token.get("expires_at")
+                    else "Never"
+                )
+
+                if token.get("revoked_at"):
+                    status = "[red]Revoked[/]"
+                elif token.get("rotated_to"):
+                    status = "[yellow]Rotated[/]"
+                else:
+                    status = "[green]Active[/]"
+
+                table.add_row(
+                    token["identifier"],
+                    scopes_str,
+                    workspaces_str,
+                    issued_str,
+                    expires_str,
+                    status,
+                )
+
+            console.print(table)
+
+        except Exception as exc:
+            handle_http_error(exc, "list service tokens")
+
+
+@app.command("show")
+def show_token(token_id: str = typer.Argument(..., help="Token identifier")) -> None:
+    """Show details for a specific service token."""
+    config = require_config()
+
+    with http_client(config) as client:
+        try:
+            response = client.get(f"/api/admin/service-tokens/{token_id}")
+            response.raise_for_status()
+            data = response.json()
+
+            console.print()
+            console.print(f"[bold]Service Token: {data['identifier']}[/]")
+            console.print()
+
+            table = Table(show_header=False, box=None)
+            table.add_column("Field", style="bold")
+            table.add_column("Value")
+
+            table.add_row("ID", data["identifier"])
+
+            if data.get("scopes"):
+                table.add_row("Scopes", ", ".join(data["scopes"]))
+            else:
+                table.add_row("Scopes", "[dim]-[/]")
+
+            if data.get("workspace_ids"):
+                table.add_row("Workspaces", ", ".join(data["workspace_ids"]))
+            else:
+                table.add_row("Workspaces", "[dim]-[/]")
+
+            if data.get("issued_at"):
+                table.add_row("Issued", format_datetime(data["issued_at"]))
+
+            if data.get("expires_at"):
+                table.add_row("Expires", format_datetime(data["expires_at"]))
+            else:
+                table.add_row("Expires", "[dim]Never[/]")
+
+            if data.get("revoked_at"):
+                table.add_row(
+                    "Revoked",
+                    f"[red]{format_datetime(data['revoked_at'])}[/]",
+                )
+                if data.get("revocation_reason"):
+                    table.add_row("Reason", data["revocation_reason"])
+
+            if data.get("rotated_to"):
+                table.add_row("Rotated To", data["rotated_to"])
+
+            console.print(table)
+            console.print()
+
+        except Exception as exc:
+            handle_http_error(exc, "show service token")
+
+
+@app.command("rotate")
+def rotate_token(
+    token_id: str = typer.Argument(..., help="Token identifier to rotate"),
+    overlap: int = typer.Option(
+        300, "--overlap", help="Grace period in seconds where both tokens are valid"
+    ),
+    expires_in: int = typer.Option(
+        None,
+        "--expires-in",
+        help="Expiration time for new token in seconds",
+        min=60,
+    ),
+) -> None:
+    """Rotate a service token, generating a new secret.
+
+    The old token remains valid during the overlap period.
+    """
+    config = require_config()
+
+    payload = {"overlap_seconds": overlap}
+    if expires_in:
+        payload["expires_in_seconds"] = expires_in
+
+    with http_client(config) as client:
+        try:
+            response = client.post(
+                f"/api/admin/service-tokens/{token_id}/rotate", json=payload
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            console.print()
+            console.print("[bold green]Token rotated successfully![/]", style="green")
+            console.print()
+            console.print(f"[bold]New Token ID:[/] {data['identifier']}")
+            console.print(
+                f"[bold yellow]New Secret:[/] [reverse]{data['secret']}[/]",
+                style="yellow",
+            )
+            console.print()
+            warning("Store this secret securely. It will not be shown again.")
+            console.print()
+
+            if data.get("message"):
+                console.print(f"[dim]{data['message']}[/]")
+
+        except Exception as exc:
+            handle_http_error(exc, "rotate service token")
+
+
+@app.command("revoke")
+def revoke_token(
+    token_id: str = typer.Argument(..., help="Token identifier to revoke"),
+    reason: str = typer.Option(..., "--reason", "-r", help="Reason for revocation"),
+) -> None:
+    """Revoke a service token immediately."""
+    config = require_config()
+
+    with http_client(config) as client:
+        try:
+            response = client.delete(
+                f"/api/admin/service-tokens/{token_id}", json={"reason": reason}
+            )
+            response.raise_for_status()
+
+            success(f"Service token '{token_id}' revoked successfully")
+            console.print(f"[dim]Reason: {reason}[/]")
+
+        except Exception as exc:
+            handle_http_error(exc, "revoke service token")
+
+
+__all__ = ["app"]

--- a/tests/backend/test_service_token_endpoints.py
+++ b/tests/backend/test_service_token_endpoints.py
@@ -1,0 +1,576 @@
+"""Tests for service token management endpoints."""
+
+from __future__ import annotations
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+import pytest
+from fastapi import HTTPException, status
+from orcheo_backend.app.authentication import (
+    AuthenticationError,
+    AuthorizationError,
+    AuthorizationPolicy,
+    RequestContext,
+    ServiceTokenManager,
+    ServiceTokenRecord,
+)
+from orcheo_backend.app.service_token_endpoints import (
+    CreateServiceTokenRequest,
+    RevokeServiceTokenRequest,
+    RotateServiceTokenRequest,
+    _record_to_response,
+    create_service_token,
+    get_service_token,
+    list_service_tokens,
+    revoke_service_token,
+    rotate_service_token,
+)
+from orcheo_backend.app.service_token_repository import (
+    InMemoryServiceTokenRepository,
+)
+
+
+@pytest.fixture
+def mock_repository():
+    """Create an in-memory repository for testing."""
+    return InMemoryServiceTokenRepository()
+
+
+@pytest.fixture
+async def mock_token_manager(mock_repository):
+    """Create a token manager with in-memory repository."""
+    return ServiceTokenManager(mock_repository)
+
+
+@pytest.fixture
+def authenticated_context():
+    """Create an authenticated context with required scopes."""
+    return RequestContext(
+        subject="admin-user",
+        identity_type="user",
+        scopes=frozenset(["admin:tokens:read", "admin:tokens:write"]),
+    )
+
+
+@pytest.fixture
+def admin_policy(authenticated_context):
+    """Create an authorization policy with admin scopes."""
+    return AuthorizationPolicy(authenticated_context)
+
+
+def test_record_to_response():
+    """Test _record_to_response converts ServiceTokenRecord to API response."""
+    record = ServiceTokenRecord(
+        identifier="test-token",
+        secret_hash="hash123",
+        scopes=frozenset(["read", "write"]),
+        workspace_ids=frozenset(["ws-1", "ws-2"]),
+        issued_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        expires_at=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
+        last_used_at=datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC),
+        use_count=42,
+        revoked_at=None,
+        revocation_reason=None,
+        rotated_to=None,
+    )
+
+    response = _record_to_response(
+        record,
+        secret="secret-value",
+        message="Test message",
+    )
+
+    assert response.identifier == "test-token"
+    assert response.secret == "secret-value"
+    assert response.scopes == ["read", "write"]
+    assert response.workspace_ids == ["ws-1", "ws-2"]
+    assert response.issued_at == datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    assert response.expires_at == datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC)
+    assert response.last_used_at == datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC)
+    assert response.use_count == 42
+    assert response.revoked_at is None
+    assert response.revocation_reason is None
+    assert response.rotated_to is None
+    assert response.message == "Test message"
+
+
+def test_record_to_response_with_revocation():
+    """Test _record_to_response includes revocation details."""
+    revoked_at = datetime(2025, 2, 1, 10, 0, 0, tzinfo=UTC)
+    record = ServiceTokenRecord(
+        identifier="revoked-token",
+        secret_hash="hash456",
+        scopes=frozenset(),
+        workspace_ids=frozenset(),
+        issued_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        revoked_at=revoked_at,
+        revocation_reason="Security breach",
+        rotated_to="new-token-id",
+    )
+
+    response = _record_to_response(record)
+
+    assert response.identifier == "revoked-token"
+    assert response.secret is None
+    assert response.revoked_at == revoked_at
+    assert response.revocation_reason == "Security breach"
+    assert response.rotated_to == "new-token-id"
+
+
+@pytest.mark.asyncio
+async def test_create_service_token_success(admin_policy):
+    """Test create_service_token endpoint creates a new token."""
+    request = CreateServiceTokenRequest(
+        identifier="my-token",
+        scopes=["read", "write"],
+        workspace_ids=["ws-1"],
+        expires_in_seconds=3600,
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_secret = "secret-token-value"
+        mock_record = ServiceTokenRecord(
+            identifier="my-token",
+            secret_hash="hash123",
+            scopes=frozenset(["read", "write"]),
+            workspace_ids=frozenset(["ws-1"]),
+            issued_at=datetime.now(tz=UTC),
+            expires_at=datetime.now(tz=UTC) + timedelta(hours=1),
+        )
+        mock_manager.mint.return_value = (mock_secret, mock_record)
+        mock_get_manager.return_value = mock_manager
+
+        response = await create_service_token(request, admin_policy)
+
+        assert response.identifier == "my-token"
+        assert response.secret == mock_secret
+        assert "Store this token securely" in response.message
+        mock_manager.mint.assert_called_once_with(
+            identifier="my-token",
+            scopes=["read", "write"],
+            workspace_ids=["ws-1"],
+            expires_in=3600,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_service_token_without_authentication():
+    """Test create_service_token requires authentication."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
+    request = CreateServiceTokenRequest()
+
+    with pytest.raises(AuthenticationError):
+        await create_service_token(request, policy)
+
+
+@pytest.mark.asyncio
+async def test_create_service_token_without_required_scope():
+    """Test create_service_token requires admin:tokens:write scope."""
+    context = RequestContext(
+        subject="user",
+        identity_type="user",
+        scopes=frozenset(["read"]),
+    )
+    policy = AuthorizationPolicy(context)
+    request = CreateServiceTokenRequest()
+
+    with pytest.raises(AuthorizationError):
+        await create_service_token(request, policy)
+
+
+@pytest.mark.asyncio
+async def test_list_service_tokens_success(admin_policy):
+    """Test list_service_tokens endpoint returns all tokens."""
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_records = [
+            ServiceTokenRecord(
+                identifier="token-1",
+                secret_hash="hash1",
+                scopes=frozenset(["read"]),
+                workspace_ids=frozenset(["ws-1"]),
+                issued_at=datetime.now(tz=UTC),
+            ),
+            ServiceTokenRecord(
+                identifier="token-2",
+                secret_hash="hash2",
+                scopes=frozenset(["write"]),
+                workspace_ids=frozenset(["ws-2"]),
+                issued_at=datetime.now(tz=UTC),
+            ),
+        ]
+        mock_manager.all.return_value = mock_records
+        mock_get_manager.return_value = mock_manager
+
+        response = await list_service_tokens(admin_policy)
+
+        assert response.total == 2
+        assert len(response.tokens) == 2
+        assert response.tokens[0].identifier == "token-1"
+        assert response.tokens[1].identifier == "token-2"
+        # Secrets should not be included
+        assert response.tokens[0].secret is None
+        assert response.tokens[1].secret is None
+        mock_manager.all.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_list_service_tokens_empty(admin_policy):
+    """Test list_service_tokens returns empty list when no tokens exist."""
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.all.return_value = []
+        mock_get_manager.return_value = mock_manager
+
+        response = await list_service_tokens(admin_policy)
+
+        assert response.total == 0
+        assert len(response.tokens) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_service_tokens_without_authentication():
+    """Test list_service_tokens requires authentication."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
+
+    with pytest.raises(AuthenticationError):
+        await list_service_tokens(policy)
+
+
+@pytest.mark.asyncio
+async def test_list_service_tokens_without_required_scope():
+    """Test list_service_tokens requires admin:tokens:read scope."""
+    context = RequestContext(
+        subject="user",
+        identity_type="user",
+        scopes=frozenset(["write"]),
+    )
+    policy = AuthorizationPolicy(context)
+
+    with pytest.raises(AuthorizationError):
+        await list_service_tokens(policy)
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_success(admin_policy):
+    """Test get_service_token endpoint retrieves a specific token."""
+    mock_record = ServiceTokenRecord(
+        identifier="token-123",
+        secret_hash="hash123",
+        scopes=frozenset(["read", "write"]),
+        workspace_ids=frozenset(["ws-1"]),
+        issued_at=datetime.now(tz=UTC),
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = mock_record
+        mock_get_manager.return_value = mock_manager
+
+        response = await get_service_token("token-123", admin_policy)
+
+        assert response.identifier == "token-123"
+        assert response.scopes == ["read", "write"]
+        assert response.workspace_ids == ["ws-1"]
+        # Secret should not be included
+        assert response.secret is None
+        mock_manager._repository.find_by_id.assert_called_once_with("token-123")
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_not_found(admin_policy):
+    """Test get_service_token raises 404 when token doesn't exist."""
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = None
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_service_token("nonexistent-token", admin_policy)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_without_authentication():
+    """Test get_service_token requires authentication."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
+
+    with pytest.raises(AuthenticationError):
+        await get_service_token("token-123", policy)
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_without_required_scope():
+    """Test get_service_token requires admin:tokens:read scope."""
+    context = RequestContext(
+        subject="user",
+        identity_type="user",
+        scopes=frozenset(["write"]),
+    )
+    policy = AuthorizationPolicy(context)
+
+    with pytest.raises(AuthorizationError):
+        await get_service_token("token-123", policy)
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_success(admin_policy):
+    """Test rotate_service_token endpoint rotates a token."""
+    request = RotateServiceTokenRequest(
+        overlap_seconds=300,
+        expires_in_seconds=7200,
+    )
+
+    mock_new_secret = "new-secret-value"
+    mock_new_record = ServiceTokenRecord(
+        identifier="new-token-id",
+        secret_hash="new-hash",
+        scopes=frozenset(["read"]),
+        workspace_ids=frozenset(["ws-1"]),
+        issued_at=datetime.now(tz=UTC),
+        expires_at=datetime.now(tz=UTC) + timedelta(hours=2),
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.rotate.return_value = (mock_new_secret, mock_new_record)
+        mock_get_manager.return_value = mock_manager
+
+        response = await rotate_service_token("old-token-id", request, admin_policy)
+
+        assert response.identifier == "new-token-id"
+        assert response.secret == mock_new_secret
+        assert "Old token 'old-token-id' valid for 300s" in response.message
+        mock_manager.rotate.assert_called_once_with(
+            "old-token-id",
+            overlap_seconds=300,
+            expires_in=7200,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_not_found(admin_policy):
+    """Test rotate_service_token raises 404 when token doesn't exist."""
+    request = RotateServiceTokenRequest(overlap_seconds=300)
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.rotate.side_effect = KeyError("Token not found")
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rotate_service_token("nonexistent-token", request, admin_policy)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_without_authentication():
+    """Test rotate_service_token requires authentication."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
+    request = RotateServiceTokenRequest()
+
+    with pytest.raises(AuthenticationError):
+        await rotate_service_token("token-123", request, policy)
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_without_required_scope():
+    """Test rotate_service_token requires admin:tokens:write scope."""
+    context = RequestContext(
+        subject="user",
+        identity_type="user",
+        scopes=frozenset(["read"]),
+    )
+    policy = AuthorizationPolicy(context)
+    request = RotateServiceTokenRequest()
+
+    with pytest.raises(AuthorizationError):
+        await rotate_service_token("token-123", request, policy)
+
+
+@pytest.mark.asyncio
+async def test_revoke_service_token_success(admin_policy):
+    """Test revoke_service_token endpoint revokes a token."""
+    request = RevokeServiceTokenRequest(reason="Security breach detected")
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.revoke.return_value = None
+        mock_get_manager.return_value = mock_manager
+
+        response = await revoke_service_token("token-to-revoke", request, admin_policy)
+
+        # Should return None (204 No Content)
+        assert response is None
+        mock_manager.revoke.assert_called_once_with(
+            "token-to-revoke",
+            reason="Security breach detected",
+        )
+
+
+@pytest.mark.asyncio
+async def test_revoke_service_token_not_found(admin_policy):
+    """Test revoke_service_token raises 404 when token doesn't exist."""
+    request = RevokeServiceTokenRequest(reason="Test")
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.revoke.side_effect = KeyError("Token not found")
+        mock_get_manager.return_value = mock_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await revoke_service_token("nonexistent-token", request, admin_policy)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_revoke_service_token_without_authentication():
+    """Test revoke_service_token requires authentication."""
+    anonymous_context = RequestContext.anonymous()
+    policy = AuthorizationPolicy(anonymous_context)
+    request = RevokeServiceTokenRequest(reason="Test")
+
+    with pytest.raises(AuthenticationError):
+        await revoke_service_token("token-123", request, policy)
+
+
+@pytest.mark.asyncio
+async def test_revoke_service_token_without_required_scope():
+    """Test revoke_service_token requires admin:tokens:write scope."""
+    context = RequestContext(
+        subject="user",
+        identity_type="user",
+        scopes=frozenset(["read"]),
+    )
+    policy = AuthorizationPolicy(context)
+    request = RevokeServiceTokenRequest(reason="Test")
+
+    with pytest.raises(AuthorizationError):
+        await revoke_service_token("token-123", request, policy)
+
+
+@pytest.mark.asyncio
+async def test_create_service_token_with_default_values(admin_policy):
+    """Test create_service_token with minimal request (default values)."""
+    request = CreateServiceTokenRequest()
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_secret = "generated-secret"
+        mock_record = ServiceTokenRecord(
+            identifier="auto-generated-id",
+            secret_hash="hash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime.now(tz=UTC),
+        )
+        mock_manager.mint.return_value = (mock_secret, mock_record)
+        mock_get_manager.return_value = mock_manager
+
+        response = await create_service_token(request, admin_policy)
+
+        assert response.identifier == "auto-generated-id"
+        assert response.secret == mock_secret
+        mock_manager.mint.assert_called_once_with(
+            identifier=None,
+            scopes=[],
+            workspace_ids=[],
+            expires_in=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rotate_service_token_with_default_overlap(admin_policy):
+    """Test rotate_service_token uses default overlap of 300 seconds."""
+    request = RotateServiceTokenRequest()  # Uses default overlap_seconds=300
+
+    mock_new_secret = "new-secret"
+    mock_new_record = ServiceTokenRecord(
+        identifier="new-token",
+        secret_hash="hash",
+        scopes=frozenset(),
+        workspace_ids=frozenset(),
+        issued_at=datetime.now(tz=UTC),
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager.rotate.return_value = (mock_new_secret, mock_new_record)
+        mock_get_manager.return_value = mock_manager
+
+        response = await rotate_service_token("old-token", request, admin_policy)
+
+        # Verify default overlap of 300 is used
+        mock_manager.rotate.assert_called_once_with(
+            "old-token",
+            overlap_seconds=300,
+            expires_in=None,
+        )
+        assert "300s" in response.message
+
+
+@pytest.mark.asyncio
+async def test_get_service_token_with_all_fields(admin_policy):
+    """Test get_service_token returns all fields from record."""
+    mock_record = ServiceTokenRecord(
+        identifier="complete-token",
+        secret_hash="hash",
+        scopes=frozenset(["admin", "read", "write"]),
+        workspace_ids=frozenset(["ws-1", "ws-2", "ws-3"]),
+        issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        expires_at=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
+        last_used_at=datetime(2025, 6, 15, 12, 30, 0, tzinfo=UTC),
+        use_count=999,
+        revoked_at=None,
+        revocation_reason=None,
+        rotated_to=None,
+    )
+
+    with patch(
+        "orcheo_backend.app.service_token_endpoints.get_service_token_manager"
+    ) as mock_get_manager:
+        mock_manager = AsyncMock()
+        mock_manager._repository.find_by_id.return_value = mock_record
+        mock_get_manager.return_value = mock_manager
+
+        response = await get_service_token("complete-token", admin_policy)
+
+        assert response.identifier == "complete-token"
+        # Scopes should be sorted
+        assert response.scopes == ["admin", "read", "write"]
+        # Workspace IDs should be sorted
+        assert response.workspace_ids == ["ws-1", "ws-2", "ws-3"]
+        assert response.use_count == 999
+        assert response.last_used_at == datetime(2025, 6, 15, 12, 30, 0, tzinfo=UTC)

--- a/tests/backend/test_service_token_repository.py
+++ b/tests/backend/test_service_token_repository.py
@@ -1,0 +1,785 @@
+"""Unit tests for service token repository implementations."""
+
+from __future__ import annotations
+from datetime import UTC, datetime
+from pathlib import Path
+import pytest
+from orcheo_backend.app.authentication import ServiceTokenRecord
+from orcheo_backend.app.service_token_repository import (
+    InMemoryServiceTokenRepository,
+    SqliteServiceTokenRepository,
+)
+
+
+@pytest.fixture
+def sample_token_record() -> ServiceTokenRecord:
+    """Create a sample service token record for testing."""
+    return ServiceTokenRecord(
+        identifier="test-token-123",
+        secret_hash="abc123hash",
+        scopes=frozenset(["read", "write"]),
+        workspace_ids=frozenset(["ws-1", "ws-2"]),
+        issued_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        expires_at=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def sample_token_with_rotation() -> ServiceTokenRecord:
+    """Create a token with rotation details."""
+    return ServiceTokenRecord(
+        identifier="rotated-token",
+        secret_hash="rotatedhash",
+        scopes=frozenset(["admin"]),
+        workspace_ids=frozenset(),
+        issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        rotation_expires_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC),
+        rotated_to="new-token-id",
+    )
+
+
+@pytest.fixture
+def sample_revoked_token() -> ServiceTokenRecord:
+    """Create a revoked token record."""
+    return ServiceTokenRecord(
+        identifier="revoked-token",
+        secret_hash="revokedhash",
+        scopes=frozenset(["read"]),
+        workspace_ids=frozenset(["ws-1"]),
+        issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        revoked_at=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+        revocation_reason="Security breach",
+    )
+
+
+class TestSqliteServiceTokenRepository:
+    """Test cases for SQLite-backed service token repository."""
+
+    @pytest.fixture
+    def db_path(self, tmp_path: Path) -> Path:
+        """Create a temporary database path."""
+        return tmp_path / "test_tokens.db"
+
+    @pytest.fixture
+    def repository(self, db_path: Path) -> SqliteServiceTokenRepository:
+        """Create a SQLite repository instance."""
+        return SqliteServiceTokenRepository(db_path)
+
+    @pytest.mark.asyncio
+    async def test_list_all_empty(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test list_all returns empty list when no tokens exist."""
+        tokens = await repository.list_all()
+        assert tokens == []
+
+    @pytest.mark.asyncio
+    async def test_list_all_returns_all_tokens(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+        sample_revoked_token: ServiceTokenRecord,
+    ) -> None:
+        """Test list_all returns all tokens including revoked ones."""
+        await repository.create(sample_token_record)
+        await repository.create(sample_revoked_token)
+
+        tokens = await repository.list_all()
+        assert len(tokens) == 2
+        identifiers = {token.identifier for token in tokens}
+        assert "test-token-123" in identifiers
+        assert "revoked-token" in identifiers
+
+    @pytest.mark.asyncio
+    async def test_list_active_excludes_revoked(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+        sample_revoked_token: ServiceTokenRecord,
+    ) -> None:
+        """Test list_active excludes revoked tokens."""
+        await repository.create(sample_token_record)
+        await repository.create(sample_revoked_token)
+
+        active_tokens = await repository.list_active()
+        assert len(active_tokens) == 1
+        assert active_tokens[0].identifier == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_list_active_excludes_expired(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test list_active excludes expired tokens."""
+        expired_token = ServiceTokenRecord(
+            identifier="expired-token",
+            secret_hash="expiredhash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC),
+            expires_at=datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
+        )
+        active_token = ServiceTokenRecord(
+            identifier="active-token",
+            secret_hash="activehash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            expires_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+
+        await repository.create(expired_token)
+        await repository.create(active_token)
+
+        now = datetime(2025, 6, 1, 0, 0, 0, tzinfo=UTC)
+        active_tokens = await repository.list_active(now=now)
+        assert len(active_tokens) == 1
+        assert active_tokens[0].identifier == "active-token"
+
+    @pytest.mark.asyncio
+    async def test_list_active_includes_never_expiring(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test list_active includes tokens with no expiration."""
+        never_expires = ServiceTokenRecord(
+            identifier="forever-token",
+            secret_hash="foreverhash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            expires_at=None,
+        )
+
+        await repository.create(never_expires)
+
+        active_tokens = await repository.list_active()
+        assert len(active_tokens) == 1
+        assert active_tokens[0].identifier == "forever-token"
+
+    @pytest.mark.asyncio
+    async def test_find_by_id_found(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test find_by_id returns the correct token."""
+        await repository.create(sample_token_record)
+
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.identifier == "test-token-123"
+        assert found.secret_hash == "abc123hash"
+        assert found.scopes == frozenset(["read", "write"])
+        assert found.workspace_ids == frozenset(["ws-1", "ws-2"])
+
+    @pytest.mark.asyncio
+    async def test_find_by_id_not_found(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test find_by_id returns None for non-existent token."""
+        found = await repository.find_by_id("nonexistent-id")
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_find_by_hash_found(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test find_by_hash returns the correct token."""
+        await repository.create(sample_token_record)
+
+        found = await repository.find_by_hash("abc123hash")
+        assert found is not None
+        assert found.identifier == "test-token-123"
+        assert found.secret_hash == "abc123hash"
+
+    @pytest.mark.asyncio
+    async def test_find_by_hash_not_found(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test find_by_hash returns None for non-existent hash."""
+        found = await repository.find_by_hash("nonexistent-hash")
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_create_token_with_all_fields(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_with_rotation: ServiceTokenRecord,
+    ) -> None:
+        """Test create stores all token fields correctly."""
+        created = await repository.create(sample_token_with_rotation)
+        assert created.identifier == "rotated-token"
+
+        found = await repository.find_by_id("rotated-token")
+        assert found is not None
+        assert found.secret_hash == "rotatedhash"
+        assert found.scopes == frozenset(["admin"])
+        assert found.rotation_expires_at == datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC)
+        assert found.rotated_to == "new-token-id"
+
+    @pytest.mark.asyncio
+    async def test_create_token_with_empty_scopes_and_workspaces(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test create handles empty scopes and workspace_ids."""
+        token = ServiceTokenRecord(
+            identifier="minimal-token",
+            secret_hash="minimalhash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+
+        await repository.create(token)
+        found = await repository.find_by_id("minimal-token")
+        assert found is not None
+        assert found.scopes == frozenset()
+        assert found.workspace_ids == frozenset()
+
+    @pytest.mark.asyncio
+    async def test_create_revoked_token(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_revoked_token: ServiceTokenRecord,
+    ) -> None:
+        """Test create stores revocation information."""
+        await repository.create(sample_revoked_token)
+
+        found = await repository.find_by_id("revoked-token")
+        assert found is not None
+        assert found.revoked_at == datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+        assert found.revocation_reason == "Security breach"
+
+    @pytest.mark.asyncio
+    async def test_update_token(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test update modifies token fields."""
+        await repository.create(sample_token_record)
+
+        # Update with new expiration and scopes
+        updated_record = ServiceTokenRecord(
+            identifier="test-token-123",
+            secret_hash="newhash",
+            scopes=frozenset(["admin", "delete"]),
+            workspace_ids=frozenset(["ws-3"]),
+            issued_at=sample_token_record.issued_at,
+            expires_at=datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC),
+        )
+
+        await repository.update(updated_record)
+
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.secret_hash == "newhash"
+        assert found.scopes == frozenset(["admin", "delete"])
+        assert found.workspace_ids == frozenset(["ws-3"])
+        assert found.expires_at == datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
+
+    @pytest.mark.asyncio
+    async def test_update_token_revocation(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test update can revoke a token."""
+        await repository.create(sample_token_record)
+
+        revoked = ServiceTokenRecord(
+            identifier="test-token-123",
+            secret_hash=sample_token_record.secret_hash,
+            scopes=sample_token_record.scopes,
+            workspace_ids=sample_token_record.workspace_ids,
+            issued_at=sample_token_record.issued_at,
+            expires_at=sample_token_record.expires_at,
+            revoked_at=datetime(2025, 2, 1, 0, 0, 0, tzinfo=UTC),
+            revocation_reason="Testing revocation",
+        )
+
+        await repository.update(revoked)
+
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.revoked_at == datetime(2025, 2, 1, 0, 0, 0, tzinfo=UTC)
+        assert found.revocation_reason == "Testing revocation"
+
+    @pytest.mark.asyncio
+    async def test_update_token_rotation(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test update can set rotation fields."""
+        await repository.create(sample_token_record)
+
+        rotated = ServiceTokenRecord(
+            identifier="test-token-123",
+            secret_hash=sample_token_record.secret_hash,
+            scopes=sample_token_record.scopes,
+            workspace_ids=sample_token_record.workspace_ids,
+            issued_at=sample_token_record.issued_at,
+            expires_at=sample_token_record.expires_at,
+            rotation_expires_at=datetime(2025, 1, 2, 12, 0, 0, tzinfo=UTC),
+            rotated_to="new-rotated-token",
+        )
+
+        await repository.update(rotated)
+
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.rotation_expires_at == datetime(2025, 1, 2, 12, 0, 0, tzinfo=UTC)
+        assert found.rotated_to == "new-rotated-token"
+
+    @pytest.mark.asyncio
+    async def test_delete_token(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test delete removes a token."""
+        await repository.create(sample_token_record)
+
+        found_before = await repository.find_by_id("test-token-123")
+        assert found_before is not None
+
+        await repository.delete("test-token-123")
+
+        found_after = await repository.find_by_id("test-token-123")
+        assert found_after is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_token(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test delete does not raise error for nonexistent token."""
+        # Should not raise
+        await repository.delete("nonexistent-token")
+
+    @pytest.mark.asyncio
+    async def test_record_usage_updates_last_used_and_count(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_usage updates last_used_at and use_count."""
+        await repository.create(sample_token_record)
+
+        initial = await repository.find_by_id("test-token-123")
+        assert initial is not None
+        assert initial.last_used_at is None
+        assert initial.use_count == 0
+
+        await repository.record_usage(
+            "test-token-123",
+            ip="192.168.1.1",
+            user_agent="TestAgent/1.0",
+        )
+
+        after_use = await repository.find_by_id("test-token-123")
+        assert after_use is not None
+        assert after_use.last_used_at is not None
+        assert after_use.use_count == 1
+
+    @pytest.mark.asyncio
+    async def test_record_usage_increments_count(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_usage increments use_count on multiple calls."""
+        await repository.create(sample_token_record)
+
+        await repository.record_usage("test-token-123")
+        await repository.record_usage("test-token-123")
+        await repository.record_usage("test-token-123")
+
+        token = await repository.find_by_id("test-token-123")
+        assert token is not None
+        assert token.use_count == 3
+
+    @pytest.mark.asyncio
+    async def test_record_usage_without_ip_and_user_agent(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_usage works without ip and user_agent."""
+        await repository.create(sample_token_record)
+
+        await repository.record_usage("test-token-123")
+
+        token = await repository.find_by_id("test-token-123")
+        assert token is not None
+        assert token.use_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_returns_usage_entries(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test get_audit_log returns usage entries."""
+        await repository.create(sample_token_record)
+
+        await repository.record_usage(
+            "test-token-123",
+            ip="10.0.0.1",
+            user_agent="Browser/1.0",
+        )
+
+        log = await repository.get_audit_log("test-token-123")
+        assert len(log) == 1
+        assert log[0]["token_id"] == "test-token-123"
+        assert log[0]["action"] == "used"
+        assert log[0]["ip_address"] == "10.0.0.1"
+        assert log[0]["user_agent"] == "Browser/1.0"
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_respects_limit(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test get_audit_log respects the limit parameter."""
+        await repository.create(sample_token_record)
+
+        # Create 10 usage entries
+        for _ in range(10):
+            await repository.record_usage("test-token-123")
+
+        log = await repository.get_audit_log("test-token-123", limit=5)
+        assert len(log) == 5
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_empty_for_nonexistent_token(
+        self, repository: SqliteServiceTokenRepository
+    ) -> None:
+        """Test get_audit_log returns empty list for nonexistent token."""
+        log = await repository.get_audit_log("nonexistent-token")
+        assert log == []
+
+    @pytest.mark.asyncio
+    async def test_record_audit_event(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_audit_event creates audit log entries."""
+        await repository.create(sample_token_record)
+
+        await repository.record_audit_event(
+            "test-token-123",
+            "created",
+            actor="admin",
+            ip="127.0.0.1",
+            details={"reason": "Testing"},
+        )
+
+        log = await repository.get_audit_log("test-token-123")
+        assert len(log) == 1
+        assert log[0]["action"] == "created"
+        assert log[0]["actor"] == "admin"
+        assert log[0]["ip_address"] == "127.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_record_audit_event_without_optional_fields(
+        self,
+        repository: SqliteServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_audit_event works without optional fields."""
+        await repository.create(sample_token_record)
+
+        await repository.record_audit_event(
+            "test-token-123",
+            "rotated",
+        )
+
+        log = await repository.get_audit_log("test-token-123")
+        assert len(log) == 1
+        assert log[0]["action"] == "rotated"
+        assert log[0]["actor"] is None
+        assert log[0]["ip_address"] is None
+
+    @pytest.mark.asyncio
+    async def test_database_path_creation(self, tmp_path: Path) -> None:
+        """Test that repository creates parent directories."""
+        nested_path = tmp_path / "nested" / "dirs" / "tokens.db"
+        repository = SqliteServiceTokenRepository(nested_path)
+
+        # Should not raise and parent dirs should exist
+        assert nested_path.parent.exists()
+
+        # Verify we can create tokens
+        token = ServiceTokenRecord(
+            identifier="test-nested",
+            secret_hash="hash",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime.now(tz=UTC),
+        )
+        await repository.create(token)
+        found = await repository.find_by_id("test-nested")
+        assert found is not None
+
+
+class TestInMemoryServiceTokenRepository:
+    """Test cases for in-memory service token repository."""
+
+    @pytest.fixture
+    def repository(self) -> InMemoryServiceTokenRepository:
+        """Create an in-memory repository instance."""
+        return InMemoryServiceTokenRepository()
+
+    @pytest.mark.asyncio
+    async def test_list_all_empty(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test list_all returns empty list when no tokens exist."""
+        tokens = await repository.list_all()
+        assert tokens == []
+
+    @pytest.mark.asyncio
+    async def test_list_all_returns_all_tokens(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+        sample_revoked_token: ServiceTokenRecord,
+    ) -> None:
+        """Test list_all returns all tokens."""
+        await repository.create(sample_token_record)
+        await repository.create(sample_revoked_token)
+
+        tokens = await repository.list_all()
+        assert len(tokens) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_active_filters_revoked_and_expired(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test list_active filters out revoked and expired tokens."""
+        active = ServiceTokenRecord(
+            identifier="active",
+            secret_hash="hash1",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            expires_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        expired = ServiceTokenRecord(
+            identifier="expired",
+            secret_hash="hash2",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC),
+            expires_at=datetime(2024, 12, 31, 0, 0, 0, tzinfo=UTC),
+        )
+        revoked = ServiceTokenRecord(
+            identifier="revoked",
+            secret_hash="hash3",
+            scopes=frozenset(),
+            workspace_ids=frozenset(),
+            issued_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+            revoked_at=datetime(2025, 1, 15, 0, 0, 0, tzinfo=UTC),
+        )
+
+        await repository.create(active)
+        await repository.create(expired)
+        await repository.create(revoked)
+
+        now = datetime(2025, 6, 1, 0, 0, 0, tzinfo=UTC)
+        active_tokens = await repository.list_active(now=now)
+        assert len(active_tokens) == 1
+        assert active_tokens[0].identifier == "active"
+
+    @pytest.mark.asyncio
+    async def test_find_by_id(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test find_by_id returns correct token."""
+        await repository.create(sample_token_record)
+
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.identifier == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_find_by_id_not_found(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test find_by_id returns None for nonexistent token."""
+        found = await repository.find_by_id("nonexistent")
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_find_by_hash(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test find_by_hash returns correct token."""
+        await repository.create(sample_token_record)
+
+        found = await repository.find_by_hash("abc123hash")
+        assert found is not None
+        assert found.identifier == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_find_by_hash_not_found(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test find_by_hash returns None for nonexistent hash."""
+        found = await repository.find_by_hash("nonexistent")
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_find_by_hash_with_multiple_tokens(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+        sample_revoked_token: ServiceTokenRecord,
+    ) -> None:
+        """Test find_by_hash searches through multiple tokens."""
+        # Create multiple tokens to ensure loop iteration
+        await repository.create(sample_token_record)
+        await repository.create(sample_revoked_token)
+
+        # Find the second token by hash
+        found = await repository.find_by_hash("revokedhash")
+        assert found is not None
+        assert found.identifier == "revoked-token"
+
+        # Verify first token can still be found
+        found_first = await repository.find_by_hash("abc123hash")
+        assert found_first is not None
+        assert found_first.identifier == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_create_and_update(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test create and update operations."""
+        created = await repository.create(sample_token_record)
+        assert created.identifier == "test-token-123"
+
+        # Update with new scopes
+        updated_record = ServiceTokenRecord(
+            identifier="test-token-123",
+            secret_hash="newhash",
+            scopes=frozenset(["admin"]),
+            workspace_ids=sample_token_record.workspace_ids,
+            issued_at=sample_token_record.issued_at,
+        )
+
+        await repository.update(updated_record)
+        found = await repository.find_by_id("test-token-123")
+        assert found is not None
+        assert found.secret_hash == "newhash"
+        assert found.scopes == frozenset(["admin"])
+
+    @pytest.mark.asyncio
+    async def test_delete(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test delete removes token."""
+        await repository.create(sample_token_record)
+
+        found_before = await repository.find_by_id("test-token-123")
+        assert found_before is not None
+
+        await repository.delete("test-token-123")
+
+        found_after = await repository.find_by_id("test-token-123")
+        assert found_after is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test delete handles nonexistent token gracefully."""
+        # Should not raise
+        await repository.delete("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_record_usage(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_usage updates token and creates audit log."""
+        await repository.create(sample_token_record)
+
+        await repository.record_usage(
+            "test-token-123",
+            ip="10.0.0.1",
+            user_agent="TestAgent/1.0",
+        )
+
+        token = await repository.find_by_id("test-token-123")
+        assert token is not None
+        assert token.use_count == 1
+        assert token.last_used_at is not None
+
+        log = await repository.get_audit_log("test-token-123")
+        assert len(log) == 1
+        assert log[0]["action"] == "used"
+        assert log[0]["ip_address"] == "10.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_record_usage_for_nonexistent_token(
+        self, repository: InMemoryServiceTokenRepository
+    ) -> None:
+        """Test record_usage handles nonexistent token gracefully."""
+        # Should not raise but should create audit log entry
+        await repository.record_usage("nonexistent-token")
+
+        log = await repository.get_audit_log("nonexistent-token")
+        assert len(log) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_limit(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test get_audit_log respects limit parameter."""
+        await repository.create(sample_token_record)
+
+        # Create multiple usage entries
+        for _ in range(10):
+            await repository.record_usage("test-token-123")
+
+        log = await repository.get_audit_log("test-token-123", limit=5)
+        # In-memory implementation returns last N entries
+        assert len(log) == 5
+
+    @pytest.mark.asyncio
+    async def test_record_audit_event(
+        self,
+        repository: InMemoryServiceTokenRepository,
+        sample_token_record: ServiceTokenRecord,
+    ) -> None:
+        """Test record_audit_event creates audit entries."""
+        await repository.create(sample_token_record)
+
+        await repository.record_audit_event(
+            "test-token-123",
+            "revoked",
+            actor="admin",
+            ip="127.0.0.1",
+            details={"reason": "Test"},
+        )
+
+        log = await repository.get_audit_log("test-token-123")
+        assert len(log) == 1
+        assert log[0]["action"] == "revoked"
+        assert log[0]["actor"] == "admin"

--- a/tests/sdk/test_cli_output.py
+++ b/tests/sdk/test_cli_output.py
@@ -1,0 +1,168 @@
+"""Tests for the CLI output module."""
+
+from __future__ import annotations
+from io import StringIO
+from unittest.mock import patch
+from orcheo_sdk.cli.output import (
+    format_datetime,
+    render_json,
+    render_table,
+    success,
+    warning,
+)
+from rich.console import Console
+
+
+def test_render_table_basic() -> None:
+    """Test rendering a basic table."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=80)
+
+    render_table(
+        console,
+        title="Test Table",
+        columns=["Column 1", "Column 2"],
+        rows=[["Value 1", "Value 2"], ["Value 3", "Value 4"]],
+    )
+
+    result = output.getvalue()
+    assert "Test Table" in result
+    assert "Column 1" in result
+    assert "Column 2" in result
+    assert "Value 1" in result
+    assert "Value 2" in result
+
+
+def test_render_table_with_numbers() -> None:
+    """Test rendering a table with numeric values."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=80)
+
+    render_table(
+        console,
+        title="Numbers",
+        columns=["ID", "Count"],
+        rows=[[1, 100], [2, 200]],
+    )
+
+    result = output.getvalue()
+    assert "1" in result
+    assert "100" in result
+
+
+def test_render_json_with_title() -> None:
+    """Test rendering JSON with a title."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=80)
+
+    payload = {"key": "value", "nested": {"inner": "data"}}
+    render_json(console, payload, title="Test JSON")
+
+    result = output.getvalue()
+    assert "Test JSON" in result
+    assert "key" in result
+    assert "value" in result
+
+
+def test_render_json_without_title() -> None:
+    """Test rendering JSON without a title."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=True, width=80)
+
+    payload = {"simple": "object"}
+    render_json(console, payload)
+
+    result = output.getvalue()
+    assert "simple" in result
+    assert "object" in result
+
+
+def test_format_datetime_valid_iso_string() -> None:
+    """Test formatting a valid ISO datetime string."""
+    iso_string = "2024-11-03T10:30:00Z"
+    result = format_datetime(iso_string)
+    assert "2024-11-03" in result
+    assert "10:30:00 UTC" in result
+
+
+def test_format_datetime_with_timezone() -> None:
+    """Test formatting a datetime string with timezone."""
+    iso_string = "2024-11-03T10:30:00+00:00"
+    result = format_datetime(iso_string)
+    assert "2024-11-03" in result
+    assert "UTC" in result
+
+
+def test_format_datetime_invalid_string() -> None:
+    """Test formatting an invalid datetime string returns original."""
+    invalid_string = "not-a-date"
+    result = format_datetime(invalid_string)
+    assert result == invalid_string
+
+
+def test_format_datetime_empty_string() -> None:
+    """Test formatting an empty string returns original."""
+    result = format_datetime("")
+    assert result == ""
+
+
+def test_format_datetime_none_attribute() -> None:
+    """Test formatting None-like value (AttributeError path)."""
+    # This tests the AttributeError exception path
+    result = format_datetime("2024-11-03")  # Valid but without Z or timezone
+    # Should still work for simple ISO format
+    assert "2024-11-03" in result
+
+
+def test_success_message() -> None:
+    """Test success message output."""
+    output = StringIO()
+    with patch("orcheo_sdk.cli.output.Console") as mock_console_class:
+        mock_console = Console(file=output, force_terminal=True)
+        mock_console_class.return_value = mock_console
+
+        success("Operation completed")
+
+        result = output.getvalue()
+        assert "Operation completed" in result
+
+
+def test_warning_message() -> None:
+    """Test warning message output."""
+    output = StringIO()
+    with patch("orcheo_sdk.cli.output.Console") as mock_console_class:
+        mock_console = Console(file=output, force_terminal=True)
+        mock_console_class.return_value = mock_console
+
+        warning("This is a warning")
+
+        result = output.getvalue()
+        assert "This is a warning" in result
+
+
+def test_success_with_special_characters() -> None:
+    """Test success message with special characters."""
+    output = StringIO()
+    with patch("orcheo_sdk.cli.output.Console") as mock_console_class:
+        mock_console = Console(file=output, force_terminal=True)
+        mock_console_class.return_value = mock_console
+
+        success("Success: 100% complete!")
+
+        result = output.getvalue()
+        assert "100" in result
+        assert "complete" in result
+
+
+def test_warning_with_special_characters() -> None:
+    """Test warning message with special characters."""
+    output = StringIO()
+    with patch("orcheo_sdk.cli.output.Console") as mock_console_class:
+        mock_console = Console(file=output, force_terminal=True)
+        mock_console_class.return_value = mock_console
+
+        warning("Warning: Rate limit 90% reached")
+
+        result = output.getvalue()
+        assert "90" in result
+        assert "Rate limit" in result

--- a/tests/sdk/test_cli_service_token.py
+++ b/tests/sdk/test_cli_service_token.py
@@ -1,0 +1,518 @@
+"""Tests for the CLI service token commands."""
+
+from __future__ import annotations
+from pathlib import Path
+import httpx
+import pytest
+import respx
+from orcheo_sdk.cli.main import app
+from typer.testing import CliRunner
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> dict[str, str]:
+    config_dir = tmp_path / "config"
+    cache_dir = tmp_path / "cache"
+    config_dir.mkdir()
+    cache_dir.mkdir()
+    return {
+        "ORCHEO_API_URL": "http://api.test",
+        "ORCHEO_SERVICE_TOKEN": "admin-token",
+        "ORCHEO_CONFIG_DIR": str(config_dir),
+        "ORCHEO_CACHE_DIR": str(cache_dir),
+        "NO_COLOR": "1",
+    }
+
+
+def test_token_create_minimal(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with minimal options."""
+    response_data = {
+        "identifier": "token-123",
+        "secret": "secret-abc-xyz",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "create"], env=env)
+
+    assert result.exit_code == 0
+    assert "token-123" in result.stdout
+    assert "secret-abc-xyz" in result.stdout
+    assert "Store this secret securely" in result.stdout
+
+
+def test_token_create_with_identifier(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with custom identifier."""
+    response_data = {
+        "identifier": "my-custom-token",
+        "secret": "secret-123",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app, ["token", "create", "--id", "my-custom-token"], env=env
+        )
+
+    assert result.exit_code == 0
+    assert "my-custom-token" in result.stdout
+
+
+def test_token_create_with_scopes(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with scopes."""
+    response_data = {
+        "identifier": "scoped-token",
+        "secret": "secret-123",
+        "scopes": ["read:workflows", "write:workflows"],
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "token",
+                "create",
+                "--scope",
+                "read:workflows",
+                "--scope",
+                "write:workflows",
+            ],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "read:workflows" in result.stdout
+    assert "write:workflows" in result.stdout
+
+
+def test_token_create_with_workspaces(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with workspace restrictions."""
+    response_data = {
+        "identifier": "workspace-token",
+        "secret": "secret-123",
+        "workspace_ids": ["ws-1", "ws-2"],
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app,
+            ["token", "create", "--workspace", "ws-1", "--workspace", "ws-2"],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "ws-1" in result.stdout
+    assert "ws-2" in result.stdout
+
+
+def test_token_create_with_expiration(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with expiration."""
+    response_data = {
+        "identifier": "expiring-token",
+        "secret": "secret-123",
+        "expires_at": "2024-12-31T23:59:59Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app, ["token", "create", "--expires-in", "3600"], env=env
+        )
+
+    assert result.exit_code == 0
+    assert "2024-12-31" in result.stdout
+
+
+def test_token_create_with_all_options(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test creating a token with all options."""
+    response_data = {
+        "identifier": "full-token",
+        "secret": "secret-123",
+        "scopes": ["read:all"],
+        "workspace_ids": ["ws-1"],
+        "expires_at": "2024-12-31T23:59:59Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "token",
+                "create",
+                "--id",
+                "full-token",
+                "--scope",
+                "read:all",
+                "--workspace",
+                "ws-1",
+                "--expires-in",
+                "3600",
+            ],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "full-token" in result.stdout
+    assert "secret-123" in result.stdout
+    assert "read:all" in result.stdout
+    assert "ws-1" in result.stdout
+
+
+def test_token_list_empty(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test listing tokens when none exist."""
+    response_data = {"tokens": [], "total": 0}
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "list"], env=env)
+
+    assert result.exit_code == 0
+    assert "No service tokens found" in result.stdout
+
+
+def test_token_list_with_tokens(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test listing tokens."""
+    response_data = {
+        "tokens": [
+            {
+                "identifier": "token-1",
+                "scopes": ["read:workflows"],
+                "workspace_ids": ["ws-1"],
+                "issued_at": "2024-11-01T10:00:00Z",
+                "expires_at": "2024-12-01T10:00:00Z",
+            },
+            {
+                "identifier": "token-2",
+                "scopes": [],
+                "workspace_ids": [],
+                "issued_at": "2024-11-02T10:00:00Z",
+            },
+        ],
+        "total": 2,
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "list"], env=env)
+
+    assert result.exit_code == 0
+    assert "Service Tokens" in result.stdout
+    assert "token-1" in result.stdout
+    assert "token-2" in result.stdout
+    assert "read:workflo" in result.stdout  # May be truncated in table
+
+
+def test_token_list_with_revoked_token(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test listing tokens includes revoked status."""
+    response_data = {
+        "tokens": [
+            {
+                "identifier": "revoked-token",
+                "scopes": [],
+                "workspace_ids": [],
+                "issued_at": "2024-11-01T10:00:00Z",
+                "revoked_at": "2024-11-02T10:00:00Z",
+            }
+        ],
+        "total": 1,
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "list"], env=env)
+
+    assert result.exit_code == 0
+    assert "revoked-token" in result.stdout
+    assert "Revoked" in result.stdout
+
+
+def test_token_list_with_rotated_token(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test listing tokens includes rotated status."""
+    response_data = {
+        "tokens": [
+            {
+                "identifier": "rotated-token",
+                "scopes": [],
+                "workspace_ids": [],
+                "issued_at": "2024-11-01T10:00:00Z",
+                "rotated_to": "new-token-id",
+            }
+        ],
+        "total": 1,
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "list"], env=env)
+
+    assert result.exit_code == 0
+    assert "rotated-token" in result.stdout
+    assert "Rotated" in result.stdout
+
+
+def test_token_show_basic(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing token details."""
+    response_data = {
+        "identifier": "token-123",
+        "scopes": ["read:workflows"],
+        "workspace_ids": ["ws-1"],
+        "issued_at": "2024-11-01T10:00:00Z",
+        "expires_at": "2024-12-01T10:00:00Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "token-123" in result.stdout
+    assert "read:workflows" in result.stdout
+    assert "ws-1" in result.stdout
+
+
+def test_token_show_without_scopes(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing token without scopes."""
+    response_data = {
+        "identifier": "token-123",
+        "issued_at": "2024-11-01T10:00:00Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "token-123" in result.stdout
+
+
+def test_token_show_without_expiration(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing token without expiration."""
+    response_data = {
+        "identifier": "token-123",
+        "issued_at": "2024-11-01T10:00:00Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "Never" in result.stdout
+
+
+def test_token_show_revoked_with_reason(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing revoked token with reason."""
+    response_data = {
+        "identifier": "token-123",
+        "issued_at": "2024-11-01T10:00:00Z",
+        "revoked_at": "2024-11-02T10:00:00Z",
+        "revocation_reason": "Security breach",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "Security breach" in result.stdout
+
+
+def test_token_show_revoked_without_reason(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    """Test showing revoked token without reason."""
+    response_data = {
+        "identifier": "token-123",
+        "issued_at": "2024-11-01T10:00:00Z",
+        "revoked_at": "2024-11-02T10:00:00Z",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "token-123" in result.stdout
+
+
+def test_token_show_without_issued_at(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing token without issued_at field."""
+    response_data = {
+        "identifier": "token-123",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "token-123" in result.stdout
+
+
+def test_token_show_rotated(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test showing rotated token."""
+    response_data = {
+        "identifier": "token-123",
+        "issued_at": "2024-11-01T10:00:00Z",
+        "rotated_to": "new-token-456",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "show", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "new-token-456" in result.stdout
+
+
+def test_token_rotate_basic(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test rotating a token."""
+    response_data = {
+        "identifier": "new-token-456",
+        "secret": "new-secret-xyz",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens/token-123/rotate").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "rotate", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "new-token-456" in result.stdout
+    assert "new-secret-xyz" in result.stdout
+    assert "Store this secret securely" in result.stdout
+
+
+def test_token_rotate_with_custom_overlap(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    """Test rotating a token with custom overlap period."""
+    response_data = {
+        "identifier": "new-token-456",
+        "secret": "new-secret-xyz",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens/token-123/rotate").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app, ["token", "rotate", "token-123", "--overlap", "600"], env=env
+        )
+
+    assert result.exit_code == 0
+    assert "new-token-456" in result.stdout
+
+
+def test_token_rotate_with_expiration(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test rotating a token with new expiration."""
+    response_data = {
+        "identifier": "new-token-456",
+        "secret": "new-secret-xyz",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens/token-123/rotate").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(
+            app, ["token", "rotate", "token-123", "--expires-in", "7200"], env=env
+        )
+
+    assert result.exit_code == 0
+    assert "new-token-456" in result.stdout
+
+
+def test_token_rotate_with_message(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test rotating a token that returns a message."""
+    response_data = {
+        "identifier": "new-token-456",
+        "secret": "new-secret-xyz",
+        "message": "Old token will expire in 5 minutes",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens/token-123/rotate").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "rotate", "token-123"], env=env)
+
+    assert result.exit_code == 0
+    assert "Old token will expire in 5 minutes" in result.stdout
+
+
+def test_token_revoke(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test revoking a token."""
+    with respx.mock(assert_all_called=True) as router:
+        router.delete("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(204)
+        )
+        result = runner.invoke(
+            app,
+            ["token", "revoke", "token-123", "--reason", "No longer needed"],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "revoked successfully" in result.stdout
+    assert "No longer needed" in result.stdout
+
+
+def test_token_revoke_security_breach(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test revoking a token due to security breach."""
+    with respx.mock(assert_all_called=True) as router:
+        router.delete("http://api.test/api/admin/service-tokens/token-123").mock(
+            return_value=httpx.Response(204)
+        )
+        result = runner.invoke(
+            app,
+            ["token", "revoke", "token-123", "-r", "Security breach detected"],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "revoked successfully" in result.stdout
+    assert "Security breach detected" in result.stdout

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,9 +1,14 @@
 """End-to-end API tests for the Orcheo FastAPI backend."""
 
 from __future__ import annotations
+import hashlib
 import importlib
+import json
+import sqlite3
+import tempfile
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 import jwt
@@ -33,7 +38,10 @@ from orcheo.vault.oauth import (
     OAuthValidationResult,
 )
 from orcheo_backend.app import create_app
-from orcheo_backend.app.authentication import reset_authentication_state
+from orcheo_backend.app.authentication import (
+    ServiceTokenRecord,
+    reset_authentication_state,
+)
 from orcheo_backend.app.chatkit_tokens import reset_chatkit_token_state
 from orcheo_backend.app.repository import InMemoryWorkflowRepository
 from orcheo_backend.app.schemas import (
@@ -41,9 +49,53 @@ from orcheo_backend.app.schemas import (
     CredentialScopePayload,
     OAuthTokenRequest,
 )
+from orcheo_backend.app.service_token_repository import SqliteServiceTokenRepository
 
 
 backend_app = importlib.import_module("orcheo_backend.app")
+
+
+def _setup_service_token(
+    monkeypatch: pytest.MonkeyPatch,
+    token_secret: str,
+    *,
+    identifier: str | None = None,
+    scopes: list[str] | None = None,
+) -> None:
+    """Set up a service token for testing."""
+    temp_dir = tempfile.mkdtemp()
+    db_path = str(Path(temp_dir) / "test_tokens.sqlite")
+    monkeypatch.setenv("ORCHEO_AUTH_SERVICE_TOKEN_DB_PATH", db_path)
+
+    _ = SqliteServiceTokenRepository(db_path)
+    token_hash = hashlib.sha256(token_secret.encode("utf-8")).hexdigest()
+    record = ServiceTokenRecord(
+        identifier=identifier or "test-token",
+        secret_hash=token_hash,
+        scopes=frozenset(scopes or []),
+        workspace_ids=frozenset(),
+        issued_at=datetime.now(tz=UTC),
+    )
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO service_tokens (
+            identifier, secret_hash, scopes, workspace_ids,
+            created_at, issued_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            record.identifier,
+            record.secret_hash,
+            json.dumps(sorted(record.scopes)) if record.scopes else None,
+            json.dumps(sorted(record.workspace_ids)) if record.workspace_ids else None,
+            datetime.now(tz=UTC).isoformat(),
+            record.issued_at.isoformat() if record.issued_at else None,
+        ),
+    )
+    conn.commit()
+    conn.close()
 
 
 class StaticProvider(OAuthProvider):
@@ -183,9 +235,8 @@ def test_chatkit_session_returns_configured_secret(
 ) -> None:
     """The ChatKit session endpoint issues a signed token with metadata."""
 
-    monkeypatch.setenv(
-        "ORCHEO_AUTH_SERVICE_TOKENS",
-        '{"id": "cli", "secret": "session-token", "scopes": ["chatkit:session"]}',
+    _setup_service_token(
+        monkeypatch, "session-token", identifier="cli", scopes=["chatkit:session"]
     )
     monkeypatch.setenv("CHATKIT_TOKEN_SIGNING_KEY", "api-signing-key")
     monkeypatch.setenv("ORCHEO_CHATKIT_TOKEN_SIGNING_KEY", "api-signing-key")
@@ -217,9 +268,8 @@ def test_chatkit_session_prefers_workflow_specific_secret(
     """Workflow identifiers should be embedded within the signed token."""
 
     workflow_id, _ = _create_workflow_with_version(api_client)
-    monkeypatch.setenv(
-        "ORCHEO_AUTH_SERVICE_TOKENS",
-        '{"id": "cli", "secret": "session-token", "scopes": ["chatkit:session"]}',
+    _setup_service_token(
+        monkeypatch, "session-token", identifier="cli", scopes=["chatkit:session"]
     )
     monkeypatch.setenv("CHATKIT_TOKEN_SIGNING_KEY", "api-signing-key")
     monkeypatch.setenv("ORCHEO_CHATKIT_TOKEN_SIGNING_KEY", "api-signing-key")
@@ -250,9 +300,8 @@ def test_chatkit_session_missing_secret_returns_service_unavailable(
 ) -> None:
     """Missing ChatKit signing key surfaces a configuration error."""
 
-    monkeypatch.setenv(
-        "ORCHEO_AUTH_SERVICE_TOKENS",
-        '{"id": "cli", "secret": "session-token", "scopes": ["chatkit:session"]}',
+    _setup_service_token(
+        monkeypatch, "session-token", identifier="cli", scopes=["chatkit:session"]
     )
     monkeypatch.delenv("CHATKIT_TOKEN_SIGNING_KEY", raising=False)
     monkeypatch.delenv("ORCHEO_CHATKIT_TOKEN_SIGNING_KEY", raising=False)


### PR DESCRIPTION
What Was Implemented
1. Database Schema & Repository ([service_token_repository.py](vscode-webview://1r1fbhlgpuq305aiopg99e1kdhdo7r9ncetof4rkkglrs64ofp65/apps/backend/src/orcheo_backend/app/service_token_repository.py))
SQLite schema with two tables:
service_tokens: Stores token metadata (identifier, secret hash, scopes, workspaces, expiration, revocation)
service_token_audit_log: Tracks all token lifecycle events (created, used, rotated, revoked)
SqliteServiceTokenRepository: Production-ready persistence
InMemoryServiceTokenRepository: For testing
Full async interface with methods: list_all(), list_active(), find_by_id(), find_by_hash(), create(), update(), delete(), record_usage(), record_audit_event()
2. Updated ServiceTokenManager ([authentication.py](vscode-webview://1r1fbhlgpuq305aiopg99e1kdhdo7r9ncetof4rkkglrs64ofp65/apps/backend/src/orcheo_backend/app/authentication.py))
Now requires a repository instance (no more in-memory-only storage)
All methods are now async (authenticate(), mint(), rotate(), revoke())
Built-in 30-second caching for active tokens to optimize performance
Automatic cache invalidation on mutations
3. Removed Environment Variable Loading
Deleted functions: _parse_service_tokens(), _normalize_service_token_entries(), _service_token_from_mapping(), _normalize_token_hash()
Removed from AuthSettings: service_tokens field
Added to AuthSettings: service_token_db_path field
Default database path: ~/.orcheo/service_tokens.sqlite (alongside workflows database)
4. FastAPI Management Endpoints ([service_token_endpoints.py](vscode-webview://1r1fbhlgpuq305aiopg99e1kdhdo7r9ncetof4rkkglrs64ofp65/apps/backend/src/orcheo_backend/app/service_token_endpoints.py))
Protected admin endpoints under /api/admin/service-tokens:
POST /: Create new token (returns secret once)
GET /: List all tokens (never returns secrets)
GET /{token_id}: Get token details
POST /{token_id}/rotate: Rotate token with overlap period
DELETE /{token_id}: Revoke token with reason
All endpoints require admin:tokens:read or admin:tokens:write scopes.
5. CLI Commands ([service_token.py](vscode-webview://1r1fbhlgpuq305aiopg99e1kdhdo7r9ncetof4rkkglrs64ofp65/packages/sdk/src/orcheo_sdk/cli/service_token.py))
New orcheo token command group:
orcheo token create --id cli-token --scope workflows:write
orcheo token list
orcheo token show <token-id>
orcheo token rotate <token-id> --overlap 300
orcheo token revoke <token-id> --reason "Compromised"
6. Updated Initialization
get_authenticator() now creates repository based on configuration
New get_service_token_manager() function for accessing token manager
Automatic database creation on first use