### PR TITLE
Document tracing configuration and rollout guidance

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -19,6 +19,13 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_HOST` | `0.0.0.0` | Hostname or IP string | Network interface to bind the FastAPI app ([config/loader.py](../src/orcheo/config/loader.py)). |
 | `ORCHEO_PORT` | `8000` | Integer (1‑65535) | TCP port exposed by the FastAPI service ([config/loader.py](../src/orcheo/config/loader.py)). |
 | `ORCHEO_CORS_ALLOW_ORIGINS` | `["http://localhost:5173","http://127.0.0.1:5173"]` | JSON array or comma-separated list of origins | CORS allow-list used when constructing the FastAPI middleware ([factory.py](../apps/backend/src/orcheo_backend/app/factory.py)). |
+| `ORCHEO_TRACING_EXPORTER` | `none` | `none`, `console`, or `otlp` | Selects the tracing exporter configured by [tracing/provider.py](../src/orcheo/tracing/provider.py). |
+| `ORCHEO_TRACING_ENDPOINT` | _none_ | HTTP(S) URL | Optional OTLP/HTTP collector endpoint (include `/v1/traces`) consumed by [tracing/provider.py](../src/orcheo/tracing/provider.py). |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | String | Resource attribute attached to every span ([config/defaults.py](../src/orcheo/config/defaults.py)). |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Float `0.0`‑`1.0` | Probability used by the trace sampler ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_INSECURE` | `false` | Boolean (`1/0`, `true/false`, etc.) | Allows insecure OTLP connections when set to true ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Positive integer | Token usage threshold that emits `token.chunk` events ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Positive integer ≥ 16 | Maximum characters retained for prompt/response previews ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
 | `ORCHEO_CHATKIT_PUBLIC_BASE_URL` | _none_ | HTTP(S) URL | Optional frontend origin used when generating ChatKit share links in the CLI/MCP; defaults to `ORCHEO_API_URL` with any `/api` suffix removed when unset ([publish.py](../packages/sdk/src/orcheo_sdk/services/workflows/publish.py)). One-off overrides can be supplied via `orcheo workflow publish --chatkit-public-base-url`. |
 
 ## Vault configuration

--- a/docs/otel_tracing/configuration.md
+++ b/docs/otel_tracing/configuration.md
@@ -1,0 +1,117 @@
+# OpenTelemetry Configuration & Trace Tab Operations
+
+This guide explains how to configure OpenTelemetry (OTel) for Orcheo, deploy a collector,
+and operate the Workflow Trace tab in Canvas. It complements the architectural notes in
+[design.md](design.md) and the implementation milestones recorded in [plan.md](plan.md).
+
+## Runtime configuration
+
+The backend reads tracing settings from environment variables using the `ORCHEO_`
+prefix. Defaults are defined in `src/orcheo/config/defaults.py` and validated by
+`AppSettings`.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ORCHEO_TRACING_EXPORTER` | `none` | Chooses the exporter: `none` disables tracing, `console` writes spans to stdout, and `otlp` emits spans via the OTLP/HTTP protocol. |
+| `ORCHEO_TRACING_ENDPOINT` | _none_ | Custom collector endpoint. For OTLP/HTTP exporters the value should include the `/v1/traces` suffix, e.g. `https://collector:4318/v1/traces`. |
+| `ORCHEO_TRACING_SERVICE_NAME` | `orcheo-backend` | Resource attribute attached to all spans. Set this to the deployment identifier (e.g. `orcheo-staging`). |
+| `ORCHEO_TRACING_SAMPLE_RATIO` | `1.0` | Probability (0.0–1.0) used by `TraceIdRatioBased` sampling. Lower the value to reduce volume in production. |
+| `ORCHEO_TRACING_INSECURE` | `false` | When `true`, disables TLS verification for OTLP exporters—useful for local collectors. Leave `false` in production. |
+| `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Token count above which `token.chunk` span events are emitted. Increase to reduce noise for long responses. |
+| `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Maximum characters kept when prompts, responses, or error messages are attached to span events. |
+
+When using the OTLP exporter, ensure the optional dependency is installed alongside the
+backend:
+
+```bash
+uv pip install opentelemetry-exporter-otlp
+```
+
+Restart the backend after adjusting environment variables so the tracer provider can be
+reconfigured.
+
+## Deployment considerations
+
+- **Collector placement** – Keep the collector near the backend to limit latency. The
+  default OTLP exporter uses HTTP; expose port `4318` (HTTP) or configure gRPC by
+  installing the gRPC exporter.
+- **Authentication** – Fronted collectors (e.g., Tempo, Honeycomb) often require API
+  tokens. Inject them via environment variables supported by the collector or a reverse
+  proxy rather than patching Orcheo code.
+- **Sampling strategy** – Tune `ORCHEO_TRACING_SAMPLE_RATIO` for production. Consider
+  `0.1` (10%) for initial rollout and adjust based on retention costs.
+- **PII controls** – Prompts and responses are truncated and redacted automatically, but
+  disable tracing (`ORCHEO_TRACING_EXPORTER=none`) in environments where even partial
+  prompts are disallowed.
+- **Version skew** – Ensure Canvas and backend deployments are upgraded together. The
+  Trace tab expects the Phase 3 API shape and the realtime payload extensions introduced
+  in Phase 2.
+
+## Trace tab usage
+
+1. Execute a workflow run from Canvas or the CLI.
+2. Select the run in the Execution sidebar; Canvas automatically opens the `Trace` tab
+   once trace data is available.
+3. Expand nodes in the span tree to inspect prompts, responses, token counts, and
+   artifact links. High token usage emits highlighted events using the configured
+   threshold.
+4. Use the metrics summary to verify end-to-end latency and token totals.
+5. Download artifacts or follow external dashboard links (if configured) directly from
+   the detail panel.
+
+The Trace tab streams updates for active runs via WebSocket messages. Closed runs load
+from the `/executions/{execution_id}/trace` endpoint and respect collector pagination.
+
+## Sample collector configuration
+
+The following minimal configuration works for the OpenTelemetry Collector receiving data
+from Orcheo and exporting it to Jaeger. Save as `otel-collector.yaml`:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  jaeger:
+    endpoint: jaeger:14250
+    insecure: true
+processors:
+  batch: {}
+pipelines:
+  traces:
+    receivers: [otlp]
+    processors: [batch]
+    exporters: [jaeger]
+```
+
+Start the collector with:
+
+```bash
+otelcol --config otel-collector.yaml
+```
+
+Point Orcheo at the collector by setting
+`ORCHEO_TRACING_EXPORTER=otlp` and `ORCHEO_TRACING_ENDPOINT=http://collector:4318/v1/traces`.
+
+## Troubleshooting
+
+- **No spans appear** – Verify `ORCHEO_TRACING_EXPORTER` is not `none` and that the
+  sample ratio is greater than zero. Check backend logs for exporter initialization
+  errors.
+- **Startup error about missing OTLP exporter** – Install
+  `opentelemetry-exporter-otlp`. The backend raises a runtime error when the exporter is
+  requested but not available.
+- **TLS handshake failures** – Set `ORCHEO_TRACING_INSECURE=true` for local collectors
+  without certificates. For production, use a certificate issued to the collector host or
+  terminate TLS before traffic reaches the collector.
+- **Trace tab stuck in loading state** – Confirm the backend is reachable at
+  `/executions/{id}/trace` and that realtime WebSocket connections are permitted through
+  firewalls or proxies.
+- **Prompt/response content truncated** – Increase
+  `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` to retain more characters at the expense of larger
+  span payloads.
+
+With the configuration above, Orcheo emits spans to your observability stack and Canvas
+renders them live in the Trace tab.

