### PR TITLE
docs: document workflow tracing initiative

### DIFF
--- a/docs/otel_tracing/design.md
+++ b/docs/otel_tracing/design.md
@@ -1,0 +1,72 @@
+# Workflow Tracing Design
+
+## Architecture Overview
+The tracing solution spans backend instrumentation, data persistence, API exposure, and frontend visualization. Each workflow execution will emit OpenTelemetry spans that capture node-level activity, enriched with prompts/responses, token usage, artifacts, and status metadata. The backend persists trace identifiers and selected span attributes for fast retrieval, while exporting full traces to the centralized OpenTelemetry Collector. The Canvas UI fetches structured trace data through a new API and renders it in a dedicated Trace tab.
+
+```
+Canvas Trace Tab ─▶ Trace API (FastAPI) ─▶ Trace Store (Postgres/History) ─▶ OTel SDK ─▶ OTel Collector ─▶ Grafana/Jaeger
+                                              │
+                                              └──── Workflow Execution Engine (LangGraph runtime)
+```
+
+## Backend Components
+### Instrumentation
+- Integrate `opentelemetry-sdk` and `opentelemetry-exporter-otlp` within `apps/backend` startup.
+- Create a `WorkflowTracer` utility that wraps LangGraph execution, creating a root span per execution and child spans for each node (and optionally for external integrations).
+- Capture span attributes: node ID/type, start/end timestamps, status, token counts, prompt hashes, artifact IDs, error stacks.
+
+### Persistence
+- Extend `RunHistoryStore` schema with columns for `trace_id`, `root_span_id`, and lightweight summary data (e.g., total_tokens, span_count).
+- Persist detailed span payloads in a JSONB column or companion table keyed by span ID to enable structured API responses without rehydrating from the collector.
+- Migrations managed via Alembic (backend) and SQLAlchemy models.
+
+### APIs
+- Add `/executions/{execution_id}/trace` endpoint returning:
+  - `trace_id`
+  - `spans`: hierarchical list with `span_id`, `parent_id`, `name`, `start_time`, `end_time`, `status`, `attributes`, `events`
+  - `artifacts`: references with download URLs
+  - `tokens`: aggregated counts per span and total
+- Guard endpoint with existing authentication/authorization middleware.
+- Provide pagination or chunking for large traces (e.g., >500 spans).
+
+### Export Pipeline
+- Configure OTLP exporter to send spans to the collector with batching and retry policies.
+- Ensure prompts/responses respect redaction; store redacted versions in span attributes but keep raw text only where secure.
+
+## Frontend Components
+### Data Fetching
+- Introduce `fetchExecutionTrace(executionId)` in Canvas data layer using existing API client patterns.
+- Extend workflow execution state to store `trace` data keyed by execution ID with loading/error states.
+
+### UI Layout
+- Update Tabs component to include `Trace` tab after `Execution`.
+- Implement `TraceTabContent` with three panes:
+  1. **Span Tree**: collapsible hierarchy showing span names, status badges, duration.
+  2. **Details Panel**: displays selected span attributes, prompts/responses, token metrics, artifacts.
+  3. **Metrics Summary**: aggregates totals (duration, token usage, artifacts) and provides download links.
+- Reuse design system components (TreeView, Accordion, Tag, Table) to ensure consistency.
+
+### Interactions
+- Selecting a span updates the Details panel.
+- Provide filter toggles (errors only, AI spans only) and search by span name.
+- Allow artifact downloads via existing download service.
+- Display a placeholder state when no trace is available.
+
+## Security & Privacy
+- Redact secrets before span export.
+- Enforce role-based access control identical to Execution tab permissions.
+- Include audit logging for trace view access if required by compliance.
+
+## Performance Considerations
+- Batch trace API responses and compress JSON (gzip).
+- Limit prompt/response previews to first N characters with expandable sections to avoid large payloads.
+- Cache recent traces in memory (TTL cache) to reduce database hits for repeated views.
+
+## Monitoring & Observability
+- Emit metrics for trace ingestion success/failure.
+- Add alerting for trace export failures and API latency spikes.
+
+## Open Questions
+1. Do we need to support live (in-progress) traces, or only completed executions?
+2. Should artifact binaries be linked directly or proxied through signed URLs?
+3. What retention period is acceptable for stored span payloads in the history database?

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -1,0 +1,62 @@
+# Workflow Tracing Implementation Plan
+
+## Phase 1 – Foundations (Week 1)
+1. **Project Setup**
+   - Add OpenTelemetry dependencies to root and backend `pyproject.toml` files.
+   - Configure local/dev collector endpoints and environment variables.
+2. **Schema Preparation**
+   - Design database migrations for `trace_id`, `root_span_id`, and span payload storage.
+   - Update SQLAlchemy models and repository interfaces.
+3. **Execution Instrumentation Spike**
+   - Prototype `WorkflowTracer` wrapping a single workflow run.
+   - Validate trace emission through the collector (Jaeger or Grafana Tempo).
+
+## Phase 2 – Backend Delivery (Weeks 2–3)
+1. **Full Instrumentation**
+   - Integrate tracer into workflow execution engine, node runners, and external integrations.
+   - Ensure prompts/responses/token metrics captured with redaction.
+2. **Persistence & Retrieval**
+   - Finalize migrations and data access logic for storing span payloads.
+   - Implement repository methods to fetch trace structures by execution ID.
+3. **API Development**
+   - Build `/executions/{execution_id}/trace` FastAPI route with serializers and pagination.
+   - Add authentication/authorization, error handling, and 404s for missing traces.
+4. **Testing**
+   - Unit tests for tracer, repositories, and API schemas.
+   - Integration test covering execution-to-trace flow.
+
+## Phase 3 – Frontend Integration (Weeks 3–4)
+1. **State & Data Fetching**
+   - Extend Canvas state management and API client with trace fetching logic.
+   - Add loading/error handling and caching for traces.
+2. **Trace Tab UI**
+   - Implement tab trigger and content container in layout components.
+   - Build span tree, details panel, and metrics summary using design system components.
+3. **Artifact & Prompt Handling**
+   - Wire artifact download links and prompt/response display with redaction indicators.
+4. **Frontend Testing**
+   - Add unit and component tests for trace fetch hook and UI interactions.
+   - Run accessibility checks on new tab.
+
+## Phase 4 – Observability & Rollout (Week 5)
+1. **Monitoring**
+   - Configure exporter metrics and dashboards for trace throughput and errors.
+   - Set alerts for missing traces or API latency spikes.
+2. **Documentation & Enablement**
+   - Update docs (user guide, runbook) and internal onboarding materials.
+   - Provide troubleshooting guide for trace ingestion.
+3. **Beta Launch**
+   - Enable feature flag for selected tenants, gather feedback, iterate on UI/UX.
+   - Prepare GA checklist (performance, security review, support training).
+
+## Risks & Mitigations
+- **Large Trace Payloads**: Implement payload size guards and server-side filtering.
+- **Collector Downtime**: Buffer spans locally with retry policy; alert on exporter failures.
+- **PII Exposure**: Enforce redaction pipeline and add automated tests verifying sensitive fields are masked.
+- **UI Performance**: Virtualize span list for workflows with hundreds of spans.
+
+## Deliverables
+- Updated roadmap entry, requirements, design, and implementation plan documentation.
+- Backend instrumentation with persisted traces and API.
+- Canvas Trace tab with visualization and artifact access.
+- Monitoring dashboards and alerting for trace pipeline health.

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -2,7 +2,7 @@
 
 ## Phase 1 – Foundations (Week 1)
 1. **Project Setup**
