### PR TITLE
Add conversational search node requirements

### DIFF
--- a/docs/conversational_search/requirements.md
+++ b/docs/conversational_search/requirements.md
@@ -5,11 +5,10 @@
 - **Project/Feature Name:** Conversational Search Node Package
 - **Type:** Product
 - **Summary:** Reusable package of graph-ready Orcheo nodes covering ingestion, retrieval, ranking, grounding, and answer generation for conversational search workflows where users issue natural-language queries across heterogeneous knowledge.
-- **Owner (if different than authors):** TBD
-- **Date Started:** TBD
+- **Owner (if different than authors):** Shaojie Jiang
+- **Date Started:** 2025-11-18
 
 ## RELEVANT LINKS & STAKEHOLDERS
-_[Include only the documents relevant to your project/feature scope]_
 
 | Documents | Link | Owner | Name |
 |-----------|------|-------|------|
@@ -23,7 +22,7 @@ _[Include only the documents relevant to your project/feature scope]_
 
 ## PROBLEM DEFINITION
 ### Objectives
-Deliver a cohesive package of conversational search nodes that lets builders compose ingestion, retrieval, grounding, and generative steps without bespoke glue code. Provide observability hooks and guardrails so production teams can operate and iterate on conversational agents confidently.
+Deliver a cohesive package of conversational search nodes that lets builders compose ingestion, retrieval, grounding, and generative steps without bespoke glue code. Provide guardrails so production teams can operate and iterate on conversational agents confidently.
 
 ### Target users
 Graph builders, applied researchers, and operations engineers who assemble conversational search workflows inside Orcheo. They need modular components to ingest data, search heterogeneous sources, craft responses, and monitor deployed agents.
@@ -31,15 +30,16 @@ Graph builders, applied researchers, and operations engineers who assemble conve
 ### User Stories
 | As a... | I want to... | So that... | Priority | Acceptance Criteria |
 |---------|--------------|------------|----------|---------------------|
-| Workflow builder | Drop in nodes for ingestion, chunking, retrieval, fusion, and generation | I can launch conversational search experiments without rewriting infrastructure | P0 | DocumentLoaderNode, ChunkingStrategyNode, EmbeddingIndexerNode, VectorRetrieverNode, BM25RetrieverNode, HybridFusionNode, and GroundedGeneratorNode available with configs |
+| Workflow builder | Drop in nodes for ingestion, chunking, retrieval, fusion, and generation | I can launch conversational search experiments without rewriting infrastructure | P0 | DocumentLoaderNode, ChunkingStrategyNode, EmbeddingIndexerNode, VectorSearchNode, BM25SearchNode, HybridFusionNode, and GroundedGeneratorNode available with configs |
 | Retrieval researcher | Swap retrievers, rankers, and planners while reusing shared interfaces | I can benchmark new strategies quickly | P0 | Base abstractions for retrievers/vector stores/memory plus configurable nodes that are independently testable |
-| Operations lead | Enable observability, guardrails, and compliance across conversations | I can safely run conversational agents in production | P1 | Guard nodes (HallucinationGuardNode, PolicyComplianceNode), and session/memory controls exposed |
+| Operations lead | Enable guardrails and compliance across conversations | I can safely run conversational agents in production | P1 | Guard nodes (HallucinationGuardNode, PolicyComplianceNode), and session/memory controls exposed |
 
 ### Context, Problems, Opportunities
-Teams currently hand-roll conversational search flows, creating duplicated work, inconsistent abstractions, and limited observability. There is an opportunity to standardize on Orcheo nodes that cover ingestion through evaluation, expose configuration-first APIs, and make it trivial to plug different vendors, memory stores, or retrievers into a conversation-aware loop.
+Teams currently hand-roll conversational search flows, creating duplicated work and inconsistent abstractions. There is an opportunity to standardize on Orcheo nodes that cover ingestion through evaluation, expose configuration-first APIs, and make it trivial to plug different vendors, memory stores, or retrievers into a conversation-aware loop.
 
 ### Product goals and Non-goals
-**Goals:** Provide modular nodes for conversational search, ensure composability through shared interfaces, and bake in guardrails that ease production operations.
+**Goals:** Provide modular nodes for conversational search, ensure composability through shared interfaces, and include guardrails that ease production operations.
+
 **Non-goals:** Custom UI surfaces, data labeling tooling, or vendor-specific orchestration beyond the defined node contracts remain out of scope.
 
 ## PRODUCT DEFINITION
