### PR TITLE
Add OpenTelemetry configuration and rollout documentation

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -21,6 +21,18 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware ([factory.py](../apps/backend/src/orcheo_backend/app/factory.py)). |
 | `ORCHEO_CHATKIT_PUBLIC_BASE_URL` | _none_ | HTTP(S) URL | Optional frontend origin used when generating ChatKit share links in the CLI/MCP; defaults to `ORCHEO_API_URL` with any `/api` suffix removed when unset ([publish.py](../packages/sdk/src/orcheo_sdk/services/workflows/publish.py)). One-off overrides can be supplied via `orcheo workflow publish --chatkit-public-base-url`. |
 
+## Tracing configuration
+
+| Variable | Default | Valid values | Purpose |
+| --- | --- | --- | --- |
+| `ORCHEO_TRACING_EXPORTER` | `none` | `none`, `console`, `otlp` | Chooses the span exporter. `console` writes spans to stdout, while `otlp` streams spans to an OTLP/HTTP endpoint ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_ENDPOINT` | _none_ | HTTP URL | Optional OTLP collector endpoint forwarded to the exporter when `otlp` is selected ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | String | Resource name advertised with each span for downstream attribution ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Float 0.0–1.0 | Probability-based sampler applied to workflow traces. Values outside the range raise validation errors ([config/app_settings.py](../src/orcheo/config/app_settings.py)). |
+| `ORCHEO_TRACING_INSECURE` | `false` | Boolean | Allows connecting to collectors with self-signed certificates when set to `true` ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Positive integer | Threshold for raising `token.chunk` events whenever a node consumes or emits more tokens than expected ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Positive integer | Maximum number of prompt/response characters persisted for previewing inside the Trace tab ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
+
 ## Vault configuration
 
 | Variable | Default | Valid values | Purpose |

--- a/docs/otel_tracing/configuration.md
+++ b/docs/otel_tracing/configuration.md
@@ -1,0 +1,83 @@
+# OpenTelemetry Configuration & Trace Tab Guide
+
+The tracing feature stitches together backend instrumentation, an OpenTelemetry (OTel) collector, and the Canvas Trace tab. This guide explains how to configure exporters, roll the feature out safely, and make the most of the Trace UI once telemetry is flowing.
+
+## Runtime configuration
+
+Tracing is controlled entirely through environment variables exposed by `AppSettings` and the Dynaconf loader. Values are read from the `ORCHEO_` namespace and fallback to the defaults defined in `src/orcheo/config/defaults.py`.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ORCHEO_TRACING_EXPORTER` | `none` | Selects the exporter backend. Supported values are `none`, `console`, or `otlp`. The backend automatically configures a `TracerProvider` with batching when tracing is enabled. |
+| `ORCHEO_TRACING_ENDPOINT` | _unset_ | Optional OTLP endpoint (HTTP) forwarded to `OTLPSpanExporter`. Leave blank for collectors running on `http://localhost:4318`. |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | Service resource name published with every span. Useful for multi-service deployments. |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Fraction of traces sampled by the backend sampler. Accepts floats in `[0.0, 1.0]`. |
+| `ORCHEO_TRACING_INSECURE` | `false` | When `true`, disables TLS verification on OTLP HTTP exports. Only use for local or trusted collectors. |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Token count above which `token.chunk` span events are emitted. Reducing the value surfaces unusually large prompts/responses sooner. |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Maximum number of characters preserved when prompts/responses are truncated for span previews. |
+
+Update the variables in your deployment manifest (Kubernetes `ConfigMap`, Docker Compose environment, etc.) and restart the backend. No code changes are necessary after toggling these settings.
+
+### Recommended scenarios
+
+- **Local verification** – Set `ORCHEO_TRACING_EXPORTER=console` to log spans directly to stdout. Combine with a low sample ratio to limit noise while validating instrumentation.
+- **Staging** – Use OTLP with a short retention window to confirm collector wiring. Example: `ORCHEO_TRACING_EXPORTER=otlp`, `ORCHEO_TRACING_ENDPOINT=https://otel-staging.internal:4318`, `ORCHEO_TRACING_SAMPLE_RATIO=0.5`.
+- **Production** – Point at the managed collector/observability backend, keep sampling near 1.0 for critical workflows, and tune thresholds to balance fidelity and storage.
+
+## Sample OpenTelemetry Collector
+
+The backend emits OTLP/HTTP spans. The snippet below shows a minimal collector configuration that receives OTLP data, attaches resource attributes, and forwards traces to Tempo and Honeycomb simultaneously.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch: {}
+  attributes/add_deployment:
+    actions:
+      - key: deployment.environment
+        value: "staging"
+        action: insert
+exporters:
+  logging:
+    verbosity: detailed
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  otlp/honeycomb:
+    endpoint: api.honeycomb.io:443
+    headers:
+      x-honeycomb-team: ${HONEYCOMB_API_KEY}
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch, attributes/add_deployment]
+      exporters: [logging, otlp/tempo, otlp/honeycomb]
+```
+
+Deploy the collector close to the backend to avoid exporting spans over the public internet. When testing locally, run the collector alongside the backend and point `ORCHEO_TRACING_ENDPOINT` to `http://localhost:4318`.
+
+## Troubleshooting
+
+1. **Trace tab stays empty** – Confirm that the backend exporter is enabled (`ORCHEO_TRACING_EXPORTER` not `none`) and that the collector is accepting spans. The backend logs a warning if the exporter fails to initialise or the OTLP dependency is missing.
+2. **`RuntimeError: OTLP exporter requested but dependency unavailable`** – Install `opentelemetry-exporter-otlp` in the backend environment or switch to the console exporter temporarily. The backend raises this exception during startup when OTLP support is missing.
+3. **TLS handshake failures** – Set `ORCHEO_TRACING_INSECURE=true` for test environments using self-signed certificates, or supply the collector's CA bundle via standard TLS configuration variables.
+4. **Missing prompt/response previews** – Increase `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` to preserve longer snippets in span events. Prompts larger than the preview limit are still exported to the collector but truncated in the Orcheo UI.
+5. **High-volume workflows overwhelm storage** – Reduce `ORCHEO_TRACING_SAMPLE_RATIO` or raise `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` to limit auxiliary span events.
+
+## Using the Trace tab
+
+Once tracing is configured, the Canvas UI automatically surfaces spans under the **Trace** tab on each workflow run:
+
+1. Select a workflow execution from the run history. The Trace tab becomes available next to the existing editor and execution tabs.
+2. The client calls `/api/executions/{execution_id}/trace` and streams live updates over the existing WebSocket channel, so traces populate even while a run is still executing.
+3. Use the search box to filter spans by name or attribute and the expand/collapse controls to adjust the tree view. Span lists, token usage summaries, and status badges are kept in sync with backend updates.
+4. Click any span to view prompts, responses, and artifact links in the details panel. Artifact links resolve through the backend `/api/artifacts/{id}/download` endpoint, letting you inspect model outputs without leaving the page.
+5. When issues arise, press **Refresh trace** in the tab header to re-fetch the latest snapshot; the client retries automatically if live updates pause.
+
+Tip: keep the Trace tab open during complex runs—`useExecutionTrace` automatically resubscribes when you change the active execution, so you can flip between runs without losing context.

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -19,7 +19,7 @@
 - [x] Write frontend tests (Vitest + React Testing Library) for tab rendering, data loading, and interaction states.
 
 ## Phase 4 – Configuration, Documentation, & QA
