### PR TITLE
Add retrieval stack for conversational search

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -29,7 +29,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 - [x] Task 1.1: Implement ingestion primitives (DocumentLoaderNode, ChunkingStrategyNode, MetadataExtractorNode, EmbeddingIndexerNode) with schema validation and Pinecone adapter.
   - Dependencies: Access to embedding model provider and Pinecone credentials.
-- [ ] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
+- [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,11 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
 from orcheo.nodes.conversational_search.vector_store import (
     BaseVectorStore,
     InMemoryVectorStore,
@@ -17,6 +22,9 @@ __all__ = [
     "BaseVectorStore",
     "InMemoryVectorStore",
     "PineconeVectorStore",
+    "VectorSearchNode",
+    "BM25SearchNode",
+    "HybridFusionNode",
     "DocumentLoaderNode",
     "ChunkingStrategyNode",
     "MetadataExtractorNode",

--- a/src/orcheo/nodes/conversational_search/models.py
+++ b/src/orcheo/nodes/conversational_search/models.py
@@ -71,3 +71,28 @@ class VectorRecord(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+class SearchResult(BaseModel):
+    """Search hit returned by a retriever."""
+
+    id: str = Field(description="Identifier of the retrieved document or chunk")
+    score: float = Field(description="Retriever-specific relevance score")
+    text: str = Field(description="Retrieved text body")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Metadata persisted alongside the retrieved text",
+    )
+    source: str | None = Field(
+        default=None, description="Optional label describing the retrieval backend"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FusedSearchResult(SearchResult):
+    """Result produced by a fusion strategy combining multiple retrievers."""
+
+    sources: list[str] = Field(
+        default_factory=list, description="Retrievers that contributed to the hit"
+    )

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -167,7 +167,8 @@ class BM25SearchNode(TaskNode):
                 freq = tf.get(term, 0)
                 if freq == 0:
                     continue
-                idf = self._idf(term, len(index), doc_freqs[term])
+                doc_freq = doc_freqs.get(term, 0)
+                idf = self._idf(term, len(index), doc_freq)
                 numerator = freq * (self.k1 + 1)
                 denominator = freq + self.k1 * (
                     1 - self.b + self.b * len(tokens) / avg_length

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -1,0 +1,306 @@
+"""Retrieval primitives for conversational search."""
+
+from __future__ import annotations
+import inspect
+import math
+import re
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field, field_validator
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.ingestion import EmbeddingIndexerNode
+from orcheo.nodes.conversational_search.models import (
+    DocumentChunk,
+    FusedSearchResult,
+    SearchResult,
+)
+from orcheo.nodes.conversational_search.vector_store import (
+    BaseVectorStore,
+    InMemoryVectorStore,
+)
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+EmbeddingFunction = Callable[[list[str]], list[list[float]]]
+
+
+@registry.register(
+    NodeMetadata(
+        name="VectorSearchNode",
+        description="Execute dense vector similarity search using a vector store.",
+        category="conversational_search",
+    )
+)
+class VectorSearchNode(TaskNode):
+    """Node that performs dense similarity search over an indexed corpus."""
+
+    input_query_key: str = Field(
+        default="query",
+        description="Key within ``state.inputs`` containing the query.",
+    )
+    filter_key: str | None = Field(
+        default="filters",
+        description="Optional key within ``state.inputs`` containing metadata filters.",
+    )
+    vector_store: BaseVectorStore = Field(
+        default_factory=InMemoryVectorStore,
+        description="Vector store adapter used to perform similarity search.",
+    )
+    embedding_function: EmbeddingFunction | None = Field(
+        default=None,
+        description="Callable that converts the query string into an embedding vector.",
+    )
+    top_k: int = Field(default=5, gt=0, description="Number of results to return.")
+    score_threshold: float = Field(
+        default=0.0, ge=0.0, description="Minimum relevance score to keep a match."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Embed the query and execute similarity search against the vector store."""
+        query = self._resolve_query(state)
+        filters = self._resolve_filters(state)
+
+        query_embedding = await self._embed_query(query)
+        matches = await self.vector_store.search(
+            query_embedding, top_k=self.top_k, filter_metadata=filters
+        )
+
+        filtered = [match for match in matches if match.score >= self.score_threshold]
+        return {"matches": filtered}
+
+    async def _embed_query(self, query: str) -> list[float]:
+        embedder = (
+            self.embedding_function or EmbeddingIndexerNode._default_embedding_function
+        )
+        result = embedder([query])
+        if inspect.isawaitable(result):
+            result = await result
+        if (
+            not isinstance(result, list)
+            or not result
+            or not isinstance(result[0], list)
+        ):
+            msg = "Embedding function must return List[List[float]]"
+            raise ValueError(msg)
+        return result[0]
+
+    def _resolve_query(self, state: State) -> str:
+        query = state.get("inputs", {}).get(self.input_query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "VectorSearchNode requires a non-empty string query"
+            raise ValueError(msg)
+        return query
+
+    def _resolve_filters(self, state: State) -> dict[str, Any] | None:
+        if self.filter_key is None:
+            return None
+        filters = state.get("inputs", {}).get(self.filter_key)
+        if filters is None:
+            return None
+        if not isinstance(filters, dict):
+            msg = "filters payload must be a mapping"
+            raise ValueError(msg)
+        return filters
+
+
+@registry.register(
+    NodeMetadata(
+        name="BM25SearchNode",
+        description="Perform BM25 search over in-memory chunk payloads.",
+        category="conversational_search",
+    )
+)
+class BM25SearchNode(TaskNode):
+    """Node implementing a lightweight BM25 scorer over document chunks."""
+
+    source_result_key: str = Field(
+        default="chunking_strategy",
+        description="Name of the upstream result entry containing chunks.",
+    )
+    chunks_field: str = Field(
+        default="chunks",
+        description="Field name within upstream results holding chunks.",
+    )
+    top_k: int = Field(default=5, gt=0, description="Number of results to return.")
+    k1: float = Field(
+        default=1.5, gt=0, description="BM25 term frequency scaling factor."
+    )
+    b: float = Field(
+        default=0.75, ge=0.0, le=1.0, description="BM25 length normalization parameter."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Score chunks using BM25 and return the top ``top_k`` hits."""
+        query = state.get("inputs", {}).get("query")
+        if not isinstance(query, str) or not query.strip():
+            msg = "BM25SearchNode requires a non-empty string query"
+            raise ValueError(msg)
+
+        chunks = self._resolve_chunks(state)
+        if not chunks:
+            msg = "BM25SearchNode requires at least one chunk"
+            raise ValueError(msg)
+
+        query_terms = self._tokenize(query)
+        if not query_terms:
+            msg = "Query must contain at least one token"
+            raise ValueError(msg)
+
+        index = [self._tokenize(chunk.content) for chunk in chunks]
+        doc_freqs: dict[str, int] = defaultdict(int)
+        for tokens in index:
+            for term in set(tokens):
+                doc_freqs[term] += 1
+
+        avg_length = sum(len(tokens) for tokens in index) / len(index)
+        scores: list[tuple[float, DocumentChunk]] = []
+        for tokens, chunk in zip(index, chunks, strict=True):
+            tf: dict[str, int] = defaultdict(int)
+            for term in tokens:
+                tf[term] += 1
+
+            score = 0.0
+            for term in query_terms:
+                freq = tf.get(term, 0)
+                if freq == 0:
+                    continue
+                idf = self._idf(term, len(index), doc_freqs[term])
+                numerator = freq * (self.k1 + 1)
+                denominator = freq + self.k1 * (
+                    1 - self.b + self.b * len(tokens) / avg_length
+                )
+                score += idf * numerator / denominator
+            scores.append((score, chunk))
+
+        scored = [
+            SearchResult(
+                id=chunk.id,
+                score=score,
+                text=chunk.content,
+                metadata=chunk.metadata,
+                source="bm25",
+            )
+            for score, chunk in scores
+        ]
+        scored.sort(key=lambda item: item.score, reverse=True)
+        return {"matches": scored[: self.top_k]}
+
+    def _resolve_chunks(self, state: State) -> list[DocumentChunk]:
+        results = state.get("results", {})
+        source = results.get(self.source_result_key, {})
+        if isinstance(source, dict) and self.chunks_field in source:
+            chunks = source[self.chunks_field]
+        else:
+            chunks = results.get(self.chunks_field)
+        if not chunks:
+            return []
+        if not isinstance(chunks, list):
+            msg = "chunks payload must be a list"
+            raise ValueError(msg)
+        return [DocumentChunk.model_validate(chunk) for chunk in chunks]
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return re.findall(r"[\w']+", text.lower())
+
+    def _idf(self, term: str, corpus_size: int, doc_freq: int) -> float:
+        return math.log(1 + (corpus_size - doc_freq + 0.5) / (doc_freq + 0.5))
+
+
+@registry.register(
+    NodeMetadata(
+        name="HybridFusionNode",
+        description="Fuse multiple retriever outputs using RRF or weighted strategies.",
+        category="conversational_search",
+    )
+)
+class HybridFusionNode(TaskNode):
+    """Node that combines retriever outputs via reciprocal-rank or weighted fusion."""
+
+    source_keys: list[str] = Field(
+        default_factory=lambda: ["vector_search", "bm25_search"],
+        description="Names of upstream result entries to fuse.",
+    )
+    results_field: str = Field(
+        default="matches",
+        description="Field within each upstream result containing search matches.",
+    )
+    strategy: str = Field(
+        default="rrf",
+        description="Fusion strategy to apply. Supported: 'rrf', 'weighted_sum'.",
+    )
+    rrf_k: int = Field(default=60, gt=0, description="Rank smoothing constant for RRF.")
+    weights: dict[str, float] = Field(
+        default_factory=dict, description="Per-retriever weights for weighted_sum."
+    )
+    top_k: int = Field(
+        default=10, gt=0, description="Number of fused results to return."
+    )
+
+    @field_validator("strategy")
+    @classmethod
+    def _validate_strategy(cls, value: str) -> str:
+        if value not in {"rrf", "weighted_sum"}:
+            msg = "strategy must be one of {'rrf', 'weighted_sum'}"
+            raise ValueError(msg)
+        return value
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fuse upstream retrieval results using the configured strategy."""
+        payloads = self._collect_payloads(state)
+        fused: list[FusedSearchResult]
+        if self.strategy == "rrf":
+            fused = self._rrf(payloads)
+        else:
+            fused = self._weighted_sum(payloads)
+
+        fused.sort(key=lambda item: item.score, reverse=True)
+        return {"fused_results": fused[: self.top_k]}
+
+    def _collect_payloads(self, state: State) -> dict[str, list[SearchResult]]:
+        results = state.get("results", {})
+        payloads: dict[str, list[SearchResult]] = {}
+        for key in self.source_keys:
+            data = results.get(key, {})
+            if not isinstance(data, dict):
+                continue
+            matches = data.get(self.results_field) or data.get("matches")
+            if not matches:
+                continue
+            payloads[key] = [SearchResult.model_validate(match) for match in matches]
+        return payloads
+
+    def _rrf(self, payloads: dict[str, list[SearchResult]]) -> list[FusedSearchResult]:
+        scores: dict[str, FusedSearchResult] = {}
+        for source, matches in payloads.items():
+            for rank, match in enumerate(matches, start=1):
+                contribution = 1 / (self.rrf_k + rank)
+                current = scores.get(match.id)
+                if current is None:
+                    data = match.model_dump(exclude={"score", "source"})
+                    current = FusedSearchResult(**data, score=0.0, sources=[source])
+                    scores[match.id] = current
+                else:
+                    current.sources.append(source)
+                current.score += contribution
+        return list(scores.values())
+
+    def _weighted_sum(
+        self, payloads: dict[str, list[SearchResult]]
+    ) -> list[FusedSearchResult]:
+        scores: dict[str, FusedSearchResult] = {}
+        for source, matches in payloads.items():
+            weight = self.weights.get(source, 1.0)
+            for match in matches:
+                current = scores.get(match.id)
+                if current is None:
+                    data = match.model_dump(exclude={"score", "source"})
+                    current = FusedSearchResult(**data, score=0.0, sources=[source])
+                    scores[match.id] = current
+                else:
+                    current.sources.append(source)
+                current.score += match.score * weight
+        return list(scores.values())

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -1,0 +1,135 @@
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.models import DocumentChunk, VectorRecord
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+class _StateFactory:
+    @staticmethod
+    def base_state(inputs: dict | None = None, results: dict | None = None) -> State:
+        return State(
+            inputs=inputs or {}, results=results or {}, structured_response=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_returns_sorted_matches() -> None:
+    store = InMemoryVectorStore()
+    await store.upsert(
+        [
+            VectorRecord(
+                id="chunk-1",
+                values=[1.0, 0.0],
+                text="alpha beta",
+                metadata={"document_id": "doc-1", "chunk_index": 0},
+            ),
+            VectorRecord(
+                id="chunk-2",
+                values=[0.5, 0.5],
+                text="beta gamma",
+                metadata={
+                    "document_id": "doc-1",
+                    "chunk_index": 1,
+                    "category": "demo",
+                },
+            ),
+        ]
+    )
+
+    node = VectorSearchNode(
+        name="vector_search",
+        vector_store=store,
+        embedding_function=lambda texts: [[1.0, 0.0] for _ in texts],
+        top_k=2,
+        score_threshold=0.2,
+    )
+    state = _StateFactory.base_state(inputs={"query": "alpha"})
+
+    result = await node.run(state, {})
+
+    matches = result["matches"]
+    assert [match.id for match in matches] == ["chunk-1", "chunk-2"]
+    assert matches[0].score > matches[1].score
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_node_scores_chunks() -> None:
+    chunks = [
+        DocumentChunk(
+            id="chunk-a",
+            document_id="doc-1",
+            index=0,
+            content="orcheo search retrieval",
+            metadata={},
+        ),
+        DocumentChunk(
+            id="chunk-b",
+            document_id="doc-2",
+            index=0,
+            content="search pipelines are modular",
+            metadata={},
+        ),
+    ]
+    state = _StateFactory.base_state(
+        inputs={"query": "search retrieval"},
+        results={"chunking_strategy": {"chunks": chunks}},
+    )
+    node = BM25SearchNode(name="bm25_search", top_k=1)
+
+    result = await node.run(state, {})
+
+    matches = result["matches"]
+    assert len(matches) == 1
+    assert matches[0].id == "chunk-a"
+    assert matches[0].source == "bm25"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_rrf_combines_sources() -> None:
+    vector_match = {"id": "shared", "score": 0.9, "text": "vec", "metadata": {}}
+    bm25_match = {"id": "shared", "score": 1.5, "text": "bm", "metadata": {}}
+    state = _StateFactory.base_state(
+        results={
+            "vector_search": {"matches": [vector_match]},
+            "bm25_search": {"matches": [bm25_match]},
+        }
+    )
+    node = HybridFusionNode(name="hybrid", strategy="rrf", rrf_k=10, top_k=1)
+
+    result = await node.run(state, {})
+
+    fused = result["fused_results"]
+    assert fused[0].id == "shared"
+    assert set(fused[0].sources) == {"vector_search", "bm25_search"}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_weighted_sum_respects_weights() -> None:
+    state = _StateFactory.base_state(
+        results={
+            "vector_search": {
+                "matches": [{"id": "a", "score": 0.5, "text": "v", "metadata": {}}]
+            },
+            "bm25_search": {
+                "matches": [{"id": "a", "score": 2.0, "text": "b", "metadata": {}}]
+            },
+        }
+    )
+    node = HybridFusionNode(
+        name="hybrid",
+        strategy="weighted_sum",
+        weights={"vector_search": 3.0, "bm25_search": 0.5},
+        top_k=1,
+    )
+
+    result = await node.run(state, {})
+
+    fused = result["fused_results"]
+    assert fused[0].id == "a"
+    assert fused[0].score == pytest.approx(3.0 * 0.5 + 0.5 * 2.0)


### PR DESCRIPTION
## Summary
- add dense, sparse, and hybrid retrieval nodes plus supporting search result models for conversational search
- extend vector store abstractions with search support and update in-memory and Pinecone adapters
- add targeted unit tests and mark the retrieval milestone as completed in the plan

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c5e6137483279a40622b801252b7)