### PR TITLE
Add OpenTelemetry configuration docs and release guidance

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -21,6 +21,18 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware ([factory.py](../apps/backend/src/orcheo_backend/app/factory.py)). |
 | `ORCHEO_CHATKIT_PUBLIC_BASE_URL` | _none_ | HTTP(S) URL | Optional frontend origin used when generating ChatKit share links in the CLI/MCP; defaults to `ORCHEO_API_URL` with any `/api` suffix removed when unset ([publish.py](../packages/sdk/src/orcheo_sdk/services/workflows/publish.py)). One-off overrides can be supplied via `orcheo workflow publish --chatkit-public-base-url`. |
 
+## Tracing configuration
+
+| Variable | Default | Valid values | Purpose |
+| --- | --- | --- | --- |
+| `ORCHEO_TRACING_EXPORTER` | `none` | `none`, `otlp`, or `console` | Selects the tracing exporter used by [`tracing/provider.py`](../src/orcheo/tracing/provider.py). Set to `otlp` to forward spans to a collector, or `console` to log them locally. |
+| `ORCHEO_TRACING_ENDPOINT` | _none_ | HTTP(S) URL | OTLP/HTTP endpoint required when using the OTLP exporter (for example `https://otel-collector:4318/v1/traces`). |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | String | Service name reported in span resources, useful when multiple Orcheo clusters send data to the same backend. |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Float between 0 and 1 | Probability that a workflow trace is sampled. Lower the ratio in high-volume environments to control storage. |
+| `ORCHEO_TRACING_INSECURE` | `false` | Boolean | When true, disables TLS verification for OTLP exporters. Use only for local testing with self-signed collectors. |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Positive integer | Token count that highlights spans in the Canvas Trace tab metrics summary ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Positive integer | Maximum number of characters shown for prompt/response previews in span detail panels ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
+
 ## Vault configuration
 
 | Variable | Default | Valid values | Purpose |

--- a/docs/otel_tracing/configuration.md
+++ b/docs/otel_tracing/configuration.md
@@ -3,7 +3,7 @@
 This guide explains how to configure OpenTelemetry tracing in Orcheo, how the
 backend and Canvas UI collaborate to surface workflow traces, and what to do
 when instrumentation misbehaves. Combine this document with the