-- [ ] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
-- [ ] Provide sample collector configuration and troubleshooting guidance.
-- [ ] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
-- [ ] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.
+- [x] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
+- [x] Provide sample collector configuration and troubleshooting guidance.
+- [x] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
+- [x] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.

--- a/docs/otel_tracing/release_rollout.md
+++ b/docs/otel_tracing/release_rollout.md
@@ -1,0 +1,25 @@
+# Trace Tab Release Notes & Rollout Checklist
+
+## Release notes
+
+- **Backend instrumentation** – Workflow executions now emit OpenTelemetry spans for the root run and every node, capturing prompts, responses, token counts, artifacts, and error details. The tracer provider supports console and OTLP exporters with sampling controls. See `src/orcheo/tracing/provider.py` and `src/orcheo/tracing/workflow.py` for implementation specifics.
+- **Trace retrieval API** – The backend exposes `/api/executions/{execution_id}/trace`, returning execution metadata, span hierarchies, and pagination data. Live executions push incremental updates over the existing WebSocket channel. Refer to `apps/backend/src/orcheo_backend/app/routers/runs.py` and `apps/backend/src/orcheo_backend/app/trace_utils.py`.
+- **Canvas Trace tab** – The Canvas UI adds a Trace tab with tree navigation, search, and span details. Data is sourced via `useExecutionTrace`, which fetches traces, subscribes to realtime updates, and resolves artifact download links. Relevant entry points live in `apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/use-execution-trace.ts` and the trace viewer components under `apps/canvas/src/features/workflow/components/trace/`.
+
+## Rollout checklist
+
+### Staging
+
+- [ ] Enable tracing in the backend environment (e.g., set `ORCHEO_TRACING_EXPORTER=otlp` and point `ORCHEO_TRACING_ENDPOINT` to the staging collector).
+- [ ] Deploy or update the staging collector using the sample configuration in [configuration.md](./configuration.md), confirming spans appear in the observability backend.
+- [ ] Run smoke workflows and verify trace trees render in Canvas, including live updates and artifact links.
+- [ ] Validate performance by monitoring collector and database load while executing high-fanout workflows.
+- [ ] Collect feedback from QA on Trace tab usability, accessibility, and error states; address any regressions.
+
+### Production
+
+- [ ] Review staging findings and adjust sampling thresholds or preview lengths as needed for production scale.
+- [ ] Coordinate deployment timing with observability owners to ensure the production collector is available and sized appropriately.
+- [ ] Roll out backend configuration changes (environment variables and dependency updates) via the standard release pipeline.
+- [ ] Announce availability to internal stakeholders, highlighting new monitoring capabilities and links to Tempo/Honeycomb dashboards if applicable.
+- [ ] Monitor error budgets and collector health during the first 24 hours; be prepared to fall back to the console exporter or disable tracing if service degradation occurs.


### PR DESCRIPTION
## Summary
- add a dedicated OpenTelemetry configuration and troubleshooting guide that covers runtime variables, deployment scenarios, and Trace tab usage
- document tracing-related environment variables alongside existing backend configuration reference material
- capture release notes plus staging and production rollout checklists for the Trace tab and mark the Phase 4 plan items complete

## Testing
- uv run make lint
- uv run make test
- uv run make canvas-lint
- uv run make canvas-test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165c0ed37c8327ae573e3a1a0c422e)