@@ -49,125 +49,46 @@ Conversational search functionality will live under `orcheo.nodes.conversational
 #### Node Overview Summary
 | Category | Node | Priority | Purpose |
 |----------|------|----------|---------|
-| **Data Ingestion** | DocumentLoaderNode | P0 | Load and normalize documents from various sources |
-| | ChunkingStrategyNode | P0 | Apply configurable chunking strategies for optimal indexing |
-| | MetadataExtractorNode | P0 | Extract structured metadata to enrich chunks |
-| | EmbeddingIndexerNode | P0 | Generate embeddings and write to vector stores |
-| | IncrementalIndexerNode | P1 | Handle delta updates without full reindexing |
-| | SyncMonitorNode | P1 | Monitor ingestion pipeline health |
-| **Retrieval** | VectorRetrieverNode | P0 | Dense vector similarity search |
-| | BM25RetrieverNode | P0 | Traditional keyword-based retrieval |
-| | HybridFusionNode | P0 | Merge results from multiple retrievers |
-| | WebSearchNode | P0 | Integrate live web search results |
-| | ReRankerNode | P1 | Apply cross-encoder reranking |
-| | SourceRouterNode | P1 | Route queries to appropriate knowledge sources |
-| **Query Processing** | QueryRewriteNode | P0 | Expand/rewrite queries using conversation context |
-| | CoreferenceResolverNode | P0 | Resolve pronouns and references |
-| | QueryClassifierNode | P0 | Classify query intent for routing |
-| | ContextCompressorNode | P0 | Deduplicate and compress context |
-| **Conversation** | ConversationStateNode | P0 | Maintain dialog state and history |
-| | ConversationHistoryCompressorNode | P0 | Compress long conversation histories |
-| | TopicShiftDetectorNode | P0 | Detect conversation topic changes |
-| | MemorySummarizerNode | P1 | Maintain episodic memory beyond the current turn |
-| **Generation & Guardrails** | GroundedGeneratorNode | P0 | Generate grounded answers with citations |
-| | StreamingGeneratorNode | P1 | Stream token-by-token responses |
-| | HallucinationGuardNode | P1 | Validate answers vs. retrieved facts |
-| | CitationsFormatterNode | P1 | Emit structured citations for UIs |
-| | QueryClarificationNode | P1 | Solicit clarifying information before answering |
-| **Memory & Optimization** | AnswerCachingNode | P1 | Cache responses for repeated or similar questions |
-| | SessionManagementNode | P1 | Handle session lifecycle and resource limits |
-| | MultiHopPlannerNode | P1 | Support planned multi-hop retrieval |
-| **Observability & Compliance** | PolicyComplianceNode | P1 | Enforce content filters |
-| | MemoryPrivacyNode | P1 | Apply redaction/retention policies |
-| | SyncMonitorNode | P1 | Emit ingestion health metrics |
-| **Evaluation & Tooling** | RetrievalEvaluationNode | P2 | Measure recall, MRR, NDCG, MAP |
-| | AnswerQualityEvaluationNode | P2 | Score generated answers |
-| | TurnAnnotationNode | P2 | Capture structured annotations |
-| | SyntheticJudgeNode | P2 | Run LLM evaluators |
-| | DataAugmentationNode | P2 | Generate synthetic training data |
-| | FailureAnalysisNode | P2 | Categorize failure modes |
-| | UserFeedbackCollectionNode | P2 | Collect implicit/explicit feedback |
-| | FeedbackIngestionNode | P2 | Persist feedback to sinks |
-| | ABTestingNode | P2 | Manage experiment traffic |
-| | AnalyticsExportNode | P2 | Export analytics data |
-
-#### Priority 0/1: Core Conversational Search
-**Data Ingestion**
-- **DocumentLoaderNode:** Connectors for file, web, and API sources with format normalization.
-- **ChunkingStrategyNode:** Configurable character/token rules with overlap control for optimal indexing.
-- **MetadataExtractorNode:** Attaches structured metadata (title, source, tags) powering filters and ranking.
-- **EmbeddingIndexerNode:** Runs embedding models, writes to supported vector stores, and validates schema.
-- **IncrementalIndexerNode:** Delta-sync pipeline that detects adds/updates/deletes without full reindexing.
-- **SyncMonitorNode:** Emits ingestion telemetry (success, error, retry counts) for observability dashboards.
-
-**Query Processing & Conversation**
-- **ConversationStateNode:** Maintains per-session context, participants, and runtime state objects.
-- **ConversationHistoryCompressorNode:** Summarizes long histories with token budgets for downstream nodes.
-- **TopicShiftDetectorNode:** Flags when queries diverge enough to warrant search resets.
-- **QueryRewriteNode:** Uses conversation memories to rewrite or expand user questions.
-- **CoreferenceResolverNode:** Resolves pronouns/entities for precise retrieval.
-- **QueryClassifierNode:** Routes queries (search vs. clarifying question vs. finalization) using classifiers.
-- **ContextCompressorNode:** Deduplicates retrieved context and enforces token budgets.
-- **QueryClarificationNode:** Requests additional details from the user when intent is ambiguous.
-
-**Retrieval & Ranking**
-- **VectorRetrieverNode:** Dense similarity search built atop the base vector store abstraction.
-- **BM25RetrieverNode:** Keyword retrieval for sparse/deterministic matching.
-- **HybridFusionNode:** Weighted/RRF fusion layer merging retriever outputs.
-- **WebSearchNode:** Optional live search for freshness.
-- **ReRankerNode:** Cross-encoder or LLM scoring pipeline for top-k results.
-- **SourceRouterNode:** Chooses the right knowledge source via heuristics or learned models.
-- **MultiHopPlannerNode:** Plans sequential retrieval hops when questions require decomposition.
-
-**Generation & Guardrails**
-- **GroundedGeneratorNode:** Core generative responder that cites retrieved context.
-- **StreamingGeneratorNode:** Streams responses via async iterators for responsive UX.
-- **HallucinationGuardNode:** Validates responses using entailment or rule-based checks with fallback routing.
-- **CitationsFormatterNode:** Produces structured reference payloads (URL, title, snippet).
-
-**Memory, Optimization, and Operations**
-- **MemorySummarizerNode:** Writes episodic memory back into `BaseMemoryStore` for personalization.
-- **AnswerCachingNode:** Caches semantically similar Q&A pairs with TTL and similarity policies.
-- **SessionManagementNode:** Controls lifecycle, concurrency, and cleanup for session workloads.
-- **PolicyComplianceNode & MemoryPrivacyNode:** Enforce content, retention, and redaction policies aligned with compliance requirements.
-
-#### Priority 2: Research, Compliance & Operations
-These nodes support evaluation, compliance, and production operations but are not required for core conversational search functionality.
-
-**Evaluation & Research**
-- **RetrievalEvaluationNode:** Computes Recall@k, MRR, NDCG, MAP using relevance labels.
-- **AnswerQualityEvaluationNode:** Scores answers via LLM-as-a-judge or rule-based metrics (faithfulness, relevance, completeness).
-- **TurnAnnotationNode:** Captures structured success/intent labels from human or heuristic sources.
-- **SyntheticJudgeNode:** Runs LLM evaluators on answers vs. references for offline experimentation and regression gating.
-- **DataAugmentationNode:** Generates synthetic training data (query variations, negatives, paraphrases) for fine-tuning and evaluation.
-- **FailureAnalysisNode:** Categorizes failure modes (no results, irrelevant results, hallucinations, formatting errors) and emits reports.
-
-**Tooling & Integration**
-- **UserFeedbackCollectionNode:** Collects implicit (clicks, reformulations) and explicit (thumbs, ratings) feedback.
-- **FeedbackIngestionNode:** Persists explicit feedback to analytics sinks for aggregation.
-- **ABTestingNode:** Routes traffic between configurations, tracks variant assignments, and exports comparison metrics.
-- **AnalyticsExportNode:** Sends structured analytics data (query patterns, performance metrics, user behavior) to warehouses or research tools.
-
-**Compliance & Security**
-- **PolicyComplianceNode:** Enforces content filters (PII, toxicity) with configurable policies and audit logging.
-- **MemoryPrivacyNode:** Applies configurable redaction and retention policies to stored dialog state per regional requirements.
-
-#### Implementation Roadmap
-##### Phase 1: MVP (Weeks 1-4)
-**Goal:** Enable basic conversational search research.
-Core retrieval loop: DocumentLoaderNode, ChunkingStrategyNode, EmbeddingIndexerNode, QueryRewriteNode, ContextCompressorNode, VectorRetrieverNode, BM25RetrieverNode, HybridFusionNode, and GroundedGeneratorNode.
-
-##### Phase 2: Conversational Features (Weeks 5-8)
-**Goal:** Add conversation-aware capabilities.
-Add conversation handling (ConversationStateNode, ConversationHistoryCompressorNode), advanced query processing (CoreferenceResolverNode, QueryClassifierNode, TopicShiftDetectorNode), clarification (QueryClarificationNode), and metadata enrichment (MetadataExtractorNode, WebSearchNode).
-
-##### Phase 3: Quality & Production (Weeks 9-12)
-**Goal:** Deliver production-ready quality improvements.
-Add ranking (ReRankerNode), routing (SourceRouterNode, MultiHopPlannerNode), quality gates (HallucinationGuardNode, CitationsFormatterNode), optimization (AnswerCachingNode, IncrementalIndexerNode), and UX (StreamingGeneratorNode).
-
-##### Phase 4: Research & Operations (Ongoing)
-**Goal:** Enable systematic improvement.
-Add evaluation (RetrievalEvaluationNode, AnswerQualityEvaluationNode, FailureAnalysisNode), data generation (DataAugmentationNode), feedback (UserFeedbackCollectionNode, ABTestingNode), analytics (AnalyticsExportNode), and compliance (PolicyComplianceNode, MemoryPrivacyNode).
+| **Data Ingestion** | DocumentLoaderNode | P0 | Connectors for file, web, and API sources with format normalization |
+| | ChunkingStrategyNode | P0 | Configurable character/token rules with overlap control for optimal indexing |
+| | MetadataExtractorNode | P0 | Attaches structured metadata (title, source, tags) powering filters and ranking |
+| | EmbeddingIndexerNode | P0 | Runs embedding models, writes to Pinecone (primary v1 adapter), and validates schema |
+| | IncrementalIndexerNode | P1 | Delta-sync pipeline that detects adds/updates/deletes without full reindexing |
+| **Retrieval** | VectorSearchNode | P0 | Dense similarity search built atop the base vector store abstraction |
+| | BM25SearchNode | P0 | Keyword retrieval for sparse/deterministic matching |
+| | HybridFusionNode | P0 | Merges retriever outputs via Reciprocal Rank Fusion (RRF) or weighted sum strategies |
+| | WebSearchNode | P0 | Optional live search for freshness |
+| | ReRankerNode | P1 | Cross-encoder or LLM scoring pipeline for top-k results |
+| | SourceRouterNode | P1 | Routes to appropriate sources (Tavily for web search, Neo4j for knowledge graphs) via heuristics or learned models |
+| **Query Processing** | QueryRewriteNode | P0 | Uses conversation memories to rewrite or expand user questions |
+| | CoreferenceResolverNode | P0 | Resolves pronouns/entities using neural approaches (NeuralCoref or transformer-based models) for precise retrieval |
+| | QueryClassifierNode | P0 | Routes queries (search vs. clarifying question vs. finalization) using classifiers |
+| | ContextCompressorNode | P0 | Deduplicates retrieved context and enforces token budgets |
+| **Conversation** | ConversationStateNode | P0 | Maintains per-session context, participants, and runtime state objects |
+| | ConversationCompressorNode | P0 | Summarizes long histories with token budgets for downstream nodes |
+| | TopicShiftDetectorNode | P0 | AI-based node that flags query divergence with user-configurable sensitivity thresholds |
+| | MemorySummarizerNode | P1 | Writes episodic memory back into BaseMemoryStore for personalization |
+| **Generation & Guardrails** | GroundedGeneratorNode | P0 | Core generative responder that cites retrieved context |
+| | StreamingGeneratorNode | P1 | Streams responses via async iterators for responsive UX |
+| | HallucinationGuardNode | P1 | Validates responses using LLM Judge approach with fallback routing |
+| | CitationsFormatterNode | P1 | Produces structured reference payloads (URL, title, snippet) |
+| | QueryClarificationNode | P1 | Requests additional details from the user when intent is ambiguous |
+| **Memory & Optimization** | AnswerCachingNode | P1 | Caches semantically similar Q&A pairs with TTL and similarity policies |
+| | SessionManagementNode | P1 | Controls lifecycle, concurrency, and cleanup for session workloads |
+| | MultiHopPlannerNode | P1 | Plans sequential retrieval hops when questions require decomposition |
+| **Compliance** | PolicyComplianceNode | P1 | Enforces content filters (PII, toxicity) with configurable policies and audit logging |
+| | MemoryPrivacyNode | P1 | Applies configurable redaction and retention policies to stored dialog state |
+| **Evaluation & Tooling** | DatasetNode | P2 | Manages golden datasets per search scenario with versioning and schema validation |
+| | RetrievalEvaluationNode | P2 | Computes Recall@k, MRR, NDCG, MAP using relevance labels |
+| | AnswerQualityEvaluationNode | P2 | Scores answers via LLM-as-a-judge or rule-based metrics (faithfulness, relevance, completeness) |
+| | TurnAnnotationNode | P2 | Captures structured success/intent labels from human or heuristic sources |
+| | LLMJudgeNode | P2 | Runs LLM evaluators on answers vs. references for offline experimentation and regression gating |
+| | DataAugmentationNode | P2 | Generates synthetic training data (query variations, negatives, paraphrases) for fine-tuning |
+| | FailureAnalysisNode | P2 | Categorizes failure modes (no results, irrelevant results, hallucinations) and emits reports |
+| | UserFeedbackCollectionNode | P2 | Collects implicit (clicks, reformulations) and explicit (thumbs, ratings) feedback |
+| | FeedbackIngestionNode | P2 | Persists explicit feedback to analytics sinks for aggregation |
+| | ABTestingNode | P2 | Routes traffic between configurations, tracks variant assignments, and exports comparison metrics |
+| | AnalyticsExportNode | P2 | Sends structured analytics data (query patterns, performance metrics) to warehouses or research tools |
 
 #### Key Dependencies
 ```
