### PR TITLE
Document workflow tracing requirements and design

### DIFF
--- a/docs/otel_tracing/design.md
+++ b/docs/otel_tracing/design.md
@@ -1,0 +1,90 @@
+# Workflow Tracing Design
+
+## Architectural Overview
+The tracing feature spans backend instrumentation, storage, API surfacing, and frontend rendering. We adopt OpenTelemetry for span generation and rely on an external collector/trace store (e.g., Tempo, Jaeger, Honeycomb) to persist data. The Orcheo backend captures trace IDs and exposes a read-optimized view of traces for the Canvas UI while also allowing operators to pivot into external dashboards.
+
+```
+Workflow Run -> Execution Engine -> OpenTelemetry SDK -> Collector -> Trace Store
+                                      |                         |
+                                      +--> Trace Metadata Store +--> Canvas Trace API
+```
+
+## Components
+### Backend Instrumentation
+- **Execution root span**: created when a workflow run starts, tagged with workflow ID, version, trigger, and user context.
+- **Node spans**: each node execution emits a child span with step metadata, prompt/response payloads, token usage, artifacts, and status.
+- **Error handling**: exceptions mark spans as errored with stack traces and remediation hints.
+- **Attributes & events**: prompts/responses stored as span events, token metrics as attributes; artifacts include download URLs and metadata references.
+- **Configuration**: instrumentation is optional, activated via environment variables that specify collector endpoint, service name, and sampling policy.
+
+### Trace Metadata Persistence
+- Store the execution-to-trace-ID mapping and a minimal cache of span summaries (IDs, names, start/end time, status) in the history repository.
+- Persisted metadata enables quick lookup of trace identifiers without querying the external collector for every request.
+- Schema changes extend `workflow_execution` records with `trace_id`, plus a `workflow_trace_summary` table for optional caching.
+
+### Trace Retrieval API
+- New FastAPI route: `GET /executions/{execution_id}/trace`.
+- Controller flow:
+  1. Authorize caller using existing execution permissions.
+  2. Resolve trace ID from metadata store.
+  3. Fetch detailed spans from collector or cache (initial MVP may proxy collector API or use OTLP HTTP).
+  4. Normalize spans into hierarchical JSON (parent/child relationships, attributes, events, artifact links).
+  5. Return metadata along with auxiliary URLs for dashboards.
+- Response example:
+```json
+{
+  "execution_id": "exec_123",
+  "trace_id": "abc123",
+  "root": {
+    "name": "Workflow Run",
+    "status": "OK",
+    "duration_ms": 12780,
+    "children": [
+      {
+        "name": "Node: Draft Email",
+        "status": "OK",
+        "duration_ms": 4500,
+        "token_usage": {"prompt": 1234, "completion": 678},
+        "prompts": [...],
+        "responses": [...],
+        "artifacts": [{"name": "email.txt", "url": "..."}],
+        "children": []
+      }
+    ]
+  },
+  "dashboards": {
+    "tempo": "https://tempo.example.com/trace/abc123"
+  }
+}
+```
+
+### Canvas Frontend
+- **Tab integration**: add a `Trace` tab to the existing tab group, coexisting with Editor, Execution, Readiness, and Settings.
+- **State management**: extend `useCanvasUiState` to track the selected tab and active execution; introduce a trace slice that caches traces per execution ID.
+- **Data fetching**: new React Query hook `useWorkflowTrace(executionId)` calls the trace endpoint, handles loading/error states, and refetches when executions change.
+- **Rendering**: implement a tree/timeline viewer with collapsible span nodes, color-coded status badges, token charts, and artifact buttons. Consider virtualized list for performance.
+- **Prompts & responses**: display within expandable sections, with copy-to-clipboard actions and redaction warnings.
+- **Artifacts**: link to existing artifact download handlers or provide direct downloads if available.
+- **Dashboard links**: show optional buttons to open external observability dashboards.
+
+### Monitoring & Telemetry
+- Expose metrics for trace emission success/failure, collector availability, and API latency via Prometheus endpoints.
+- Log sampling decisions to help operators tune configuration.
+- Provide health checks that detect when tracing is configured but not functioning.
+
+## Alternatives Considered
+1. **Persist full trace data in Orcheo DB**: rejected due to storage/maintenance burden and duplication of existing tracing backends.
+2. **Frontend-only integration with external dashboards**: rejected because users need in-app visibility without leaving Canvas.
+3. **Custom tracing implementation**: rejected in favor of OpenTelemetry standardization and ecosystem tooling.
+
+## Open Questions
+- Which collector/storage backend will the initial deployment target (Tempo vs. Jaeger vs. Honeycomb)?
+- Do we require sampling strategies beyond head sampling (e.g., tail-based)?
+- How should we redact or filter sensitive prompt content dynamically per tenant?
+- What retention SLA is acceptable for trace summaries cached in Orcheo storage?
+
+## Future Enhancements
+- Integrate trace search/filtering UI for historical executions.
+- Correlate traces with metrics and logs within a unified observability dashboard.
+- Add streaming updates so traces update live during execution.
+- Provide export functionality (e.g., JSON, CSV) for compliance audits.

