### PR TITLE
Implement conversational search retrieval stack

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -29,7 +29,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 - [x] Task 1.1: Implement ingestion primitives (DocumentLoaderNode, ChunkingStrategyNode, MetadataExtractorNode, EmbeddingIndexerNode) with schema validation and Pinecone adapter.
   - Dependencies: Access to embedding model provider and Pinecone credentials.
-- [ ] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
+- [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,12 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
 from orcheo.nodes.conversational_search.vector_store import (
     BaseVectorStore,
     InMemoryVectorStore,
@@ -17,8 +23,12 @@ __all__ = [
     "BaseVectorStore",
     "InMemoryVectorStore",
     "PineconeVectorStore",
+    "SearchResult",
     "DocumentLoaderNode",
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "VectorSearchNode",
+    "BM25SearchNode",
+    "HybridFusionNode",
 ]

--- a/src/orcheo/nodes/conversational_search/models.py
+++ b/src/orcheo/nodes/conversational_search/models.py
@@ -71,3 +71,25 @@ class VectorRecord(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+class SearchResult(BaseModel):
+    """Normalized retrieval result returned by search nodes."""
+
+    id: str = Field(description="Identifier of the retrieved record")
+    content: str = Field(description="Text content associated with the hit")
+    score: float = Field(ge=0.0, description="Relevance score for ranking")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional metadata for the hit",
+    )
+    source: str | None = Field(
+        default=None,
+        description="Name of the retriever that produced the hit",
+    )
+    sources: list[str] = Field(
+        default_factory=list,
+        description="Retrievers that contributed to the fused result",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -1,0 +1,430 @@
+"""Retrieval and fusion nodes for conversational search."""
+
+from __future__ import annotations
+import inspect
+import math
+import re
+from collections import Counter
+from collections.abc import Callable
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, ConfigDict, Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import (
+    Document,
+    DocumentChunk,
+    SearchResult,
+)
+from orcheo.nodes.conversational_search.vector_store import (
+    BaseVectorStore,
+    InMemoryVectorStore,
+)
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+EmbeddingFunction = Callable[[list[str]], list[list[float]]]
+
+
+class _BM25Document(BaseModel):
+    """Lightweight normalized document for BM25 scoring."""
+
+    id: str
+    content: str
+    metadata: dict[str, Any]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@registry.register(
+    NodeMetadata(
+        name="VectorSearchNode",
+        description="Perform dense similarity search using a vector store.",
+        category="conversational_search",
+    )
+)
+class VectorSearchNode(TaskNode):
+    """Node that runs dense similarity search against a vector store."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key within ``state.inputs`` containing the query",
+    )
+    vector_store: BaseVectorStore = Field(
+        default_factory=InMemoryVectorStore,
+        description="Vector store adapter used for retrieval",
+    )
+    embedding_function: EmbeddingFunction | None = Field(
+        default=None,
+        description="Callable that embeds the user query for similarity search",
+    )
+    top_k: int = Field(default=10, gt=0, description="Number of hits to return")
+    score_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Minimum score required for a hit to be kept",
+    )
+    filter_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional metadata filters passed to the store",
+    )
+    include_metadata: bool = Field(
+        default=True,
+        description="Whether to return metadata stored with the vector record",
+    )
+    result_source_name: str = Field(
+        default="vector",
+        description="Label applied to results from this node",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Embed the query and search the configured vector store."""
+        query = self._resolve_query(state)
+        query_vector = await self._embed([query])
+        if len(query_vector) != 1:
+            msg = "Embedding function must return exactly one vector for the query"
+            raise ValueError(msg)
+
+        raw_results = await self.vector_store.search(
+            query_vector=query_vector[0],
+            top_k=self.top_k,
+            filter_metadata=self.filter_metadata or None,
+            include_metadata=self.include_metadata,
+        )
+
+        results = [
+            self._apply_source(SearchResult.model_validate(result))
+            for result in raw_results
+            if result.score >= self.score_threshold
+        ]
+        return {"results": results}
+
+    def _resolve_query(self, state: State) -> str:
+        query = state.get("inputs", {}).get(self.query_key)
+        if query is None:
+            msg = f"Missing query under inputs['{self.query_key}']"
+            raise ValueError(msg)
+        if not isinstance(query, str):
+            msg = "query input must be a string"
+            raise ValueError(msg)
+        normalized = query.strip()
+        if not normalized:
+            msg = "query input cannot be empty"
+            raise ValueError(msg)
+        return normalized
+
+    async def _embed(self, texts: list[str]) -> list[list[float]]:
+        embedder = self.embedding_function or self._default_embedding_function
+        result = embedder(texts)
+        if inspect.isawaitable(result):
+            result = await result  # type: ignore[assignment]
+        if not isinstance(result, list) or not all(
+            isinstance(row, list) for row in result
+        ):
+            msg = "Embedding function must return List[List[float]]"
+            raise ValueError(msg)
+        return result
+
+    @staticmethod
+    def _default_embedding_function(texts: list[str]) -> list[list[float]]:
+        """Deterministic embedding based on input length."""
+        embeddings: list[list[float]] = []
+        for text in texts:
+            # Use length-derived embedding for reproducibility and tests
+            embeddings.append([float(len(text))])
+        return embeddings
+
+    def _apply_source(self, result: SearchResult) -> SearchResult:
+        sources = result.sources or []
+        if not sources and self.result_source_name:
+            sources = [self.result_source_name]
+        update: dict[str, Any] = {"sources": sources}
+        if result.source is None:
+            update["source"] = self.result_source_name
+        return result.model_copy(update=update)
+
+
+@registry.register(
+    NodeMetadata(
+        name="BM25SearchNode",
+        description="Perform sparse BM25 retrieval over in-memory documents.",
+        category="conversational_search",
+    )
+)
+class BM25SearchNode(TaskNode):
+    """Lightweight BM25 retrieval that operates on provided documents."""
+
+    query_key: str = Field(default="query", description="State input key for the query")
+    source_result_key: str | None = Field(
+        default=None,
+        description="Optional result key containing documents to search",
+    )
+    documents_field: str = Field(
+        default="documents",
+        description="Field within the source result containing documents",
+    )
+    documents: list[Document | DocumentChunk | dict[str, Any] | str] = Field(
+        default_factory=list,
+        description="Inline corpus to search when state does not provide one",
+    )
+    top_k: int = Field(default=10, gt=0, description="Number of hits to return")
+    score_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Minimum score required for a hit to be included",
+    )
+    include_metadata: bool = Field(
+        default=True,
+        description="Whether to emit metadata with each hit",
+    )
+    k1: float = Field(default=1.5, gt=0, description="BM25 term frequency scaling")
+    b: float = Field(default=0.75, ge=0.0, le=1.0, description="BM25 length norm")
+    result_source_name: str = Field(
+        default="bm25",
+        description="Label applied to BM25 results",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Score documents using BM25 and return ranked results."""
+        query = self._resolve_query(state)
+        corpus = self._resolve_corpus(state)
+        if not corpus:
+            msg = "BM25SearchNode requires at least one document"
+            raise ValueError(msg)
+
+        query_tokens = self._tokenize(query)
+        if not query_tokens:
+            msg = "Query must contain at least one alphanumeric token"
+            raise ValueError(msg)
+
+        doc_tokens = [self._tokenize(doc.content) for doc in corpus]
+        avgdl = sum(len(tokens) for tokens in doc_tokens) / len(doc_tokens)
+        idf = self._inverse_document_frequency(doc_tokens)
+
+        scored: list[SearchResult] = []
+        for doc, tokens in zip(corpus, doc_tokens, strict=True):
+            score = self._bm25_score(tokens, query_tokens, idf, avgdl)
+            if score < self.score_threshold:
+                continue
+            metadata = doc.metadata if self.include_metadata else {}
+            scored.append(
+                SearchResult(
+                    id=doc.id,
+                    content=doc.content,
+                    score=max(score, 0.0),
+                    metadata=metadata,
+                    source=self.result_source_name,
+                    sources=[self.result_source_name],
+                )
+            )
+
+        ranked = sorted(scored, key=lambda result: result.score, reverse=True)[
+            : self.top_k
+        ]
+        return {"results": ranked}
+
+    def _resolve_query(self, state: State) -> str:
+        query = state.get("inputs", {}).get(self.query_key)
+        if query is None:
+            msg = f"Missing query under inputs['{self.query_key}']"
+            raise ValueError(msg)
+        if not isinstance(query, str):
+            msg = "query input must be a string"
+            raise ValueError(msg)
+        normalized = query.strip()
+        if not normalized:
+            msg = "query input cannot be empty"
+            raise ValueError(msg)
+        return normalized
+
+    def _resolve_corpus(self, state: State) -> list[_BM25Document]:
+        documents: list[Any] = list(self.documents)
+        if self.source_result_key:
+            source = state.get("results", {}).get(self.source_result_key, {})
+            if isinstance(source, dict) and self.documents_field in source:
+                documents.extend(source[self.documents_field])
+            elif source:
+                documents.extend(source if isinstance(source, list) else [])
+
+        normalized: list[_BM25Document] = []
+        for document in documents:
+            if isinstance(document, _BM25Document):
+                normalized.append(document)
+            elif isinstance(document, Document | DocumentChunk):
+                normalized.append(
+                    _BM25Document(
+                        id=document.id,
+                        content=document.content,
+                        metadata=document.metadata,
+                    )
+                )
+            elif isinstance(document, str):
+                normalized.append(
+                    _BM25Document(id=document, content=document, metadata={}),
+                )
+            elif isinstance(document, dict):
+                normalized.append(_BM25Document(**document))
+            else:
+                msg = f"Unsupported document type: {type(document).__name__}"
+                raise TypeError(msg)
+        return normalized
+
+    def _inverse_document_frequency(
+        self, doc_tokens: list[list[str]]
+    ) -> dict[str, float]:
+        df: Counter[str] = Counter()
+        for tokens in doc_tokens:
+            df.update(set(tokens))
+        num_docs = len(doc_tokens)
+        return {
+            term: math.log((num_docs - freq + 0.5) / (freq + 0.5) + 1)
+            for term, freq in df.items()
+        }
+
+    def _bm25_score(
+        self,
+        tokens: list[str],
+        query_tokens: list[str],
+        idf: dict[str, float],
+        avgdl: float,
+    ) -> float:
+        if not tokens:
+            return 0.0
+        term_freq = Counter(tokens)
+        score = 0.0
+        doc_len = len(tokens)
+        for term in query_tokens:
+            if term not in term_freq:
+                continue
+            freq = term_freq[term]
+            numerator = idf.get(term, 0.0) * freq * (self.k1 + 1)
+            denominator = freq + self.k1 * (1 - self.b + self.b * doc_len / avgdl)
+            score += numerator / denominator
+        return score
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return re.findall(r"\w+", text.lower())
+
+
+@registry.register(
+    NodeMetadata(
+        name="HybridFusionNode",
+        description="Fuse retrieval results using RRF or weighted strategies.",
+        category="conversational_search",
+    )
+)
+class HybridFusionNode(TaskNode):
+    """Combine results from multiple retrievers using scoring fusion."""
+
+    retrieval_results_key: str | None = Field(
+        default=None,
+        description="Optional key containing a mapping of retriever -> results",
+    )
+    source_result_keys: dict[str, str] = Field(
+        default_factory=lambda: {"vector": "vector_search", "bm25": "bm25_search"},
+        description="Mapping of retriever label to state results key",
+    )
+    strategy: str = Field(
+        default="rrf",
+        description="Fusion strategy: 'rrf' or 'weighted_sum'",
+    )
+    rrf_k: int = Field(
+        default=60,
+        gt=0,
+        description="RRF hyperparameter controlling rank damping",
+    )
+    weights: dict[str, float] = Field(
+        default_factory=dict,
+        description="Weights applied per retriever for weighted_sum",
+    )
+    top_k: int = Field(default=10, gt=0, description="Number of fused hits to return")
+    include_metadata: bool = Field(
+        default=True,
+        description="Whether to keep metadata on fused results",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fuse retrieval results from configured retrievers."""
+        sources = self._collect_sources(state)
+        if not sources:
+            msg = "HybridFusionNode requires at least one set of retrieval results"
+            raise ValueError(msg)
+
+        fused_scores: dict[str, float] = {}
+        fused_payloads: dict[str, SearchResult] = {}
+
+        for label, results in sources.items():
+            normalized = [self._normalize_result(result, label) for result in results]
+            for rank, result in enumerate(normalized, start=1):
+                contribution = self._score_contribution(label, result, rank)
+                fused_scores[result.id] = (
+                    fused_scores.get(result.id, 0.0) + contribution
+                )
+
+                payload = fused_payloads.get(result.id)
+                if payload is None:
+                    payload = result
+                else:
+                    merged_sources = list(
+                        dict.fromkeys(payload.sources + result.sources)
+                    )
+                    payload = payload.model_copy(update={"sources": merged_sources})
+                fused_payloads[result.id] = payload
+
+        fused_results = [
+            result.model_copy(update={"score": fused_scores[result_id]})
+            for result_id, result in fused_payloads.items()
+        ]
+        ranked = sorted(fused_results, key=lambda res: res.score, reverse=True)[
+            : self.top_k
+        ]
+        return {"results": ranked}
+
+    def _collect_sources(self, state: State) -> dict[str, list[Any]]:
+        sources: dict[str, list[Any]] = {}
+        container = None
+        if self.retrieval_results_key:
+            container = state.get("results", {}).get(self.retrieval_results_key)
+            if container is None:
+                container = state.get("inputs", {}).get(self.retrieval_results_key)
+        if isinstance(container, dict):
+            for label, payload in container.items():
+                sources[label] = self._extract_results(payload)
+
+        for label, key in self.source_result_keys.items():
+            payload = state.get("results", {}).get(key)
+            if payload is None or label in sources:
+                continue
+            sources[label] = self._extract_results(payload)
+        return sources
+
+    def _extract_results(self, payload: Any) -> list[Any]:
+        if isinstance(payload, dict) and "results" in payload:
+            payload = payload["results"]
+        if not isinstance(payload, list):
+            msg = "retrieval results must be a list"
+            raise ValueError(msg)
+        return payload
+
+    def _normalize_result(self, result: Any, label: str) -> SearchResult:
+        model = SearchResult.model_validate(result)
+        metadata = model.metadata if self.include_metadata else {}
+        sources = model.sources or []
+        if label not in sources:
+            sources.append(label)
+        update = {
+            "source": model.source or label,
+            "metadata": metadata,
+            "sources": sources,
+        }
+        return model.model_copy(update=update)
+
+    def _score_contribution(self, label: str, result: SearchResult, rank: int) -> float:
+        if self.strategy == "weighted_sum":
+            weight = self.weights.get(label, 1.0)
+            return result.score * weight
+        if self.strategy != "rrf":
+            msg = "Fusion strategy must be either 'rrf' or 'weighted_sum'"
+            raise ValueError(msg)
+        return 1.0 / (self.rrf_k + rank)

--- a/src/orcheo/nodes/conversational_search/vector_store.py
+++ b/src/orcheo/nodes/conversational_search/vector_store.py
@@ -151,7 +151,7 @@ class PineconeVectorStore(BaseVectorStore):
             top_k=top_k,
             namespace=self.namespace,
             filter=filter_metadata,
-            include_metadata=include_metadata,
+            include_metadata=True,
             include_values=False,
         )
         if inspect.iscoroutine(response):
@@ -167,7 +167,7 @@ class PineconeVectorStore(BaseVectorStore):
         results: list[SearchResult] = []
         for match in matches:
             metadata = match.get("metadata") or {}
-            text = metadata.get("text", "")
+            text = metadata.get("text") or match.get("text", "")
             results.append(
                 SearchResult(
                     id=str(match.get("id")),

--- a/src/orcheo/nodes/conversational_search/vector_store.py
+++ b/src/orcheo/nodes/conversational_search/vector_store.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 import inspect
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
-from orcheo.nodes.conversational_search.models import VectorRecord
+from orcheo.nodes.conversational_search.models import SearchResult, VectorRecord
 
 
 class BaseVectorStore(ABC, BaseModel):
@@ -17,6 +18,17 @@ class BaseVectorStore(ABC, BaseModel):
     @abstractmethod
     async def upsert(self, records: Iterable[VectorRecord]) -> None:
         """Persist ``records`` into the backing vector store."""
+
+    @abstractmethod
+    async def search(
+        self,
+        query_vector: list[float],
+        top_k: int,
+        *,
+        filter_metadata: dict[str, Any] | None = None,
+        include_metadata: bool = True,
+    ) -> list[SearchResult]:
+        """Return the ``top_k`` nearest records for ``query_vector``."""
 
 
 class InMemoryVectorStore(BaseVectorStore):
@@ -29,9 +41,73 @@ class InMemoryVectorStore(BaseVectorStore):
         for record in records:
             self.records[record.id] = record
 
-    def list(self) -> list[VectorRecord]:  # pragma: no cover - helper
+    def list_records(self) -> list[VectorRecord]:  # pragma: no cover - helper
         """Return a copy of stored records for inspection."""
         return list(self.records.values())
+
+    async def search(
+        self,
+        query_vector: list[float],
+        top_k: int,
+        *,
+        filter_metadata: dict[str, Any] | None = None,
+        include_metadata: bool = True,
+    ) -> list[SearchResult]:
+        """Perform cosine-similarity search against stored vectors."""
+        if not query_vector:
+            msg = "query_vector cannot be empty"
+            raise ValueError(msg)
+
+        filtered_records = [
+            record
+            for record in self.records.values()
+            if self._matches_filter(record.metadata, filter_metadata)
+        ]
+        scores: list[tuple[float, VectorRecord]] = []
+        for record in filtered_records:
+            score = self._cosine_similarity(query_vector, record.values)
+            scores.append((score, record))
+
+        ranked = sorted(scores, key=lambda item: item[0], reverse=True)[:top_k]
+        results: list[SearchResult] = []
+        for score, record in ranked:
+            metadata = record.metadata if include_metadata else {}
+            results.append(
+                SearchResult(
+                    id=record.id,
+                    content=record.text,
+                    score=max(score, 0.0),
+                    metadata=metadata,
+                )
+            )
+        return results
+
+    @staticmethod
+    def _matches_filter(
+        metadata: dict[str, Any], filter_metadata: dict[str, Any] | None
+    ) -> bool:
+        if not filter_metadata:
+            return True
+        for key, expected in filter_metadata.items():
+            actual = metadata.get(key)
+            if isinstance(expected, list):
+                if actual not in expected:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    @staticmethod
+    def _cosine_similarity(a: list[float], b: list[float]) -> float:
+        if len(a) != len(b):
+            msg = "query_vector and stored vector must have the same dimensions"
+            raise ValueError(msg)
+        dot = sum(x * y for x, y in zip(a, b, strict=True))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
 
 
 class PineconeVectorStore(BaseVectorStore):
@@ -58,6 +134,51 @@ class PineconeVectorStore(BaseVectorStore):
         result = index.upsert(vectors=payload, namespace=self.namespace)
         if inspect.iscoroutine(result):
             await result
+
+    async def search(
+        self,
+        query_vector: list[float],
+        top_k: int,
+        *,
+        filter_metadata: dict[str, Any] | None = None,
+        include_metadata: bool = True,
+    ) -> list[SearchResult]:
+        """Execute a similarity query against the Pinecone index."""
+        client = self._resolve_client()
+        index = self._resolve_index(client)
+        response = index.query(
+            vector=query_vector,
+            top_k=top_k,
+            namespace=self.namespace,
+            filter=filter_metadata,
+            include_metadata=include_metadata,
+            include_values=False,
+        )
+        if inspect.iscoroutine(response):
+            response = await response
+
+        matches_attr = getattr(response, "matches", None)
+        if matches_attr is not None:
+            matches = matches_attr
+        elif isinstance(response, dict):
+            matches = response.get("matches", [])
+        else:  # pragma: no cover - defensive guard for unknown response types
+            matches = []
+        results: list[SearchResult] = []
+        for match in matches:
+            metadata = match.get("metadata") or {}
+            text = metadata.get("text", "")
+            results.append(
+                SearchResult(
+                    id=str(match.get("id")),
+                    content=text,
+                    score=float(match.get("score", 0.0)),
+                    metadata=metadata if include_metadata else {},
+                    source="vector",
+                )
+            )
+
+        return results
 
     def _resolve_client(self) -> Any:
         if self.client is not None:

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -1,0 +1,138 @@
+"""Tests for conversational search retrieval nodes."""
+
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.models import SearchResult, VectorRecord
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+@pytest.mark.asyncio
+async def test_vector_search_filters_and_excludes_metadata() -> None:
+    store = InMemoryVectorStore(
+        records={
+            "keep": VectorRecord(
+                id="keep",
+                values=[1.0],
+                text="matching text",
+                metadata={"tag": "yes"},
+            ),
+            "drop": VectorRecord(
+                id="drop",
+                values=[1.0],
+                text="other text",
+                metadata={"tag": "no"},
+            ),
+        }
+    )
+    node = VectorSearchNode(
+        name="vector_search",
+        vector_store=store,
+        filter_metadata={"tag": "yes"},
+        include_metadata=False,
+        embedding_function=lambda texts: [[1.0]],
+    )
+    state = State(inputs={"query": "hello"}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    hits = result["results"]
+    assert len(hits) == 1
+    assert hits[0].id == "keep"
+    assert hits[0].metadata == {}
+    assert hits[0].source == "vector"
+    assert hits[0].sources == ["vector"]
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_ranks_and_truncates_results() -> None:
+    node = BM25SearchNode(
+        name="bm25",
+        documents=[
+            {"id": "doc-1", "content": "alpha beta beta", "metadata": {"m": 1}},
+            {"id": "doc-2", "content": "gamma", "metadata": {"m": 2}},
+        ],
+        top_k=1,
+        include_metadata=False,
+    )
+    state = State(inputs={"query": "beta"}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    hits = result["results"]
+    assert len(hits) == 1
+    assert hits[0].id == "doc-1"
+    assert hits[0].metadata == {}
+    assert hits[0].source == "bm25"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_rrf_prefers_combined_hits() -> None:
+    state = State(
+        inputs={},
+        results={
+            "vector_search": {
+                "results": [
+                    SearchResult(
+                        id="a", content="A", score=0.9, metadata={}, sources=["vector"]
+                    ),
+                    SearchResult(
+                        id="b", content="B", score=0.8, metadata={}, sources=["vector"]
+                    ),
+                ]
+            },
+            "bm25_search": {
+                "results": [
+                    SearchResult(
+                        id="b", content="B", score=2.0, metadata={}, sources=["bm25"]
+                    ),
+                    SearchResult(
+                        id="c", content="C", score=1.0, metadata={}, sources=["bm25"]
+                    ),
+                ]
+            },
+        },
+        structured_response=None,
+    )
+    node = HybridFusionNode(name="fusion", strategy="rrf", top_k=2)
+
+    result = await node.run(state, {})
+
+    hits = result["results"]
+    assert [hit.id for hit in hits] == ["b", "a"]
+    assert hits[0].sources == ["vector", "bm25"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_weighted_sum_uses_weights() -> None:
+    state = State(
+        inputs={},
+        results={
+            "retrieval_results": {
+                "vector": [
+                    {"id": "x", "content": "X", "score": 0.6, "metadata": {}},
+                ],
+                "bm25": [
+                    {"id": "y", "content": "Y", "score": 1.0, "metadata": {}},
+                ],
+            }
+        },
+        structured_response=None,
+    )
+    node = HybridFusionNode(
+        name="fusion-weighted",
+        retrieval_results_key="retrieval_results",
+        strategy="weighted_sum",
+        weights={"vector": 2.0, "bm25": 0.5},
+    )
+
+    result = await node.run(state, {})
+
+    hits = result["results"]
+    assert [hit.id for hit in hits][:1] == ["x"]
+    assert hits[0].source == "vector"


### PR DESCRIPTION
## Summary
- add a SearchResult payload and extend vector stores with search support, including in-memory cosine search and Pinecone queries
- implement VectorSearchNode, BM25SearchNode, and HybridFusionNode to provide dense, sparse, and fused retrieval flows
- add retrieval-focused unit tests and mark Task 1.2 complete in the conversational search plan

## Testing
- make lint
- uv run pytest tests/nodes/conversational_search/test_retrieval.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c5e6137483279a40622b801252b7)