--- a/docs/otel_tracing/configuration.md
+++ b/docs/otel_tracing/configuration.md
@@ -34,7 +34,7 @@ reconfigured.
 
 - **Collector placement** – Keep the collector near the backend to limit latency. The
   default OTLP exporter uses HTTP; expose port `4318` (HTTP) or configure gRPC by
-  installing the gRPC exporter.
+  installing the gRPC exporter (`pip install opentelemetry-exporter-otlp[grpc]`).
 - **Authentication** – Fronted collectors (e.g., Tempo, Honeycomb) often require API
   tokens. Inject them via environment variables supported by the collector or a reverse
   proxy rather than patching Orcheo code.
@@ -93,7 +93,8 @@ otelcol --config otel-collector.yaml
 ```
 
 Point Orcheo at the collector by setting
-`ORCHEO_TRACING_EXPORTER=otlp` and `ORCHEO_TRACING_ENDPOINT=http://collector:4318/v1/traces`.
+`ORCHEO_TRACING_EXPORTER=otlp` and `ORCHEO_TRACING_ENDPOINT=http://collector:4318/v1/traces`
+(note the required `/v1/traces` suffix).
 
 ## Troubleshooting
 

--- a/docs/otel_tracing/plan.md
+++ b/docs/otel_tracing/plan.md
@@ -19,7 +19,7 @@
 - [x] Write frontend tests (Vitest + React Testing Library) for tab rendering, data loading, and interaction states.
 
 ## Phase 4 – Configuration, Documentation, & QA
-- [ ] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
-- [ ] Provide sample collector configuration and troubleshooting guidance.
-- [ ] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
-- [ ] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.
+- [x] Document OpenTelemetry configuration, deployment considerations, and Trace tab usage in docs.
+- [x] Provide sample collector configuration and troubleshooting guidance.
+- [x] Run full lint/test suites (backend + canvas) and address performance or accessibility findings.
+- [x] Prepare release notes and rollout checklist for enabling the Trace tab in staging and production environments.