--- a/docs/otel_tracing/design.md
+++ b/docs/otel_tracing/design.md
@@ -3,10 +3,15 @@
 ## Architectural Overview
 The tracing feature spans backend instrumentation, storage, API surfacing, and frontend rendering. We adopt OpenTelemetry for span generation and rely on an external collector/trace store (e.g., Tempo, Jaeger, Honeycomb) to persist data. The Orcheo backend captures trace IDs and exposes a read-optimized view of traces for the Canvas UI while also allowing operators to pivot into external dashboards.
 
-```
-Workflow Run -> Execution Engine -> OpenTelemetry SDK -> Collector -> Trace Store
-                                      |                         |
-                                      +--> Trace Metadata Store +--> Canvas Trace API
+```mermaid
+flowchart LR
+    WorkflowRun[Workflow Run] --> ExecutionEngine[Execution Engine]
+    ExecutionEngine --> OTEL[OpenTelemetry SDK]
+    OTEL --> Collector
+    Collector --> TraceStore[Trace Store]
+    ExecutionEngine --> MetadataStore[Trace Metadata Store]
+    MetadataStore --> CanvasAPI[Canvas Trace API]
+    Collector --> CanvasAPI
 ```
 
 ## Components
@@ -75,7 +80,7 @@ Workflow Run -> Execution Engine -> OpenTelemetry SDK -> Collector -> Trace Stor
 ## Alternatives Considered
 1. **Persist full trace data in Orcheo DB**: rejected due to storage/maintenance burden and duplication of existing tracing backends.
 2. **Frontend-only integration with external dashboards**: rejected because users need in-app visibility without leaving Canvas.
-3. **Custom tracing implementation**: rejected in favor of OpenTelemetry standardization and ecosystem tooling.
+3. **Custom tracing implementation**: rejected because building and operating bespoke instrumentation would duplicate vendor-integration work, fragment tracing semantics across services, and slow adoption of community tooling compared to the OpenTelemetry standard.
 
 ## Open Questions
 - Which collector/storage backend will the initial deployment target (Tempo vs. Jaeger vs. Honeycomb)?

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -1,0 +1,72 @@
+# Workflow Tracing Implementation Plan
+
+## Phase 0 – Foundations (Week 1)
+- **Owner**: Backend team lead
+- Finalize OpenTelemetry collector selection and deployment topology.
+- Document environment variables and secrets required for tracing (collector endpoint, headers, sampling rate).
+- Align on data retention policies and redaction rules with security/compliance stakeholders.
+
+## Phase 1 – Backend Instrumentation (Weeks 2–3)
+1. **Add dependencies**
+   - Update `pyproject.toml` packages (`orcheo`, backend app) with `opentelemetry-sdk`, OTLP exporter, and Prometheus bridge.
+   - Ensure `uv.lock` is refreshed and CI passes.
+2. **Instrumentation hooks**
+   - Wrap workflow execution start in a root span, embed trace context in execution metadata.
+   - Emit child spans for each node, capturing prompts, responses, tokens, artifacts.
+   - Handle errors with span status and exception details.
+3. **Configuration**
+   - Introduce environment-driven configuration (enable/disable tracing, sampling rate, collector endpoint).
+   - Add startup validation that warns if tracing is enabled but collector is unreachable.
+4. **Metadata persistence**
+   - Extend execution models, migrations, and repositories with `trace_id` and optional summary cache.
+   - Update tests covering persistence and regression checks.
+
+## Phase 2 – Trace Retrieval API (Weeks 3–4)
+1. **Collector integration**
+   - Build a client module that queries traces by trace ID (initially using OTLP/HTTP or gRPC).
+   - Implement exponential backoff and circuit breaker logic for collector downtime.
+2. **FastAPI endpoints**
+   - Add `GET /executions/{id}/trace` route that authorizes, fetches, normalizes, and returns trace trees.
+   - Provide optional query parameters for sampling (e.g., include prompts=false).
+   - Cover endpoint with unit and integration tests (fixtures simulate collector responses).
+3. **Monitoring**
+   - Export metrics for trace fetch latency and failure counts.
+   - Update logging to include trace IDs for cross-correlation.
+
+## Phase 3 – Canvas Trace Tab (Weeks 5–6)
+1. **UI scaffolding**
+   - Add Trace tab trigger/content to workflow layout components.
+   - Extend state hooks and controllers to manage trace loading per execution.
+2. **Data fetching**
+   - Create TypeScript models and API client wrappers for the trace endpoint.
+   - Implement React Query hooks with caching, retries, and background refresh.
+3. **Visualization**
+   - Build `TraceTabContent` component with span tree, status badges, duration bars, token charts, and artifact links.
+   - Add prompt/response drawers with copy and redaction indicators.
+   - Provide empty/loading/error states consistent with design system.
+4. **Testing & QA**
+   - Add unit tests for hooks, reducers, and components (Vitest + RTL).
+   - Run accessibility checks for the new tab interactions.
+   - Capture UX feedback loops with design team.
+
+## Phase 4 – Documentation & Launch (Week 7)
+- Update operator docs for configuring tracing, dashboards, and troubleshooting.
+- Publish Canvas user guide for the Trace tab, including screenshots and workflows.
+- Conduct performance benchmarking (load testing on trace-heavy executions).
+- Finalize go/no-go review with stakeholders and schedule beta rollout.
+
+## Milestones & Deliverables
+- **M1**: Backend emits spans to collector; trace IDs stored per execution.
+- **M2**: Trace API returns normalized span trees for recent executions.
+- **M3**: Canvas Trace tab available behind feature flag.
+- **M4**: Feature flag removed after QA sign-off; documentation published.
+
+## Risks & Mitigations
+- **Collector unavailability**: Provide graceful degradation and retries; keep tracing optional.
+- **Payload bloat**: Add configuration to truncate prompts/responses or switch to on-demand fetching.
+- **Security concerns**: Enforce access control and redact sensitive data before returning to clients.
+
+## Staffing Estimate
+- Backend: 1 senior engineer (6 weeks) + 1 supporting engineer (3 weeks for API/testing).
+- Frontend: 1 senior engineer (4 weeks) + design support (1 week) + QA (1 week shared).
+- DevOps: 0.5 engineer (2 weeks) for collector deployment and monitoring.

--- a/docs/otel_tracing/requirement.md
+++ b/docs/otel_tracing/requirement.md
@@ -17,7 +17,7 @@ The observability initiative for Milestone 6 is shifting toward a dedicated trac
 - Documentation updates covering setup, configuration, and user guidance for tracing.
 
 ## Out of Scope
-- Long-term storage and retention policies beyond the MVP retention window (to be defined later).
+- Long-term storage and retention policies beyond the MVP retention window (targeting 14 days for the initial release, with longer-term retention to be defined later).
 - Third-party collector deployment or hosted tracing infrastructure; the MVP targets compatibility with an existing OpenTelemetry collector endpoint provided by operators.
 - Retrofitting legacy execution viewers outside the Canvas workflow page.
 
@@ -44,6 +44,6 @@ The observability initiative for Milestone 6 is shifting toward a dedicated trac
 - UI complexity leading to confusing trace navigation without careful UX design.
 
 ## Compliance & Security Considerations
-- Sensitive prompt or response content must be redacted or protected in accordance with data handling policies.
+- Sensitive prompt or response content must be redacted or protected in accordance with data handling policies outlined in the [Milestone 3 Security Review](../milestone3_security_review.md).
 - Trace endpoints must enforce the same authorization scope as execution history APIs.
 - Token and artifact data should respect existing audit logging and access controls.

--- a/docs/otel_tracing/requirement.md
+++ b/docs/otel_tracing/requirement.md
@@ -1,0 +1,49 @@
+# Workflow Tracing Requirements
+
+## Overview
+The observability initiative for Milestone 6 is shifting toward a dedicated tracing experience. We must expose OpenTelemetry trace data for every workflow run and present it inside the Canvas application so operators can inspect execution behavior, prompts, token usage, artifacts, and system health in one place.
+
+## Goals
+- Provide a first-class "Trace" tab within the Canvas workflow page that visualizes the trace tree for the active execution.
+- Capture per-step prompt/response payloads, token metrics, and generated artifacts as trace span attributes.
+- Surface links or embedded previews for artifacts generated during a workflow run.
+- Enable operators to diagnose latency, failure points, and infrastructure issues using trace metadata and dashboards.
+
+## In Scope
+- Integrating OpenTelemetry instrumentation into workflow execution services to emit spans for workflows and individual nodes.
+- Persisting trace identifiers and minimal metadata required to retrieve trace data for a given execution.
+- Backend API endpoints or proxies that return trace content tailored for the Canvas experience.
+- Canvas UI work to fetch, render, and interact with the trace data, including token and artifact details.
+- Documentation updates covering setup, configuration, and user guidance for tracing.
+
+## Out of Scope
+- Long-term storage and retention policies beyond the MVP retention window (to be defined later).
+- Third-party collector deployment or hosted tracing infrastructure; the MVP targets compatibility with an existing OpenTelemetry collector endpoint provided by operators.
+- Retrofitting legacy execution viewers outside the Canvas workflow page.
+
+## Success Criteria
+- Users can open the Trace tab for any execution and see a hierarchical view of spans, each annotated with prompts/responses, token counts, durations, and status.
+- Artifact downloads or inline previews are accessible from the associated span entries.
+- Trace metadata is queryable via API within <300 ms for recent executions.
+- Instrumentation is gated behind configuration toggles so environments without OpenTelemetry collectors continue to function without errors.
+- Monitoring dashboards (e.g., Grafana/Tempo or similar) can ingest the emitted spans without custom adapters.
+
+## Assumptions
+- An OpenTelemetry collector endpoint is available and reachable from backend services.
+- Workflow executions already have stable identifiers that can be correlated with trace IDs.
+- Frontend teams can extend existing state management patterns to include trace data without rewriting the entire Canvas layout.
+
+## Dependencies
+- OpenTelemetry SDK packages for Python backend services.
+- Frontend visualization components (potentially third-party timeline/tree libraries) that can render nested spans.
+- Backend storage layer capable of persisting additional trace metadata.
+
+## Risks
+- High volume of span attributes (prompts, responses, artifacts) increasing payload sizes and impacting performance.
+- Instrumentation errors causing execution slowdowns or failures when the collector is unavailable.
+- UI complexity leading to confusing trace navigation without careful UX design.
+
+## Compliance & Security Considerations
+- Sensitive prompt or response content must be redacted or protected in accordance with data handling policies.
+- Trace endpoints must enforce the same authorization scope as execution history APIs.
+- Token and artifact data should respect existing audit logging and access controls.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ### Milestone 6 – Observability, Testing & Launch Prep
 - [x] Implement end-to-end authentication layer (OIDC integration, service tokens, ChatKit session hardening, webhook signatures) per [Authentication System Design](./authentication_design.md).
 - [x] ChatKit public page + workflow publish UX (CLI) and backend actions
-- [ ] Instrument execution viewer with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
+- [ ] Deliver a dedicated workflow tracing tab with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
 - [ ] Establish success metrics tracking (uv installs, GitHub stars, quickstart completion rate, failure backlog) and analytics pipelines.
 - [ ] Produce onboarding docs, templates, SDK examples, closed-beta playbook, and feedback/A-B testing loops for AI node recommendations.
 - [ ] Run end-to-end reliability tests, load tests on React Flow canvas, finalize beta rollout plan, and prepare Phase 1/Phase 2 regional launch gates.


### PR DESCRIPTION
## Summary
- Reframed the Milestone 6 observability task to highlight the dedicated workflow tracing tab
- Added OpenTelemetry tracing requirements, design, and implementation plan documents under docs/otel_tracing/

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ba9e061c83278baca2067c4ef13d)