-[environment variable reference](../environment_variables.md) when rolling out
+[environment variable reference](../environment_variables.md#tracing-configuration) when rolling out
 tracing to new environments.
 
 ## Backend configuration
@@ -19,7 +19,7 @@ networking, and UI thresholds:
 | `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | Service name reported in span resources. Override when running multiple Orcheo clusters. |
 | `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Probability (0‑1) that a trace will be recorded. Reduce in high-traffic environments to control cardinality. |
 | `ORCHEO_TRACING_INSECURE` | `false` | When `true`, disables TLS verification for the OTLP exporter (useful for local collectors with self-signed certificates). |
-| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Token count that marks span metrics as "high usage" in the Trace tab summary. |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Token count that marks span metrics as "high usage" in the Trace tab summary. When a span exceeds this value the backend emits a `token.chunk` event with `reason="high_usage"`, prompting the Trace tab to highlight the span's token totals. |
 | `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Maximum number of characters shown for prompt/response previews within span details. |
 
 > **Tip:** For containerized deployments, mount a config map or secret with the
@@ -91,6 +91,10 @@ Deploy the collector alongside the backend and set
    are truncated using `ORCHEO_TRACING_PREVIEW_MAX_LENGTH`.
 4. Use the metrics summary to identify spans with elevated token usage and
    download attachments when available.
+
+Spans that emit the `token.chunk` event because they crossed
+`ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` appear with a warning badge in the
+metrics summary so operators can review them first.
 
 WebSocket updates stream new spans into the tree while a run is in progress; the
 final state is cached by the trace retrieval API for historical review.

--- a/docs/otel_tracing/configuration.md
+++ b/docs/otel_tracing/configuration.md
@@ -1,0 +1,111 @@
+# OpenTelemetry Configuration & Trace Tab Guide
+
+This guide explains how to configure OpenTelemetry tracing in Orcheo, how the
+backend and Canvas UI collaborate to surface workflow traces, and what to do
+when instrumentation misbehaves. Combine this document with the
+[environment variable reference](../environment_variables.md) when rolling out
+tracing to new environments.
+
+## Backend configuration
+
+Orcheo loads tracing options from Dynaconf settings and the `ORCHEO_`
+environment prefix. The following variables control exporter selection,
+networking, and UI thresholds:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ORCHEO_TRACING_EXPORTER` | `none` | Selects the exporter implementation registered by `orcheo.tracing.provider`. Supported values are `none`, `otlp`, and `console`. |
+| `ORCHEO_TRACING_ENDPOINT` | _none_ | OTLP endpoint URL (e.g. `https://otel-collector:4318/v1/traces`). Required when `ORCHEO_TRACING_EXPORTER=otlp`. |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | Service name reported in span resources. Override when running multiple Orcheo clusters. |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Probability (0‑1) that a trace will be recorded. Reduce in high-traffic environments to control cardinality. |
+| `ORCHEO_TRACING_INSECURE` | `false` | When `true`, disables TLS verification for the OTLP exporter (useful for local collectors with self-signed certificates). |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Token count that marks span metrics as "high usage" in the Trace tab summary. |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Maximum number of characters shown for prompt/response previews within span details. |
+
+> **Tip:** For containerized deployments, mount a config map or secret with the
+> desired `ORCHEO_TRACING_*` values and pass them to both the backend service
+> and asynchronous worker pods.
+
+## Deployment considerations
+
+### Local development
+
+- Set `ORCHEO_TRACING_EXPORTER=console` to log spans to stdout while iterating.
+- Alternatively, run a local collector (`docker run otel/opentelemetry-collector`) and
+  point `ORCHEO_TRACING_ENDPOINT` to `http://localhost:4318/v1/traces`.
+- Leave `ORCHEO_TRACING_SAMPLE_RATIO=1.0` so every workflow execution surfaces in the Trace tab.
+
+### Staging environments
+
+- Use the OTLP exporter with TLS (`https://`) and keep `ORCHEO_TRACING_INSECURE=false`.
+- Configure the collector to forward traces to your preferred backend (Tempo, Jaeger, Honeycomb, etc.).
+- Start with `ORCHEO_TRACING_SAMPLE_RATIO=0.5` if staging handles load tests; adjust after monitoring storage/ingest costs.
+
+### Production environments
+
+- Define a unique `ORCHEO_TRACING_SERVICE_NAME` per cluster or region for quicker filtering downstream.
+- Tune `ORCHEO_TRACING_SAMPLE_RATIO` based on steady-state RPS and trace retention policies (e.g. 0.1 for large clusters).
+- Monitor collector queue metrics; increase batch sizes or add sharding if exporters report backpressure.
+- Ensure the Trace tab still provides useful previews by keeping `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` ≥ 256.
+
+## Sample OTLP collector configuration
+
+The snippet below wires the Orcheo backend to an OTLP/HTTP collector that
+forwards data to Grafana Tempo. Adapt exporters/receivers for your vendor:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/tempo:
+    endpoint: https://tempo.example.com:4318
+    headers:
+      Authorization: Bearer ${TEMPO_API_TOKEN}
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_max_size: 1024
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/tempo]
+```
+
+Deploy the collector alongside the backend and set
+`ORCHEO_TRACING_ENDPOINT=http://otel-collector:4318/v1/traces`.
+
+## Trace tab usage
+
+1. Open a workflow in the Canvas UI and trigger an execution.
+2. Select the **Trace** tab to visualize span hierarchy, token metrics, and
+   referenced artifacts in real time.
+3. Click a span to inspect prompts, responses, and emitted events. Long values
+   are truncated using `ORCHEO_TRACING_PREVIEW_MAX_LENGTH`.
+4. Use the metrics summary to identify spans with elevated token usage and
+   download attachments when available.
+
+WebSocket updates stream new spans into the tree while a run is in progress; the
+final state is cached by the trace retrieval API for historical review.
+
+## Troubleshooting
+
+- **No spans visible:** Confirm `ORCHEO_TRACING_EXPORTER` is not `none` and the
+  collector endpoint is reachable from the backend (check for `403`/`503`
+  responses in logs).
+- **Missing live updates:** Ensure the Canvas client can reach the WebSocket
+  endpoint (`/ws/workflows`). Network proxies that strip WebSocket upgrades will
+  prevent real-time span delivery.
+- **TLS errors:** Set `ORCHEO_TRACING_INSECURE=true` only in non-production
+  environments while you install trusted certificates on the collector.
+- **High-cardinality storage costs:** Lower `ORCHEO_TRACING_SAMPLE_RATIO` or
+  configure rate limiting in the collector's batch processor.
+- **Preview truncation feels aggressive:** Increase
+  `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` and restart the backend to apply.

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -19,7 +19,7 @@
 - [x] Write frontend tests (Vitest + React Testing Library) for tab rendering, data loading, and interaction states.
 
 ## Phase 4 – Configuration, Documentation, & QA