@@ -190,22 +111,17 @@ Parallel tracks after Phase 1:
 ### Designs (if applicable)
 No dedicated UI designs; relies on node reference docs and example graphs. Figma artifacts TBD as UI or orchestration surfaces emerge.
 
-### Other Teams Impacted
-- **Docs & Education:** Requires coordination for MkDocs reference pages and adoption guides.
-- **Security & Compliance:** PolicyComplianceNode and MemoryPrivacyNode demand alignment with security/legal reviews.
-
 ## TECHNICAL CONSIDERATIONS
-_[The goal of this section is to outline the high level engineering requirement to facilitate the engineering resource planning. Detailed engineering requirements or system design is out of scope for this section.]_
+The conversational search node package requires a backend engineering pod with ML expertise. Key engineering investments include: (1) base abstractions for vector stores, memory stores, and retrieval interfaces; (2) streaming infrastructure for real-time generation; (3) evaluation harnesses for offline metrics; and (4) integration with Orcheo's existing node registry, state management, and secret binding systems. External dependencies include vector database clients (Pinecone, PGVector, LanceDB), embedding model APIs, and LLM providers with streaming support.
 
 ### Architecture Overview
-Conversational search nodes plug into Orcheo graphs as modular steps for ingestion, retrieval, planning, generation, and observability. Each node exposes a typed `NodeConfig`, shares telemetry and tracing contracts, and interoperates with shared abstractions (vector stores, memory stores, message buses). The package also ships reference graphs plus schema validators demonstrating how flows connect.
+Conversational search nodes plug into Orcheo graphs as modular steps for ingestion, retrieval, planning, and generation. Each node exposes a typed `NodeConfig` and interoperates with shared abstractions (vector stores, memory stores, message buses). The package also ships reference graphs plus schema validators demonstrating how flows connect.
 
 ### Technical Requirements
 - **Configurability:** Every node exposes validated configs with documented defaults and schema enforcement.
-- **Observability:** Nodes integrate with Orcheo telemetry, emitting structured events, correlation IDs, and health metrics (e.g., SyncMonitorNode).
 - **Error Handling:** Implement graceful retries with exponential backoff for transient failures via `NodeResult.status` semantics.
 - **Performance Targets:** Meet ingestion throughput (≥ 500 docs/minute), retrieval p95 latency (≤ 1.5s), and generation p95 latency (≤ 4s) assuming GPU-backed LLMs.
-- **Security:** Nodes handling credentials rely on Orcheo secret bindings and redact sensitive values in logs/storage.
+- **Security:** Nodes handling credentials rely on Orcheo secret bindings and redact sensitive values in logs/storage. Data retention follows Orcheo's global settings.
 - **Testing:** Provide unit tests per node plus integration coverage for a reference conversational search graph located under `tests/nodes/conversational_search/`.
 - **Resourcing:** Roadmap assumes a cross-functional pod (backend, MLE, DS, DX writers) delivering sequential phases outlined above.
 
@@ -214,7 +130,7 @@ Conversational search nodes plug into Orcheo graphs as modular steps for ingesti
 Nodes must ingest heterogeneous corpora (files, URLs, web search) enriched with metadata, store conversation histories for personalization, and capture user feedback/annotations for evaluation. Evaluation nodes rely on golden datasets with relevance labels, while synthetic data generation nodes create paraphrases/negatives to expand coverage.
 
 #### Algorithm selection
-Baseline algorithms combine dense vector retrieval with BM25 keyword search, fused via RRF or weighted strategies. Re-ranking leverages cross-encoders or LLM checkers, while conversation understanding uses coreference resolution, intent classification, and topic shift detection. Generation nodes employ LLMs constrained by retrieved evidence with optional streaming transports.
+Baseline algorithms combine dense vector retrieval with BM25 keyword search, fused via RRF (Reciprocal Rank Fusion) or weighted strategies. Re-ranking leverages cross-encoders or LLM checkers, while conversation understanding uses coreference resolution, intent classification, and topic shift detection. Generation nodes employ LLMs constrained by retrieved evidence with optional streaming transports.
 
 #### Model performance requirements
 - Ingestion throughput ≥ 500 documents/minute.
@@ -236,26 +152,23 @@ Primary consumers are Orcheo users building conversational retrieval application
 |------|--------------------|
 | [Primary] Retrieval latency | p95 ≤ 1.5s to keep conversations responsive during hybrid retrieval |
 | [Secondary] Generation latency | p95 ≤ 4s with citations attached for final responses |
-| [Guardrail] Ingestion throughput | ≥ 500 documents/minute while maintaining observability and retry semantics |
+| [Guardrail] Ingestion throughput | ≥ 500 documents/minute while maintaining retry semantics |
 
 ### Rollout Strategy
 Roll out sequential phases that move from MVP ingestion/retrieval/generation to conversation features, production hardening, and ongoing research/operations. Each phase unlocks a distinct user outcome (experimentation, multi-turn quality, production readiness, continuous improvement) while keeping dependencies manageable.
 
 ### Experiment Plan (if applicable)
-Evaluation is driven by RetrievalEvaluationNode, AnswerQualityEvaluationNode, SyntheticJudgeNode, and FailureAnalysisNode, enabling offline recall/NDCG checks plus LLM-as-a-judge answer assessment. Traffic experiments use ABTestingNode with holdouts for new retrieval/generation strategies once Phase 2 components land.
+Evaluation is driven by RetrievalEvaluationNode, AnswerQualityEvaluationNode, LLMJudgeNode, and FailureAnalysisNode, enabling offline recall/NDCG checks plus LLM-as-a-judge answer assessment. Traffic experiments use ABTestingNode with holdouts for new retrieval/generation strategies once Phase 2 components land.
 
 ### Estimated Launch Phases (if applicable)
 | Phase | Target | Description |
 |-------|--------|-------------|
-| **Phase 1** | Research pods (Weeks 1-4) | Deliver MVP ingestion, query processing, retrieval, and generation loop for experimentation. |
-| **Phase 2** | Early adopters (Weeks 5-8) | Layer conversation management, coreference resolution, clarification, and metadata enrichment. |
-| **Phase 3** | Production teams (Weeks 9-12) | Ship quality, routing, optimization, and UX upgrades for production readiness. |
-| **Phase 4** | Broad rollout (Ongoing) | Continue evaluation, analytics, compliance, and feedback capabilities as incremental releases. |
+| **Phase 1** | Research pods | Deliver MVP ingestion, query processing, retrieval, and generation loop for experimentation. |
+| **Phase 2** | Early adopters | Layer conversation management, coreference resolution, clarification, and metadata enrichment. |
+| **Phase 3** | Production teams | Ship quality, routing, optimization, and UX upgrades for production readiness. |
+| **Phase 4** | Broad rollout | Continue evaluation, analytics, compliance, and feedback capabilities as incremental releases. |
 
 ## HYPOTHESIS & RISKS
-_[Each hypothesis/risk should be limited to 2-3 sentences (i.e., one sentence for hypothesis, one sentence for confidence in hypothesis). Generally, PRDs should be focused on validating a single hypothesis and no more than two hypotheses.]_
-_[Hypothesis: what do you believe to be true, and what do you think will happen if you are correct? Recommend framing your hypothesis in a customer-centric way, while also describing how the user problem impacts metrics.]_
-_[Risk: what are potential risk areas for this feature and what could be some unintended consequences?]_
 - **Hypothesis:** Providing modular conversational search nodes with shared interfaces will cut graph assembly time by enabling plug-and-play ingestion, retrieval, and generation; confidence is medium pending adoption metrics.
 - **Hypothesis:** Built-in guardrails will accelerate production rollouts because operations teams can observe, triage, and gate deployments; confidence is medium once Phase 3 components exist.
 - **Risk:** Vector store and external connector support (e.g., Pinecone vs. LanceDB) may not match team expectations, slowing adoption until adapters land.
