### PR TITLE
Add workflow tracing documentation and update roadmap scope

### DIFF
--- a/docs/otel_tracing/design.md
+++ b/docs/otel_tracing/design.md
@@ -1,0 +1,79 @@
+# Workflow Tracing Design
+
+## Architecture Overview
+The tracing capability spans backend instrumentation, persistence, APIs, and frontend presentation. Workflow executions emit OpenTelemetry spans that are exported to both an external collector and the Orcheo backend for retrieval. The Canvas app consumes a new trace endpoint and renders a Trace tab dedicated to the active workflow run.
+
+```
+Workflow Runner ──▶ OTel SDK ──▶ Collector (optional)
+      │                         │
+      └─▶ Trace Persistence Service ──▶ Database (spans + metadata)
+                                       │
+Frontend Canvas ◀─ Trace API ◀──────────┘
+```
+
+## Backend Components
+1. **OpenTelemetry Initialization**
+   - Add OpenTelemetry SDK dependencies to the backend environment.
+   - Configure a tracer provider with batch span processor(s) targeting: (a) an OTLP exporter for external collectors, and (b) an in-process exporter that stores span data for Orcheo persistence.
+   - Support configuration via environment variables (collector endpoint, sampling ratio, feature flags).
+
+2. **Execution Instrumentation**
+   - Start a root span (`workflow.execution`) when a workflow run begins, attaching workflow/run identifiers.
+   - Create child spans for each node execution (`workflow.node`), tool invocation (`workflow.tool`), and external call as needed.
+   - Annotate spans with attributes: status, latency, input/output hashes, prompt text, response text, token counts, retry metadata, artifact references, and monitoring links.
+   - Emit events for errors and retries; propagate trace context through async tasks and WebSocket notifications.
+
+3. **Trace Persistence Layer**
+   - Extend existing run history models with trace metadata (trace ID, span counts, artifact IDs).
+   - Introduce a `trace_spans` table storing span hierarchy, timing, attributes, and references.
+   - Provide repository methods to persist spans as they complete, using bulk upserts for efficiency.
+   - Implement retention policies (e.g., configurable TTL) and pruning jobs.
+
+4. **Trace Retrieval API**
+   - Add FastAPI routes under `/executions/{execution_id}/trace` returning span trees.
+   - Support query parameters for pagination (e.g., `?cursor=`) and filtering (node IDs, status).
+   - Serialize spans into a normalized DTO: span metadata, children list, prompt/response payloads, token usage, artifact links, monitoring URLs.
+   - Enforce authentication/authorization; reuse existing run permission checks.
+
+5. **Telemetry & Error Handling**
+   - Emit metrics for trace emission success/failure, API latencies, and data volume.
+   - Ensure workflows proceed if tracing fails; log warnings and degrade gracefully.
+
+## Frontend Components
+1. **State Management**
+   - Extend Canvas state (`useCanvasUiState`, selectors, controllers) to track the selected Trace tab and active execution ID.
+   - Add a trace data cache keyed by execution ID to avoid redundant fetches.
+
+2. **Data Access**
+   - Create a client helper (e.g., `loadWorkflowTrace`) that calls the new trace endpoint, maps DTOs to view models, and normalizes prompt/response/token data.
+   - Implement retry logic and loading/error states consistent with existing execution tab behavior.
+
+3. **Trace Tab UI**
+   - Add a new `TabsTrigger` and `TabsContent` for `trace` in the workflow layout.
+   - Build a `TraceTabContent` component presenting:
+     - **Timeline view**: hierarchical span list with expand/collapse, duration bars, status indicators.
+     - **Detail panel**: prompt/response text, token metrics (input/output/total), retry info.
+     - **Artifacts section**: buttons/links to download associated files.
+     - **Monitoring panel**: external dashboard link(s) surfaced when provided.
+   - Provide responsive design and accessible semantics (ARIA roles, keyboard navigation).
+
+4. **Interactions**
+   - Sync trace selection with execution list; when a user selects a run, fetch traces and focus the corresponding root span.
+   - Allow filtering by status (success/failure) and searching by node name.
+   - Offer copy-to-clipboard for trace IDs.
+
+5. **Testing & QA**
+   - Unit tests for trace serialization, repository operations, and API responses.
+   - Frontend unit/integration tests validating tab rendering, data fetching, and timeline interactions.
+   - End-to-end scenario covering trace display for a sample workflow.
+
+## Deployment Considerations
+- Provide migration scripts for new trace tables/columns.
+- Document environment variables for enabling/disabling tracing and configuring the OTLP endpoint.
+- Validate compatibility with existing observability stack; ensure collectors can ingest spans without schema changes.
+
+## Risks & Mitigations
+- **Performance Overhead**: Mitigate via sampling, batching, and asynchronous persistence.
+- **Storage Growth**: Introduce retention policies and compression for stored spans.
+- **Sensitive Data Exposure**: Redact secrets and allow masking configurations for prompts/responses.
+- **UI Complexity**: Start with a focused feature set; gather feedback before expanding advanced analytics.

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -1,0 +1,35 @@
+# Workflow Tracing Implementation Plan
+
+## Phase 1 – Foundations (Week 1)
+- Finalize configuration for enabling tracing and document new environment variables.
+- Add OpenTelemetry dependencies to backend projects and bootstrap tracer provider with OTLP + persistence exporters.
+- Implement root/node span instrumentation in workflow execution paths with feature flag to disable tracing.
+- Draft database migration scripts (trace tables, run metadata columns) and review with infra team.
+
+## Phase 2 – Persistence & API (Week 2)
+- Implement repositories/services that persist spans and associate them with workflow executions.
+- Build FastAPI endpoints for retrieving traces, including pagination/filtering support.
+- Add unit/integration tests covering span persistence, serialization, and API responses.
+- Deploy migrations to staging and validate trace storage under load.
+
+## Phase 3 – Canvas Integration (Week 3)
+- Extend Canvas state management and layout to include the Trace tab.
+- Build data fetching hooks and API clients for trace retrieval.
+- Implement Trace tab UI components (timeline, details, artifacts, monitoring links).
+- Add frontend tests (unit + integration) and run canvas lint/test suites.
+
+## Phase 4 – End-to-End Validation (Week 4)
+- Create sample workflows that emit diverse spans (success, retries, errors) for QA.
+- Execute manual and automated end-to-end tests verifying trace capture, storage, and UI display.
+- Measure performance metrics (API latency, UI load time) and tune sampling/batching as needed.
+- Document operational playbooks, monitoring dashboards, and troubleshooting guides.
+
+## Dependencies & Coordination
+- Align with infrastructure team on OpenTelemetry collector availability and retention policies.
+- Collaborate with security/compliance stakeholders on prompt/response redaction rules.
+- Coordinate with documentation team to update user-facing guides once feature is ready for beta.
+
+## Exit Criteria
+- Trace tab enabled by default in staging, with documented rollback/feature flag strategy.
+- 95%+ of staging executions record complete trace trees.
+- No critical bugs in trace retrieval or UI rendering during soak testing.

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -4,7 +4,7 @@
 - Finalize configuration for enabling tracing and document new environment variables.
 - Add OpenTelemetry dependencies to backend projects and bootstrap tracer provider with OTLP + persistence exporters.
 - Implement root/node span instrumentation in workflow execution paths with feature flag to disable tracing.