-   - Add OpenTelemetry dependencies to root and backend `pyproject.toml` files.
+   - Add OpenTelemetry dependencies to root and backend `pyproject.toml` files: `opentelemetry-sdk==1.27.0`, `opentelemetry-exporter-otlp==1.27.0`, and `opentelemetry-instrumentation-fastapi==0.48b0`. Verify transitive pins do not conflict with the existing FastAPI/uvicorn stack.
    - Configure local/dev collector endpoints and environment variables.
 2. **Schema Preparation**
    - Design database migrations for `trace_id`, `root_span_id`, and span payload storage.
@@ -23,7 +23,8 @@
    - Add authentication/authorization, error handling, and 404s for missing traces.
 4. **Testing**
    - Unit tests for tracer, repositories, and API schemas.
-   - Integration test covering execution-to-trace flow.
+   - Integration test covering execution-to-trace flow: execute a sample workflow, assert spans persisted in Postgres companion table, and validate API pagination cursors.
+   - Add a load test (Locust or pytest-benchmark) that exercises a 250-span trace to ensure the `/trace` endpoint returns within the 2-second SLA.
 
 ## Phase 3 – Frontend Integration (Weeks 3–4)
 1. **State & Data Fetching**

--- a/docs/otel_tracing/requirement.md
+++ b/docs/otel_tracing/requirement.md
@@ -1,0 +1,43 @@
+# Workflow Tracing Requirement
+
+## Objective
+Provide end-to-end OpenTelemetry-based tracing for Canvas workflow executions so operators can inspect spans, prompts, token usage, artifacts, and system metrics for each run through a dedicated "Trace" tab in the Canvas UI.
+
+## Scope
+- **Workflows**: All Canvas-triggered executions, including manual, scheduled, and webhook-based runs.
+- **Environments**: Local development, staging, and production deployments.
+- **Trace Depth**: Root workflow span plus child spans per node execution and per external service interaction (LLM, HTTP request, storage, etc.).
+- **Data Modalities**: Prompt/response payloads (with redaction), token counts, runtime metrics (duration, status), linked artifacts, and error information.
+
+## Success Criteria
+1. Every workflow execution has a trace ID stored alongside run history data.
+2. The backend exposes an authenticated API that returns a structured trace tree for a workflow execution, including prompts, responses, token metrics, artifacts, and span metadata.
+3. Canvas UI includes a Trace tab that loads and visualizes the trace for the selected execution within 2 seconds over typical broadband.
+4. Users can download artifacts and copy prompt/response text from the Trace tab without leaving the page.
+5. System dashboards (Grafana/OTel collector) can ingest emitted traces for fleet-wide monitoring.
+
+## Non-Goals
+- Replacing existing execution logs or readiness checks.
+- Providing editing or replay capabilities directly from the Trace tab.
+- Implementing organization-wide trace retention policies (handled separately).
+
+## Stakeholders
+- **Primary Users**: Workflow developers, SREs monitoring runtime behavior, customer support debugging user workflows.
+- **Supporting Teams**: Backend platform team, Canvas frontend team, DevOps/observability team.
+
+## Constraints & Assumptions
+- OpenTelemetry Collector is available and reachable from backend services.
+- Sensitive data in prompts/responses must respect existing redaction rules.
+- Trace payload size must remain under 1 MB per execution to avoid storage pressure.
+- UI must conform to existing Canvas design system components.
+
+## Metrics & KPIs
+- Trace coverage rate (% of executions with trace data).
+- Median Trace tab load time.
+- Number of trace-assisted incident resolutions (qualitative, via support tickets).
+- Error rate of trace ingestion/exporter pipeline.
+
+## Dependencies
+- Existing run history persistence layer.
+- Canvas workflow execution selection state.
+- Infrastructure for hosting OpenTelemetry Collector and dashboards.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,7 @@ This roadmap consolidates Orcheo's milestone sequencing and task backlog in a si
 ### Milestone 6 – Observability, Testing & Launch Prep
 - [x] Implement end-to-end authentication layer (OIDC integration, service tokens, ChatKit session hardening, webhook signatures) per [Authentication System Design](./authentication_design.md).
 - [x] ChatKit public page + workflow publish UX (CLI) and backend actions
-- [ ] Instrument execution viewer with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
+- [ ] Deliver a dedicated workflow tracing tab with per-step prompts/responses, token metrics, artifact downloads, and monitoring dashboards.
 - [ ] Establish success metrics tracking (uv installs, GitHub stars, quickstart completion rate, failure backlog) and analytics pipelines.
 - [ ] Produce onboarding docs, templates, SDK examples, closed-beta playbook, and feedback/A-B testing loops for AI node recommendations.
 - [ ] Run end-to-end reliability tests, load tests on React Flow canvas, finalize beta rollout plan, and prepare Phase 1/Phase 2 regional launch gates.


### PR DESCRIPTION
## Summary
- update the Milestone 6 roadmap task to call out the dedicated workflow tracing tab
- add requirements, design, and implementation plan docs for the OpenTelemetry tracing feature

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ba9e061c83278baca2067c4ef13d)