@@ -263,24 +176,14 @@ _[Risk: what are potential risk areas for this feature and what could be some un
 
 ## APPENDIX
 ### Node Composition Patterns
-1. **Basic RAG Pipeline:** DocumentLoader → Chunking → Indexer → VectorRetriever → GroundedGenerator.
-2. **Hybrid Search:** (VectorRetriever + BM25Retriever) → HybridFusion → ReRanker → GroundedGenerator.
-3. **Conversational Search:** ConversationState → QueryRewrite → CoreferenceResolver → Retrieval → GroundedGenerator.
-4. **Multi-hop Reasoning:** MultiHopPlanner → (QueryRewrite → Retrieval)* → ContextCompressor → GroundedGenerator.
-5. **Research Pipeline:** Retrieval → RetrievalEvaluation + AnswerQualityEvaluation → FailureAnalysis.
+1. **Basic RAG Pipeline:** DocumentLoader → Chunking → Indexer → VectorSearch → GroundedGenerator.
+2. **Hybrid Search:** (VectorSearch + BM25Search) → HybridFusion → ReRanker → GroundedGenerator.
+3. **Conversational Search:** ConversationState → QueryRewrite → CoreferenceResolver → VectorSearch → GroundedGenerator.
+4. **Multi-hop Reasoning:** MultiHopPlanner → (QueryRewrite → VectorSearch)* → ContextCompressor → GroundedGenerator.
+5. **Research Pipeline:** VectorSearch → RetrievalEvaluation + AnswerQualityEvaluation → FailureAnalysis.
 
 ### Node Granularity Decisions
-- **VectorRetrieverNode** and **BM25RetrieverNode** stay separate for independent configuration/benchmarking.
+- **VectorSearchNode** and **BM25SearchNode** stay separate for independent configuration/benchmarking.
 - **HybridFusionNode** remains explicit to support experimentation with fusion strategies.
 - **ChunkingStrategyNode** is separate from DocumentLoaderNode for independent chunking research.
 - **QueryClassifierNode** powers conditional branching without embedding logic inside retrievers.
-
-### Open Questions
-1. Which vector store adapters must be supported in v1 (e.g., Pinecone, PGVector, LanceDB, Chroma)?
-2. Preferred hallucination detection approach (LLM judge vs. rule-based)?
-3. Data retention requirements for stored conversation history across geographies.
-4. Which external search/graph connectors are most valuable for the initial SourceRouterNode targets?
-5. What golden datasets or heuristics should SyntheticJudgeNode rely on for consistent offline evaluation?
-6. Should coreference resolution use rule-based (SpaCy) or neural approaches (NeuralCoref)?
-7. What fusion strategies should HybridFusionNode prioritize (RRF, weighted sum, learned models)?
-8. How should topic shift detection balance sensitivity vs. false positives in conversation flow?

--- a/docs/conversational_search/requirements.md
+++ b/docs/conversational_search/requirements.md
@@ -1,0 +1,61 @@
+# Conversational Search Node Package Requirements
+
+## Overview
+This document captures the functional and non-functional requirements for a reusable package of Orcheo nodes dedicated to conversational search scenarios. The package targets workflows where users engage in natural-language dialogue to retrieve, refine, and ground knowledge from heterogeneous data sources.
+
+## Objectives
+1. Provide a cohesive set of graph-ready nodes for ingestion, retrieval, ranking, grounding, and answer generation.
+2. Ensure nodes are composable so builders can swap models, retrievers, or memory stores without rewriting glue logic.
+3. Offer observability hooks and guardrails that make it easy to operate conversational search agents in production.
+
+## Scope
+- Nodes intended for inclusion under `orcheo.nodes.conversational_search`.
+- Shared utilities that the nodes depend upon (e.g., schema validators, telemetry wrappers).
+- Documentation and examples necessary for teams to adopt the nodes.
+
+Out of scope: custom UI surfaces, data labeling tooling, or vendor-specific orchestration outside of node contracts.
+
+## Functional Requirements
+### 1. Data Ingestion Nodes
+- **DocumentLoaderNode**: Accepts file blobs or URLs, normalizes into chunked `Document` objects, and emits metadata (source, mime type, checksum).
+- **EmbeddingIndexerNode**: Consumes normalized documents, batches them, computes embeddings (configurable model), and writes to a vector store interface (`BaseVectorStore`). Must support upsert semantics.
+- **SyncMonitorNode**: Emits status events for ingestion pipelines (success/failure counts, retry schedules).
+
+### 2. Retrieval & Ranking Nodes
+- **RetrieverNode**: Queries one or more `BaseVectorStore` implementations using hybrid (BM25 + dense) retrieval, returning scored `DocumentChunk` items.
+- **ReRankerNode**: Applies LLM or cross-encoder re-ranking; configurable top-k, threshold, and fallback modes.
+- **ContextCompressorNode**: Deduplicates and compresses context while preserving citations.
+
+### 3. Conversation & Memory Nodes
+- **ConversationStateNode**: Maintains dialog state (turn history, entity store, user profile). Pluggable persistence (Redis, Postgres, in-memory) with TTL management.
+- **FollowUpClassifierNode**: Determines whether the next action is retrieval, clarification, or final answer.
+- **MemorySummarizerNode**: Periodically summarizes long histories into episodic memory slots stored via `BaseMemoryStore`.
+
+### 4. Answer Generation & Grounding Nodes
+- **GroundedGeneratorNode**: Invokes LLMs with retrieved context, enforces citation attachment, and emits confidence scores.
+- **HallucinationGuardNode**: Validates generated answers against retrieved facts using entailment or rule-based checks; routes to fallback strategies when confidence < threshold.
+- **CitationsFormatterNode**: Produces structured references (URL, title, snippet) suitable for UI consumption.
+
+### 5. Tooling & Integration Nodes
+- **FeedbackIngestionNode**: Accepts explicit user feedback (thumbs up/down, free-form text) and writes to analytics sinks.
+- **TelemetryExportNode**: Exposes OpenTelemetry spans/metrics with node-level attributes (latency, token usage, result quality).
+- **PolicyComplianceNode**: Enforces content filters (PII, toxicity) with configurable policies and audit logging.
+
+## Non-Functional Requirements
+1. **Configurability**: Each node must expose a `NodeConfig` dataclass with validation and serde; defaults documented.
+2. **Observability**: Nodes emit structured events through Orcheo's tracing utilities and support correlation IDs.
+3. **Error Handling**: Graceful retries with exponential backoff for transient failures; surfaced via `NodeResult.status`.
+4. **Performance**: Baseline targets — ingestion throughput ≥ 500 documents/minute, retrieval p95 latency ≤ 1.5s, generation p95 ≤ 4s (assuming standard GPU-backed LLMs).
+5. **Security**: All nodes handling credentials must rely on Orcheo's secret manager bindings and redact sensitive values from logs.
+6. **Testing**: Provide unit tests per node plus integration tests for a reference conversational search graph defined under `tests/nodes/conversational_search/`.
+
+## Deliverables
+- Node implementations with docstrings and typing.
+- Example graph demonstrating ingestion → retrieval → generation pipeline.
+- MkDocs reference page summarizing configuration tables and usage notes.
+- Automated tests and fixtures.
+
+## Open Questions
+1. Which vector store adapters must be supported in v1 (e.g., Pinecone, PGVector, LanceDB)?
+2. Preferred hallucination detection approach (LLM judge vs. rule-based)?
+3. Data retention requirements for stored conversation history across geographies.

--- a/docs/conversational_search/requirements.md
+++ b/docs/conversational_search/requirements.md
@@ -16,30 +16,145 @@ This document captures the functional and non-functional requirements for a reus
 Out of scope: custom UI surfaces, data labeling tooling, or vendor-specific orchestration outside of node contracts.
 
 ## Functional Requirements
-### 1. Data Ingestion Nodes
+
+### Node Overview Summary
+
+The following table provides a quick reference of all proposed nodes organized by category and priority:
+
+| Category | Node | Priority | Purpose |
+|----------|------|----------|---------|
+| **Data Ingestion** | DocumentLoaderNode | P1 | Load and normalize documents from various sources |
+| | ChunkingStrategyNode | P1 | Apply configurable chunking strategies for optimal indexing |
+| | MetadataExtractorNode | P1 | Extract structured metadata to enrich chunks |
+| | EmbeddingIndexerNode | P1 | Generate embeddings and write to vector stores |
+| | IncrementalIndexerNode | P2 | Handle delta updates without full reindexing |
+| | SyncMonitorNode | P2 | Monitor ingestion pipeline health |
+| **Retrieval** | VectorRetrieverNode | P1 | Dense vector similarity search |
+| | BM25RetrieverNode | P1 | Traditional keyword-based retrieval |
+| | HybridFusionNode | P1 | Merge results from multiple retrievers |
+| | WebSearchNode | P1 | Integrate live web search results |
+| | ReRankerNode | P2 | Apply cross-encoder reranking |
+| | SourceRouterNode | P2 | Route queries to appropriate knowledge sources |
+| **Query Processing** | QueryRewriteNode | P1 | Expand/rewrite queries using conversation context |
+| | CoreferenceResolverNode | P1 | Resolve pronouns and references |
+| | QueryClassifierNode | P1 | Classify query intent for routing |
+| | ContextCompressorNode | P1 | Deduplicate and compress context |
+| **Conversation** | ConversationStateNode | P1 | Maintain dialog state and history |
+| | ConversationHistoryCompressorNode | P1 | Compress long conversation histories |
+| | TopicShiftDetectorNode | P1 | Detect conversation topic changes |
+| | MemorySummarizerNode | P2 | Summarize histories into episodic memory |
+| | SessionManagementNode | P2 | Handle session lifecycle and isolation |
+| **Generation** | GroundedGeneratorNode | P1 | Generate answers with citations |
+| | QueryClarificationNode | P1 | Generate clarifying questions |
+| | StreamingGeneratorNode | P2 | Token-by-token streaming responses |
+| | HallucinationGuardNode | P2 | Validate answers against facts |
+| | CitationsFormatterNode | P2 | Format citations for UI |
+| **Planning & Routing** | MultiHopPlannerNode | P2 | Plan multi-step retrieval tasks |
+| | FollowUpClassifierNode | P2 | Determine next action in conversation |
+| **Caching & Optimization** | AnswerCachingNode | P2 | Cache similar query results |
+| **Evaluation** | RetrievalEvaluationNode | P3 | Compute retrieval metrics (Recall@k, MRR, NDCG) |
+| | AnswerQualityEvaluationNode | P3 | LLM-as-a-judge answer evaluation |
+| | TurnAnnotationNode | P3 | Capture success/intent labels |
+| | SyntheticJudgeNode | P3 | Automated answer evaluation |
+| | DataAugmentationNode | P3 | Generate synthetic training data |
+| | FailureAnalysisNode | P3 | Categorize and analyze failures |
+| **Analytics** | UserFeedbackCollectionNode | P3 | Collect implicit/explicit feedback |
+| | FeedbackIngestionNode | P3 | Ingest user feedback |
+| | ABTestingNode | P3 | Support A/B testing workflows |
+| | TelemetryExportNode | P3 | Export OpenTelemetry data |
+| | AnalyticsExportNode | P3 | Export analytics to data warehouses |
+| **Compliance** | PolicyComplianceNode | P3 | Enforce content filters and policies |
+| | MemoryPrivacyNode | P3 | Apply redaction and retention policies |
+
+**Priority Legend**: P1 = Essential (MVP), P2 = Production-Ready, P3 = Research & Operations
+
+### Detailed Node Specifications
+
+The nodes are organized into three priority tiers to guide implementation:
+
+### Priority 1: Essential Nodes (MVP for conversational search research)
+
+These nodes form the minimal viable conversational search loop and should be implemented first.
+
+#### Data Ingestion
 - **DocumentLoaderNode**: Accepts file blobs or URLs, normalizes into chunked `Document` objects, and emits metadata (source, mime type, checksum).
+- **ChunkingStrategyNode**: Applies configurable chunking strategies (fixed-size, semantic, sentence-based, sliding window) to documents. Supports overlap configuration and metadata preservation. Essential for indexing quality experimentation.
+- **MetadataExtractorNode**: Extracts structured metadata from documents (title, date, author, section hierarchy, document type). Enriches chunks with contextual information for improved retrieval.
 - **EmbeddingIndexerNode**: Consumes normalized documents, batches them, computes embeddings (configurable model), and writes to a vector store interface (`BaseVectorStore`). Must support upsert semantics.
-- **SyncMonitorNode**: Emits status events for ingestion pipelines (success/failure counts, retry schedules).
 
-### 2. Retrieval & Ranking Nodes
-- **RetrieverNode**: Queries one or more `BaseVectorStore` implementations using hybrid (BM25 + dense) retrieval, returning scored `DocumentChunk` items.
-- **ReRankerNode**: Applies LLM or cross-encoder re-ranking; configurable top-k, threshold, and fallback modes.
-- **ContextCompressorNode**: Deduplicates and compresses context while preserving citations.
+#### Retrieval & Ranking
+- **VectorRetrieverNode**: Queries vector stores using dense embeddings. Supports configurable similarity metrics (cosine, dot product, euclidean) and top-k selection.
+- **BM25RetrieverNode**: Performs traditional keyword-based retrieval using BM25/Lucene. Essential for low-cost baseline experiments and handling keyword-heavy queries.
+- **HybridFusionNode**: Merges results from multiple retrievers (vector + BM25) using configurable fusion strategies (RRF - Reciprocal Rank Fusion, weighted scoring, or learned fusion). Critical for optimal retrieval performance.
+- **WebSearchNode**: Integrates live web search APIs (e.g., Google, Bing, SerpAPI) to augment retrieved knowledge with fresh web content. Returns normalized search results compatible with vector store outputs. Essential for hybrid retrieval experiments and accessing fresh information.
 
-### 3. Conversation & Memory Nodes
+#### Query Processing
+- **QueryRewriteNode**: Expands or rewrites user queries using conversational context to improve recall (synonym expansion, entity resolution, language normalization) before retrieval runs.
+- **CoreferenceResolverNode**: Resolves pronouns and references in conversational context ("it", "that document", "the previous one") to explicit entities. Essential for multi-turn conversations where users reference prior context.
+- **QueryClassifierNode**: Classifies query intent and type (factual, navigational, clarification needed, multi-hop) to route to appropriate retrieval strategies. Enables conditional workflow branching.
+- **ContextCompressorNode**: Deduplicates and compresses context while preserving citations. Critical for working within token limits during research experimentation.
+
+#### Conversation Management
 - **ConversationStateNode**: Maintains dialog state (turn history, entity store, user profile). Pluggable persistence (Redis, Postgres, in-memory) with TTL management.
-- **FollowUpClassifierNode**: Determines whether the next action is retrieval, clarification, or final answer.
-- **MemorySummarizerNode**: Periodically summarizes long histories into episodic memory slots stored via `BaseMemoryStore`.
+- **ConversationHistoryCompressorNode**: Compresses long conversation histories while preserving key information. Uses summarization or selective retention strategies to manage token budgets in multi-turn dialogs.
+- **TopicShiftDetectorNode**: Detects when conversation topic changes to trigger context reset or new search sessions. Prevents irrelevant prior context from polluting current queries.
 
-### 4. Answer Generation & Grounding Nodes
+#### Answer Generation
 - **GroundedGeneratorNode**: Invokes LLMs with retrieved context, enforces citation attachment, and emits confidence scores.
+- **QueryClarificationNode**: Generates clarifying questions when query ambiguity is detected. Prevents incorrect assumptions and improves answer accuracy through user interaction.
+
+### Priority 2: Production-Ready Enhancements
+
+These nodes add robustness, quality, and scalability for production deployments.
+
+#### Query Planning & Routing
+- **SourceRouterNode**: Chooses among heterogeneous knowledge sources (vector stores, scalar/BM25 indexes, web search, graph stores) and fuses their results based on confidence and freshness signals.
+- **MultiHopPlannerNode**: Breaks complex user intents into ordered retrieval/generation steps and emits sub-task directives for downstream nodes.
+
+#### Retrieval & Ranking
+- **ReRankerNode**: Applies LLM or cross-encoder re-ranking; configurable top-k, threshold, and fallback modes. Valuable for production quality but not required for basic research prototypes.
+
+#### Quality & Grounding
 - **HallucinationGuardNode**: Validates generated answers against retrieved facts using entailment or rule-based checks; routes to fallback strategies when confidence < threshold.
 - **CitationsFormatterNode**: Produces structured references (URL, title, snippet) suitable for UI consumption.
 
-### 5. Tooling & Integration Nodes
+#### Conversation Flow
+- **FollowUpClassifierNode**: Determines whether the next action is retrieval, clarification, or final answer. Useful for production but simple heuristics suffice for research.
+
+#### Memory & Optimization
+- **MemorySummarizerNode**: Periodically summarizes long histories into episodic memory slots stored via `BaseMemoryStore`.
+- **AnswerCachingNode**: Caches semantically similar queries and their answers to reduce latency and LLM costs. Uses configurable similarity thresholds and TTL policies.
+- **SessionManagementNode**: Handles session lifecycle events (creation, timeout, cleanup), manages multi-user session isolation, and enforces resource limits per session.
+
+#### User Experience
+- **StreamingGeneratorNode**: Extends GroundedGeneratorNode to support token-by-token streaming responses for real-time user experience. Emits partial results via async iterators. UX enhancement rather than research necessity.
+
+#### Data Ingestion Monitoring
+- **SyncMonitorNode**: Emits status events for ingestion pipelines (success/failure counts, retry schedules).
+- **IncrementalIndexerNode**: Handles delta/incremental updates to existing indexes. Detects document changes (add/update/delete) and efficiently updates vector stores without full reindexing.
+
+### Priority 3: Research, Compliance & Operations
+
+These nodes support evaluation, compliance, and production operations but are not required for core conversational search functionality.
+
+#### Evaluation & Research
+- **RetrievalEvaluationNode**: Computes standard retrieval metrics (Recall@k, MRR, NDCG, MAP) given ground truth relevance labels. Essential for systematic retrieval quality assessment.
+- **AnswerQualityEvaluationNode**: Evaluates generated answers using LLM-as-a-judge or rule-based metrics (faithfulness, relevance, completeness). Supports both reference-based and reference-free evaluation.
+- **TurnAnnotationNode**: Captures structured success/intent labels (e.g., answer quality, follow-up need) either from human feedback loops or scripted heuristics and emits them to evaluation stores.
+- **SyntheticJudgeNode**: Runs LLM-based evaluators on generated answers vs. references to support offline experimentation and regression gating.
+- **DataAugmentationNode**: Generates synthetic training data (query variations, negative samples, paraphrases) for model fine-tuning and evaluation dataset expansion.
+- **FailureAnalysisNode**: Identifies and categorizes failure modes in retrieval and generation (no results, irrelevant results, hallucinations, formatting errors). Emits structured failure reports for systematic improvement.
+
+#### Tooling & Integration
+- **UserFeedbackCollectionNode**: Collects both implicit (click-through, dwell time, reformulation) and explicit (thumbs up/down, ratings, comments) user feedback signals for evaluation and model improvement.
 - **FeedbackIngestionNode**: Accepts explicit user feedback (thumbs up/down, free-form text) and writes to analytics sinks.
+- **ABTestingNode**: Supports A/B testing of different retrieval or generation configurations. Routes traffic, tracks variant assignments, and exports comparison metrics.
 - **TelemetryExportNode**: Exposes OpenTelemetry spans/metrics with node-level attributes (latency, token usage, result quality).
+- **AnalyticsExportNode**: Exports structured analytics data (query patterns, performance metrics, user behavior) to data warehouses or analysis tools for offline research.
+
+#### Compliance & Security
 - **PolicyComplianceNode**: Enforces content filters (PII, toxicity) with configurable policies and audit logging.
+- **MemoryPrivacyNode**: Applies configurable redaction and retention policies to stored dialog state to meet regional compliance requirements before persistence.
 
 ## Non-Functional Requirements
 1. **Configurability**: Each node must expose a `NodeConfig` dataclass with validation and serde; defaults documented.
@@ -55,7 +170,107 @@ Out of scope: custom UI surfaces, data labeling tooling, or vendor-specific orch
 - MkDocs reference page summarizing configuration tables and usage notes.
 - Automated tests and fixtures.
 
+## Architecture Considerations
+
+### Node Composition Patterns
+The conversational search nodes are designed to compose into flexible workflows:
+
+1. **Basic RAG Pipeline**: DocumentLoader → Chunking → Indexer → VectorRetriever → GroundedGenerator
+2. **Hybrid Search**: (VectorRetriever + BM25Retriever) → HybridFusion → ReRanker → GroundedGenerator
+3. **Conversational Search**: ConversationState → QueryRewrite → CoreferenceResolver → Retrieval → GroundedGenerator
+4. **Multi-hop Reasoning**: MultiHopPlanner → (QueryRewrite → Retrieval)* → ContextCompressor → GroundedGenerator
+5. **Research Pipeline**: Retrieval → RetrievalEvaluation + AnswerQualityEvaluation → FailureAnalysis
+
+### Node Granularity Decisions
+
+Some capabilities are intentionally separated for flexibility:
+
+- **VectorRetrieverNode** and **BM25RetrieverNode** are separate to allow independent configuration and benchmarking
+- **HybridFusionNode** is explicit rather than embedded in retrievers to support experimentation with fusion strategies
+- **ChunkingStrategyNode** is separate from DocumentLoader to enable chunking strategy research without re-loading documents
+- **QueryClassifierNode** enables conditional workflow branching based on query type
+
+Nodes can be combined in implementations where separation isn't needed for a specific use case.
+
+## Implementation Recommendations
+
+### Phase 1: MVP (Weeks 1-4)
+**Goal**: Enable basic conversational search research
+
+Core retrieval loop:
+1. **Data Ingestion**: DocumentLoaderNode, ChunkingStrategyNode, EmbeddingIndexerNode
+2. **Query Processing**: QueryRewriteNode, ContextCompressorNode
+3. **Retrieval**: VectorRetrieverNode, BM25RetrieverNode, HybridFusionNode
+4. **Generation**: GroundedGeneratorNode
+
+This minimal set enables:
+- Document ingestion and indexing
+- Hybrid retrieval experimentation
+- Basic answer generation with citations
+- Query rewriting research
+
+### Phase 2: Conversational Features (Weeks 5-8)
+**Goal**: Add conversation-aware capabilities
+
+Add conversation handling:
+1. **Conversation Management**: ConversationStateNode, ConversationHistoryCompressorNode
+2. **Advanced Query Processing**: CoreferenceResolverNode, QueryClassifierNode, TopicShiftDetectorNode
+3. **Clarification**: QueryClarificationNode
+4. **External Knowledge**: WebSearchNode
+5. **Metadata**: MetadataExtractorNode
+
+This phase enables:
+- Multi-turn conversation handling
+- Reference resolution ("it", "that document")
+- Ambiguity handling through clarification
+- Fresh information via web search
+
+### Phase 3: Quality & Production (Weeks 9-12)
+**Goal**: Production-ready quality improvements
+
+Add quality and robustness:
+1. **Ranking**: ReRankerNode
+2. **Routing**: SourceRouterNode, MultiHopPlannerNode
+3. **Quality Gates**: HallucinationGuardNode, CitationsFormatterNode
+4. **Optimization**: AnswerCachingNode, IncrementalIndexerNode
+5. **UX**: StreamingGeneratorNode
+
+### Phase 4: Research & Operations (Ongoing)
+**Goal**: Enable systematic improvement
+
+Add evaluation and analytics:
+1. **Evaluation**: RetrievalEvaluationNode, AnswerQualityEvaluationNode, FailureAnalysisNode
+2. **Data Generation**: DataAugmentationNode
+3. **Feedback**: UserFeedbackCollectionNode, ABTestingNode
+4. **Analytics**: TelemetryExportNode, AnalyticsExportNode
+5. **Compliance**: PolicyComplianceNode, MemoryPrivacyNode
+
+### Key Dependencies
+
+```
+Phase 1 (MVP)
+└─ Phase 2 (Conversational)
+   └─ Phase 3 (Production Quality)
+      └─ Phase 4 (Research & Ops)
+
+Parallel tracks after Phase 1:
+- Evaluation nodes (Phase 4) can be built alongside Phase 2-3
+- Compliance nodes can be added as needed
+```
+
+### Technical Priorities
+
+1. **Interfaces First**: Define `BaseRetriever`, `BaseVectorStore`, `BaseMemoryStore` abstractions before node implementations
+2. **Composability**: Each node should be independently testable and configurable
+3. **Evaluation Early**: Build RetrievalEvaluationNode in Phase 2 to measure progress
+4. **Incremental Complexity**: Start with rule-based/simple approaches, then add ML-based variants
+
 ## Open Questions
-1. Which vector store adapters must be supported in v1 (e.g., Pinecone, PGVector, LanceDB)?
+1. Which vector store adapters must be supported in v1 (e.g., Pinecone, PGVector, LanceDB, Chroma)?
 2. Preferred hallucination detection approach (LLM judge vs. rule-based)?
 3. Data retention requirements for stored conversation history across geographies.
+4. Which external search/graph connectors are most valuable for the initial SourceRouterNode targets?
+5. What golden datasets or heuristics should SyntheticJudgeNode rely on for consistent offline evaluation?
+6. Should coreference resolution use rule-based (SpaCy) or neural approaches (NeuralCoref)?
+7. What fusion strategies should HybridFusionNode prioritize (RRF, weighted sum, learned models)?
+8. How should topic shift detection balance sensitivity vs. false positives in conversation flow?

--- a/docs/templates/design_template.md
+++ b/docs/templates/design_template.md
@@ -1,0 +1,120 @@
+# Design Document
+
+## For <Feature Name>
+
+- **Version:** 0.1
+- **Author:** <author>
+- **Date:** <date>
+- **Status:** Draft | In Review | Approved
+
+---
+
+## Overview
+
+A brief (2-3 paragraph) description of what this feature/system does, why it's being built, and the key goals it aims to achieve.
+
+## Components
+
+List the major components involved in this feature, with clear ownership boundaries. For each component, briefly describe its responsibility.
+
+- **Component A (Technology/Team)**
+  - Responsibility description
+  - Key interfaces or dependencies
+
+- **Component B (Technology/Team)**
+  - Responsibility description
+  - Key interfaces or dependencies
+
+## Request Flows
+
+Describe the main user/system flows with numbered steps. Include multiple flows if there are distinct paths (e.g., authenticated vs. public access).
+
+### Flow 1: <Flow Name>
+
+1. User/system initiates action
+2. Component A processes request
+3. Component B responds
+4. Result returned to user
+
+### Flow 2: <Flow Name>
+
+1. ...
+
+## API Contracts
+
+Document the key API endpoints, WebSocket messages, or inter-service contracts.
+
+```
+METHOD /api/endpoint
+Headers:
+  Authorization: Bearer <token>
+Body:
+  field: type
+
+Response:
+  200 OK -> { response_schema }
+  4xx/5xx -> error cases
+```
+
+## Data Models / Schemas
+
+Define key data structures, database schema changes, or message formats.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Unique identifier |
+| ... | ... | ... |
+
+Or use JSON/code blocks for complex schemas:
+
+```json
+{
+  "field": "type",
+  "nested": {
+    "child": "type"
+  }
+}
+```
+
+## Security Considerations
+
+- Authentication/authorization requirements
+- Data privacy and redaction needs
+- Input validation and sanitization
+- CORS, rate limiting, abuse prevention
+- Secrets management
+
+## Performance Considerations
+
+- Expected load/throughput
+- Caching strategy
+- Pagination or lazy loading needs
+- Resource constraints
+
+## Testing Strategy
+
+- **Unit tests**: Key logic to cover
+- **Integration tests**: API and service interaction tests
+- **Manual QA checklist**: Critical user flows to verify
+
+## Rollout Plan
+
+1. Phase 1: Internal/flag-gated deployment
+2. Phase 2: Limited rollout with monitoring
+3. Phase 3: General availability
+
+Include feature flags, migration steps, or backwards compatibility notes.
+
+## Open Issues
+
+- [ ] Unresolved question or decision
+- [ ] Dependency on external team/service
+- [ ] Future work explicitly deferred
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| | | Initial draft |

--- a/docs/templates/plan_template.md
+++ b/docs/templates/plan_template.md
@@ -14,7 +14,7 @@
 Brief summary of the project scope, objectives, and expected outcomes. Reference the related PRD and Design documents if available.
 
 **Related Documents:**
-- PRD: [Link]
+- Requirements: [Link]
 - Design: [Link]
 
 ---

--- a/docs/templates/plan_template.md
+++ b/docs/templates/plan_template.md
@@ -1,0 +1,91 @@
+# Project Plan
+
+## For <Feature/Project Name>
+
+- **Version:** 0.1
+- **Author:** <author>
+- **Date:** <date>
+- **Status:** Draft | In Progress | Completed
+
+---
+
+## Overview
+
+Brief summary of the project scope, objectives, and expected outcomes. Reference the related PRD and Design documents if available.
+
+**Related Documents:**
+- PRD: [Link]
+- Design: [Link]
+
+---
+
+## Milestones
+
+### Milestone 1: <Milestone Name>
+
+**Target Date:** <date>
+**Owner:** <owner>
+**Status:** Not Started | In Progress | Completed | Blocked
+
+**Description:** Brief description of what this milestone achieves and its success criteria.
+
+#### Task Checklist
+
+- [ ] Task 1.1: <Task description>
+  - Owner: <name>
+  - Dependencies: <list any blockers or prerequisites>
+- [ ] Task 1.2: <Task description>
+  - Owner: <name>
+  - Dependencies: None
+- [ ] Task 1.3: <Task description>
+  - Owner: <name>
+  - Dependencies: Task 1.1
+
+---
+
+### Milestone 2: <Milestone Name>
+
+**Target Date:** <date>
+**Owner:** <owner>
+**Status:** Not Started | In Progress | Completed | Blocked
+
+**Description:** Brief description of what this milestone achieves and its success criteria.
+
+#### Task Checklist
+
+- [ ] Task 2.1: <Task description>
+  - Owner: <name>
+  - Dependencies: Milestone 1
+- [ ] Task 2.2: <Task description>
+  - Owner: <name>
+  - Dependencies: None
+- [ ] Task 2.3: <Task description>
+  - Owner: <name>
+  - Dependencies: Task 2.1
+
+---
+
+### Milestone 3: <Milestone Name>
+
+**Target Date:** <date>
+**Owner:** <owner>
+**Status:** Not Started | In Progress | Completed | Blocked
+
+**Description:** Brief description of what this milestone achieves and its success criteria.
+
+#### Task Checklist
+
+- [ ] Task 3.1: <Task description>
+  - Owner: <name>
+  - Dependencies: Milestone 2
+- [ ] Task 3.2: <Task description>
+  - Owner: <name>
+  - Dependencies: None
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| | | Initial draft |

--- a/docs/templates/requirements_template.md
+++ b/docs/templates/requirements_template.md
@@ -1,22 +1,25 @@
-# PRD Template
+# Requirements Document Template
 
 ## METADATA
 - **Authors:**
-- **Project name (if applicable):**
-- **Product Summary:**
+- **Project/Feature Name:**
+- **Type:** Product | Feature | Enhancement
+- **Summary:**
 - **Owner (if different than authors):**
 - **Date Started:**
 
 ## RELEVANT LINKS & STAKEHOLDERS
+_[Include only the documents relevant to your project/feature scope]_
+
 | Documents | Link | Owner | Name |
 |-----------|------|-------|------|
 | Prior Artifacts | [Add link] | PM | [Insert name] |
-| PRD / Design Review | Deck | PM | [Insert name] |
+| Design Review | Deck | PM | [Insert name] |
 | Design File/Deck | Figma | Designer | [Insert name] |
 | Eng Requirement Doc | ERD | Tech Lead | [Insert name] |
-| Marketing Requirement Doc | MRD | PMM | [Insert name] |
-| Experiment Plan | link | DS | [Insert name] |
-| Product Rollout Docs | GTM & Launch Documentation | Product Ops | [Insert name] |
+| Marketing Requirement Doc (if applicable) | MRD | PMM | [Insert name] |
+| Experiment Plan (if applicable) | link | DS | [Insert name] |
+| Rollout Docs (if applicable) | GTM & Launch Documentation | Product Ops | [Insert name] |
 
 ## PROBLEM DEFINITION
 ### Objectives
@@ -62,27 +65,32 @@ _[Briefly summarize the overall impact on various products, parties, and functio
 ## TECHNICAL CONSIDERATIONS
 _[The goal of this section is to outline the high level engineering requirement to facilitate the engineering resource planning. Detailed engineering requirements or system design is out of scope for this section.]_
 
-### Why AI?
-_[Explain why AI is required/preferred for solving this problem]_
+### Architecture Overview
+_[For features: How does this fit into the existing system? For products: High-level system design]_
 [Insert text or link here]
 
-### Data Requirements
-_[What type of data is required for training the AI model? How do you plan to collect them?]_
+### Technical Requirements
+_[Key technical constraints, dependencies, and implementation considerations]_
 [Insert text or link here]
 
-### Algorithm selection
+### AI/ML Considerations (if applicable)
+_[Only include this section if AI/ML is part of the solution]_
+
+#### Data Requirements
+_[What type of data is required? How do you plan to collect it?]_
+[Insert text or link here]
+
+#### Algorithm selection
 _[Describe your initial thoughts on model selection, and why]_
 [Insert text or link here]
 
-### Model performance requirements
-_[Based on the product design, what’s the requirements on model performance? e.g. accuracy, recall, precision]_
+#### Model performance requirements
+_[What are the requirements on model performance? e.g. accuracy, recall, precision]_
 [Insert text or link here]
 
-### Engineering resource
-_[Estimate of # of DS, MLE, BE, FE, Designer, etc, and eng weeks]_
-[Insert text or link here]
+## MARKET DEFINITION (for products or large features)
+_[Skip this section for internal features or enhancements without external market impact]_
 
-## MARKET DEFINITION
 ### Total Addressable Market
 _[What is your TAM?]_
 _[What markets are not addressable by this product and why?]_
@@ -96,10 +104,7 @@ _[An exclusion request for specific markets captured in the TAM above.]_
 |--------|--------|--------------------------|
 | [Insert Region, Country, City, etc.] | [Insert Status: No launch/will launch/in discussion] | [Insert Text Here - briefly summarize why this market was requested for exclusion. Provide any relevant links] |
 
-## LAUNCH PLAN
-### Experiment Plan
-_[Provide an overview of the overall experiment approach. A/B test? Switchback? Pre-post? Holdout groups? The details of the experiment should be captured in the experiment plan driven by DS. Document where your XP will launch and should consider a market in each mega-region covered by your TAM]_
-[Insert text or link here]
+## LAUNCH/ROLLOUT PLAN
 
 ### Success metrics
 | KPIs | Target & Rationale |
@@ -108,17 +113,21 @@ _[Provide an overview of the overall experiment approach. A/B test? Switchback? 
 | [Secondary] [KPI 2] | [Goal] |
 | [Guardrail] [KPI 3] | [Goal] |
 
-### Estimated Geo Launch Phases (if applicable)
-_[Enter the estimated timeline using the expected month for each step. The intent is less on date precision but articulating why this product may need to roll out in phases to the TAM outlined above. The sum of all launch phases should equal the TAM minus any approved exclusion requests]_
-
-| XP launch | [Insert Month] | [Insert Text Here] |
-|-----------|----------------|---------------------|
-| **Phase 1 Launch** | [Insert Estimated Month or Quarter] | [Insert Text Here] _[List markets that will receive the feature in this phase. Outline why any markets will **not** receive this feature in this phase]_ |
-| **Phase 2 Launch** | [Insert Estimated Month or Quarter] | [Insert Text Here] _[List markets that will receive the feature in this phase. Outline why any markets will **not** receive this feature in this phase]_ |
-
-### Pricing strategy (if applicable)
-_[How do you price your product and why]_
+### Rollout Strategy
+_[For features: How will this be released? (feature flag, gradual rollout, etc.) For products: Full launch plan]_
 [Insert text or link here]
+
+### Experiment Plan (if applicable)
+_[Provide an overview of the overall experiment approach. A/B test? Switchback? Pre-post? Holdout groups?]_
+[Insert text or link here]
+
+### Estimated Launch Phases (if applicable)
+_[For phased rollouts, describe each phase and criteria for progression]_
+
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | [Insert target: users/markets/percentage] | [Insert Text Here] |
+| **Phase 2** | [Insert target] | [Insert Text Here] |
 
 ## HYPOTHESIS & RISKS
 _[Each hypothesis/risk should be limited to 2-3 sentences (i.e., one sentence for hypothesis, one sentence for confidence in hypothesis). Generally, PRDs should be focused on validating a single hypothesis and no more than two hypotheses.]_

--- a/docs/templates/requirements_template.md
+++ b/docs/templates/requirements_template.md
@@ -1,0 +1,129 @@
+# PRD Template
+
+## METADATA
+- **Authors:**
+- **Project name (if applicable):**
+- **Product Summary:**
+- **Owner (if different than authors):**
+- **Date Started:**
+
+## RELEVANT LINKS & STAKEHOLDERS
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| Prior Artifacts | [Add link] | PM | [Insert name] |
+| PRD / Design Review | Deck | PM | [Insert name] |
+| Design File/Deck | Figma | Designer | [Insert name] |
+| Eng Requirement Doc | ERD | Tech Lead | [Insert name] |
+| Marketing Requirement Doc | MRD | PMM | [Insert name] |
+| Experiment Plan | link | DS | [Insert name] |
+| Product Rollout Docs | GTM & Launch Documentation | Product Ops | [Insert name] |
+
+## PROBLEM DEFINITION
+### Objectives
+_[Two sentences max. What are you trying to do?]_
+[Insert text here]
+
+### Target users
+_[Who are you trying to solve the problem for?]_
+[Insert text here]
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+|         |              |            |          |                     |
+
+### Context, Problems, Opportunities
+_[This section should be limited to half a page or less. Cross-link any strategy decks, prior analysis, and prior experiments to keep this section concise while also sourcing your data.]_
+_[What problem are we solving, or what opportunity are we going after?]_
+_[Problem definition should be framed around exactly what we believe the problem to be with the current customer experience.]_
+[Insert text here]
+
+### Product goals and Non-goals
+_[What are the product goals? How do users benefit from using this product?]_
+_[What are the non-goals?]_
+[Insert text here]
+
+## PRODUCT DEFINITION
+### Requirements
+_[What are you building? What functionality is needed? What are the components? What does it look like? Given the goals, non-goals, and success metrics above, is there a proposed feature prioritization or phasing for the project? For large projects, please categorize requirements blocking an experiment / MVP (P0) vs serving as a future optimization before scaling (P1 or P2) vs out of scope entirely. For most projects, this section should constitute the majority of your PRD, driving clarity amongst your team and among cross-functional partners as to what is being built. It should be treated as an ongoing source of truth until launched.]_
+[Insert text or link here]
+
+### Designs (if applicable)
+_[Include an overview of the end-to-end design solution. Focus on key screens.]_
+[Insert Figma link]
+[Insert copy doc]
+[Insert text or link here]
+
+### [Optional] Other Teams Impacted
+_[Briefly summarize the overall impact on various products, parties, and functions across the ecosystem]_
+- [Affected Area]: [Elaboration of effect]
+- [Affected Area]: [Elaboration of effect]
+
+## TECHNICAL CONSIDERATIONS
+_[The goal of this section is to outline the high level engineering requirement to facilitate the engineering resource planning. Detailed engineering requirements or system design is out of scope for this section.]_
+
+### Why AI?
+_[Explain why AI is required/preferred for solving this problem]_
+[Insert text or link here]
+
+### Data Requirements
+_[What type of data is required for training the AI model? How do you plan to collect them?]_
+[Insert text or link here]
+
+### Algorithm selection
+_[Describe your initial thoughts on model selection, and why]_
+[Insert text or link here]
+
+### Model performance requirements
+_[Based on the product design, what’s the requirements on model performance? e.g. accuracy, recall, precision]_
+[Insert text or link here]
+
+### Engineering resource
+_[Estimate of # of DS, MLE, BE, FE, Designer, etc, and eng weeks]_
+[Insert text or link here]
+
+## MARKET DEFINITION
+### Total Addressable Market
+_[What is your TAM?]_
+_[What markets are not addressable by this product and why?]_
+[Insert text here]
+
+### Launch Exceptions
+_(for Product / Product Ops to fill-out)_
+_[An exclusion request for specific markets captured in the TAM above.]_
+
+| Market | Status | Considerations & Summary |
+|--------|--------|--------------------------|
+| [Insert Region, Country, City, etc.] | [Insert Status: No launch/will launch/in discussion] | [Insert Text Here - briefly summarize why this market was requested for exclusion. Provide any relevant links] |
+
+## LAUNCH PLAN
+### Experiment Plan
+_[Provide an overview of the overall experiment approach. A/B test? Switchback? Pre-post? Holdout groups? The details of the experiment should be captured in the experiment plan driven by DS. Document where your XP will launch and should consider a market in each mega-region covered by your TAM]_
+[Insert text or link here]
+
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| [Primary] [KPI 1] | [Goal] |
+| [Secondary] [KPI 2] | [Goal] |
+| [Guardrail] [KPI 3] | [Goal] |
+
+### Estimated Geo Launch Phases (if applicable)
+_[Enter the estimated timeline using the expected month for each step. The intent is less on date precision but articulating why this product may need to roll out in phases to the TAM outlined above. The sum of all launch phases should equal the TAM minus any approved exclusion requests]_
+
+| XP launch | [Insert Month] | [Insert Text Here] |
+|-----------|----------------|---------------------|
+| **Phase 1 Launch** | [Insert Estimated Month or Quarter] | [Insert Text Here] _[List markets that will receive the feature in this phase. Outline why any markets will **not** receive this feature in this phase]_ |
+| **Phase 2 Launch** | [Insert Estimated Month or Quarter] | [Insert Text Here] _[List markets that will receive the feature in this phase. Outline why any markets will **not** receive this feature in this phase]_ |
+
+### Pricing strategy (if applicable)
+_[How do you price your product and why]_
+[Insert text or link here]
+
+## HYPOTHESIS & RISKS
+_[Each hypothesis/risk should be limited to 2-3 sentences (i.e., one sentence for hypothesis, one sentence for confidence in hypothesis). Generally, PRDs should be focused on validating a single hypothesis and no more than two hypotheses.]_
+_[Hypothesis: what do you believe to be true, and what do you think will happen if you are correct? Recommend framing your hypothesis in a customer-centric way, while also describing how the user problem impacts metrics.]_
+_[Risk: what are potential risk areas for this feature and what could be some unintended consequences?]_
+[Insert text here]
+
+## APPENDIX

--- a/docs/templates/requirements_template.md
+++ b/docs/templates/requirements_template.md
@@ -1,5 +1,7 @@
 # Requirements Document Template
 
+**Developer note:** Remove any guidance text written in the `_[text]_` format when producing the final requirements document.
+
 ## METADATA
 - **Authors:**
 - **Project/Feature Name:**


### PR DESCRIPTION
## Summary
- add a new documentation space under `docs/conversational_search/`
- capture functional, non-functional, and open requirements for a conversational search node package

## Testing
- not run; documentation-only change

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c964adf008327a994b3f83b6c0d67)