--- a/docs/otel_tracing/rollout.md
+++ b/docs/otel_tracing/rollout.md
@@ -1,0 +1,59 @@
+# Trace Tab Release Notes & Rollout Checklist
+
+This document captures the release messaging and operational steps required to enable
+the Workflow Trace tab across environments.
+
+## Release notes
+
+- **Workflow insights at a glance** – Every workflow execution now emits an
+  OpenTelemetry trace. Canvas visualizes the trace as a collapsible tree so teams can
+  inspect prompts, responses, token usage, latency, and artifacts without leaving the
+  app.
+- **Live updates** – The Trace tab streams node progress in real time for in-flight runs.
+  Completed runs load historical traces on demand, matching the `/executions/{id}/trace`
+  API response.
+- **Observability integrations** – Deployments can forward spans to any OTLP-compatible
+  backend (Tempo, Jaeger, Honeycomb, etc.). External dashboards appear in Canvas when
+  configured.
+- **Configurable privacy controls** – Administrators can disable tracing entirely or tune
+  redaction limits via environment variables described in
+  [configuration.md](configuration.md).
+
+Share these highlights in changelog or release announcements to set expectations for
+stakeholders.
+
+## Rollout checklist
+
+### Staging
+
+1. **Upgrade dependencies** – Deploy backend image with
+   `opentelemetry-exporter-otlp` installed and ensure Canvas includes the Trace tab UI.
+2. **Configure tracing** – Set `ORCHEO_TRACING_EXPORTER=otlp` and point
+   `ORCHEO_TRACING_ENDPOINT` at the staging collector. Use a reduced sample ratio (e.g.,
+   `0.25`).
+3. **Provision collector** – Apply the sample collector configuration (see
+   [configuration.md](configuration.md)) or reuse the shared observability cluster. Verify
+   spans arrive in the backend by inspecting the collector UI.
+4. **Run smoke tests** – Execute representative workflows via Canvas and the CLI. Confirm
+   traces populate in the Trace tab and external dashboards. Capture screenshots for the
+   release notes.
+5. **Validate retention** – Ensure trace metadata is purged according to staging policy
+   and that sensitive content remains redacted.
+
+### Production
+
+1. **Communicate rollout window** – Notify stakeholders about the Trace tab deployment
+   and any expected downtime.
+2. **Promote artifacts** – Roll out the backend and Canvas builds validated in staging.
+3. **Update configuration** – Set production-specific values for exporter endpoint,
+   service name, and sampling rate. Confirm TLS certificates or `ORCHEO_TRACING_INSECURE`
+   overrides as needed.
+4. **Monitor rollout** – During the first 24 hours, monitor collector load, token usage
+   events, and Canvas performance. Adjust sampling if ingestion volume exceeds limits.
+5. **Enable external links** – If external observability dashboards are available, add the
+   URLs to the Canvas configuration so users can pivot directly from the Trace tab.
+6. **Document completion** – Mark the Phase 4 tasks in [plan.md](plan.md) as complete and
+   update public release notes with screenshots and usage docs.
+
+Following this checklist ensures the Trace tab launches smoothly while keeping operators
+and end users informed.

--- a/docs/otel_tracing/rollout.md
+++ b/docs/otel_tracing/rollout.md
@@ -30,7 +30,7 @@ stakeholders.
    `opentelemetry-exporter-otlp` installed and ensure Canvas includes the Trace tab UI.
 2. **Configure tracing** – Set `ORCHEO_TRACING_EXPORTER=otlp` and point
    `ORCHEO_TRACING_ENDPOINT` at the staging collector. Use a reduced sample ratio (e.g.,
-   `0.25`).
+   `0.25`). Verify backend startup logs show successful tracer provider initialization.
 3. **Provision collector** – Apply the sample collector configuration (see
    [configuration.md](configuration.md)) or reuse the shared observability cluster. Verify
    spans arrive in the backend by inspecting the collector UI.
@@ -48,8 +48,9 @@ stakeholders.
 3. **Update configuration** – Set production-specific values for exporter endpoint,
    service name, and sampling rate. Confirm TLS certificates or `ORCHEO_TRACING_INSECURE`
    overrides as needed.
-4. **Monitor rollout** – During the first 24 hours, monitor collector load, token usage
-   events, and Canvas performance. Adjust sampling if ingestion volume exceeds limits.
+4. **Monitor rollout** – During the first 24 hours, monitor collector load, span ingestion
+   rate, token usage events, Canvas performance, and any OTLP export errors in backend
+   logs. Adjust sampling if ingestion volume exceeds limits.
 5. **Enable external links** – If external observability dashboards are available, add the
    URLs to the Canvas configuration so users can pivot directly from the Trace tab.
 6. **Document completion** – Mark the Phase 4 tasks in [plan.md](plan.md) as complete and


### PR DESCRIPTION
## Summary
- add a comprehensive OpenTelemetry configuration and troubleshooting guide for the Trace tab
- capture release highlights plus staging and production rollout checklists
- document tracing environment variables and mark Phase 4 tasks complete in the tracing plan

## Testing
- make lint
- make test
- make canvas-lint
- make canvas-test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165c0ed37c8327ae573e3a1a0c422e)