-- [ ] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
-- [ ] Provide sample collector configuration and troubleshooting guidance.
-- [ ] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
-- [ ] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.
+- [x] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
+- [x] Provide sample collector configuration and troubleshooting guidance.
+- [x] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
+- [x] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.

--- a/docs/otel_tracing/release_plan.md
+++ b/docs/otel_tracing/release_plan.md
@@ -4,6 +4,12 @@ This document captures the user-facing release notes for the Trace tab along
 with the steps required to enable OpenTelemetry tracing safely in staging and
 production.
 
+### Release identifiers
+
+- Backend: `backend-v0.10.0`
+- Canvas bundle: build from commit matching `backend-v0.10.0` (update if the
+  frontend tag differs at release time).
+
 ## Release notes
 
 - Introduces a **Trace** tab on the workflow Canvas that streams OpenTelemetry

--- a/docs/otel_tracing/release_plan.md
+++ b/docs/otel_tracing/release_plan.md
@@ -1,0 +1,46 @@
+# Trace Tab Release Notes & Rollout Checklist
+
+This document captures the user-facing release notes for the Trace tab along
+with the steps required to enable OpenTelemetry tracing safely in staging and
+production.
+
+## Release notes
+
+- Introduces a **Trace** tab on the workflow Canvas that streams OpenTelemetry
+  spans for each execution.
+- Displays token usage summaries, prompt/response previews, span events, and
+  downloadable artifact references.
+- Adds backend configuration to select OTLP exporters, sampling ratios, and
+  preview limits via `ORCHEO_TRACING_*` environment variables.
+- Ships WebSocket updates so operators can debug long-running workflows without
+  polling.
+
+## Rollout checklist
+
+### Staging
+
+1. Deploy the latest backend build with tracing instrumentation.
+2. Provision or reuse an OTLP collector; update `ORCHEO_TRACING_EXPORTER=otlp`
+   and `ORCHEO_TRACING_ENDPOINT` in staging secrets.
+3. Set `ORCHEO_TRACING_SERVICE_NAME=orcheo-staging` for easier filtering.
+4. Validate collector connectivity by running a workflow and confirming spans in
+   the Trace tab and downstream backend (Tempo/Jaeger/etc.).
+5. Exercise the Canvas UI and ensure WebSocket updates flow in corporate network
+   conditions.
+6. Capture screenshots and update runbooks if the Trace tab behavior differs
+   from expectations.
+
+### Production
+
+1. Mirror the staging configuration while adjusting secrets/hostnames for
+   production collectors.
+2. Decide on an initial `ORCHEO_TRACING_SAMPLE_RATIO` based on production RPS; a
+   conservative starting point is `0.25`.
+3. Enable feature flags or config toggles that expose the Trace tab to end users
+   (if using a gradual rollout strategy).
+4. Monitor collector telemetry (queue size, error rates) and Canvas performance
+   during the first 24 hours. Increase resources if spans backlog.
+5. Communicate availability to stakeholders and document escalation contacts for
+   tracing-related incidents.
+6. Schedule a follow-up review after one week to adjust sampling, retention, or
+   UI thresholds based on observed usage.


### PR DESCRIPTION
## Summary
- add a dedicated OpenTelemetry configuration and Trace tab guide with deployment notes and troubleshooting tips
- document tracing environment variables and add release notes plus rollout checklist for staging and production
- mark Phase 4 tasks in the tracing implementation plan as complete

## Testing
- make lint
- make test
- make canvas-lint
- make canvas-test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165c0ed37c8327ae573e3a1a0c422e)