-- Draft database migration scripts (trace tables, run metadata columns) and review with infra team.
+- Draft database migrations (trace tables, run metadata columns) and review with infra team.
 
 ## Phase 2 – Persistence & API (Week 2)
 - Implement repositories/services that persist spans and associate them with workflow executions.

--- a/docs/otel_tracing/requirement.md
+++ b/docs/otel_tracing/requirement.md
@@ -15,16 +15,16 @@ Provide end-to-end visibility into workflow executions by introducing a dedicate
 - Supporting non-Canvas consumers (CLI, SDK) in this iteration.
 
 ## Functional Requirements
-1. **Trace Generation**: Each workflow execution creates a root span with child spans representing workflow nodes, tool calls, and downstream services. Each span includes timing, status, prompt/response metadata (for LLM nodes), token counts, and artifact references.
-2. **Trace Persistence**: The backend stores trace identifiers, span metadata, and links to artifacts/metrics so they can be retrieved after execution completes.
-3. **Trace Retrieval API**: Expose REST endpoints that return trace trees for a given execution ID, with pagination options for large runs.
-4. **Trace Tab UI**: Add a "Trace" tab (after "Execution") on the workflow Canvas page that renders span timelines, prompts/responses, token metrics charts, and artifact download links. The tab must respond to execution selection changes.
+1. **Trace Generation**: Each workflow execution creates a root span with child spans representing workflow nodes, tool calls, and downstream services. Each span includes timing, status, prompt/response metadata (for LLM nodes), token counts, and artifact references. Implementation guidance lives in [Backend Components](./design.md#backend-components).
+2. **Trace Persistence**: The backend stores trace identifiers, span metadata, and links to artifacts/metrics so they can be retrieved after execution completes. The proposed schema is summarized in [Trace Persistence Layer](./design.md#backend-components).
+3. **Trace Retrieval API**: Expose REST endpoints that return trace trees for a given execution ID, with pagination options for large runs. DTO details appear in [Trace Retrieval API](./design.md#backend-components).
+4. **Trace Tab UI**: Add a "Trace" tab (after "Execution") on the workflow Canvas page that renders span timelines, prompts/responses, token metrics charts, and artifact download links. The tab must respond to execution selection changes. See [Trace Tab UI](./design.md#frontend-components) for the planned interactions.
 5. **Monitoring Links**: Provide deep links from spans or the Trace tab header to external dashboards (e.g., OpenTelemetry collector, metrics monitors) when configured.
 6. **Access Control**: Respect existing workflow access permissions; only authorized users can load traces.
 
 ## Quality Attributes
-- **Performance**: Loading a trace for a typical execution (≤500 spans) should complete within 1 second in the UI with cached API responses.
-- **Reliability**: Trace capture must not fail the workflow execution; fall back to logging when collectors are unavailable.
+- **Performance**: Loading a trace for a typical execution (defined as a run with ≤60 nodes, ≤10 tool calls per node, and ≤500 spans) should complete within 1 second in the UI with cached API responses.
+- **Reliability**: Trace capture must not fail the workflow execution; fall back to logging when collectors are unavailable and follow the degraded experience described in [Telemetry & Error Handling](./design.md#backend-components).
 - **Security & Privacy**: Sensitive prompt/response content must honor redaction rules; artifacts download only for authorized roles.
 - **Observability**: Emit backend metrics on trace generation, storage, and retrieval success/failure rates.
 

--- a/docs/otel_tracing/requirement.md
+++ b/docs/otel_tracing/requirement.md
@@ -1,0 +1,34 @@
+# Workflow Tracing Requirements
+
+## Overview
+Provide end-to-end visibility into workflow executions by introducing a dedicated Trace tab on the Canvas workflow page that surfaces OpenTelemetry-based traces alongside prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
+
+## Goals
+- Capture per-execution OpenTelemetry traces that cover workflow, node, and tool-level spans.
+- Persist trace metadata and artifacts so that the Trace tab can load complete histories on demand.
+- Display trace timelines, step metadata, prompts/responses, and token utilization in a workflow-specific Trace tab.
+- Link trace entries to downloadable artifacts and monitoring dashboards for deep inspection.
+
+## Non-Goals
+- Replacing the existing Execution tab or run-history viewer.
+- Building a full observability backend (e.g., collector storage) beyond what is required for workflow tracing.
+- Supporting non-Canvas consumers (CLI, SDK) in this iteration.
+
+## Functional Requirements
+1. **Trace Generation**: Each workflow execution creates a root span with child spans representing workflow nodes, tool calls, and downstream services. Each span includes timing, status, prompt/response metadata (for LLM nodes), token counts, and artifact references.
+2. **Trace Persistence**: The backend stores trace identifiers, span metadata, and links to artifacts/metrics so they can be retrieved after execution completes.
+3. **Trace Retrieval API**: Expose REST endpoints that return trace trees for a given execution ID, with pagination options for large runs.
+4. **Trace Tab UI**: Add a "Trace" tab (after "Execution") on the workflow Canvas page that renders span timelines, prompts/responses, token metrics charts, and artifact download links. The tab must respond to execution selection changes.
+5. **Monitoring Links**: Provide deep links from spans or the Trace tab header to external dashboards (e.g., OpenTelemetry collector, metrics monitors) when configured.
+6. **Access Control**: Respect existing workflow access permissions; only authorized users can load traces.
+
+## Quality Attributes
+- **Performance**: Loading a trace for a typical execution (≤500 spans) should complete within 1 second in the UI with cached API responses.
+- **Reliability**: Trace capture must not fail the workflow execution; fall back to logging when collectors are unavailable.
+- **Security & Privacy**: Sensitive prompt/response content must honor redaction rules; artifacts download only for authorized roles.
+- **Observability**: Emit backend metrics on trace generation, storage, and retrieval success/failure rates.
+
+## Success Metrics
+- ≥95% of workflow executions emit trace data with complete span hierarchies.
+- Canvas users report improved debugging efficiency (qualitative feedback) with trace tab usage.
+- No regression in existing execution monitoring features or performance.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ### Milestone 6 – Observability, Testing & Launch Prep
 - [x] Implement end-to-end authentication layer (OIDC integration, service tokens, ChatKit session hardening, webhook signatures) per [Authentication System Design](./authentication_design.md).
 - [x] ChatKit public page + workflow publish UX (CLI) and backend actions
-- [ ] Instrument execution viewer with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
+- [ ] Launch a dedicated workflow tracing tab (per workflow) that surfaces per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
 - [ ] Establish success metrics tracking (uv installs, GitHub stars, quickstart completion rate, failure backlog) and analytics pipelines.
 - [ ] Produce onboarding docs, templates, SDK examples, closed-beta playbook, and feedback/A-B testing loops for AI node recommendations.
 - [ ] Run end-to-end reliability tests, load tests on React Flow canvas, finalize beta rollout plan, and prepare Phase 1/Phase 2 regional launch gates.


### PR DESCRIPTION
## Summary
- rescope the Milestone 6 observability task to focus on a dedicated workflow tracing tab
- add requirements, design, and implementation plan documents for the OpenTelemetry tracing initiative

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ba9e061c83278baca2067c4ef13d)