### PR TITLE
Add conversational search retrieval stack

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -29,7 +29,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 - [x] Task 1.1: Implement ingestion primitives (DocumentLoaderNode, ChunkingStrategyNode, MetadataExtractorNode, EmbeddingIndexerNode) with schema validation and Pinecone adapter.
   - Dependencies: Access to embedding model provider and Pinecone credentials.
-- [ ] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
+- [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,11 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
 from orcheo.nodes.conversational_search.vector_store import (
     BaseVectorStore,
     InMemoryVectorStore,
@@ -21,4 +26,7 @@ __all__ = [
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "VectorSearchNode",
+    "BM25SearchNode",
+    "HybridFusionNode",
 ]

--- a/src/orcheo/nodes/conversational_search/models.py
+++ b/src/orcheo/nodes/conversational_search/models.py
@@ -71,3 +71,25 @@ class VectorRecord(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+class SearchResult(BaseModel):
+    """Standard retrieval result returned by conversational search nodes."""
+
+    id: str = Field(description="Identifier of the matched record")
+    content: str = Field(description="Retrieved text content")
+    score: float = Field(description="Relevance score for the match")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Associated metadata for filtering/citations",
+    )
+    source: str | None = Field(
+        default=None,
+        description="Name of the retriever or upstream source",
+    )
+    sources: list[str] = Field(
+        default_factory=list,
+        description="Retrieval sources contributing to the result",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -173,7 +173,9 @@ class BM25SearchNode(TaskNode):
             if isinstance(source, dict) and self.documents_field in source:
                 payload = source[self.documents_field]
             else:
-                payload = source or results.get(self.documents_field)
+                payload = (
+                    results.get(self.documents_field) if source is None else source
+                )
         else:
             payload = results.get(self.documents_field)
         if payload is None:

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -1,0 +1,342 @@
+"""Retrieval nodes for conversational search flows."""
+
+from __future__ import annotations
+import hashlib
+import math
+from collections import Counter
+from collections.abc import Iterable
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import ConfigDict, Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.ingestion import EmbeddingFunction
+from orcheo.nodes.conversational_search.models import (
+    Document,
+    DocumentChunk,
+    SearchResult,
+)
+from orcheo.nodes.conversational_search.vector_store import (
+    BaseVectorStore,
+    InMemoryVectorStore,
+)
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="VectorSearchNode",
+        description="Perform dense retrieval against a vector store.",
+        category="conversational_search",
+    )
+)
+class VectorSearchNode(TaskNode):
+    """Embed the query and retrieve similar chunks from a vector store."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key in ``state.inputs`` containing the query string.",
+    )
+    vector_store: BaseVectorStore = Field(
+        default_factory=InMemoryVectorStore,
+        description="Vector store adapter used for similarity search",
+    )
+    embedding_function: EmbeddingFunction | None = Field(
+        default=None,
+        description="Callable that converts queries to embedding vectors",
+    )
+    top_k: int = Field(default=10, gt=0, description="Maximum results to return")
+    score_threshold: float = Field(
+        default=0.0,
+        description="Minimum score required to include a match",
+    )
+    filter_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Metadata filters applied before scoring",
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Embed the incoming query and return ranked vector matches."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = f"Missing or invalid query under inputs['{self.query_key}']"
+            raise ValueError(msg)
+
+        vector = (await self._embed([query.strip()]))[0]
+        results = await self.vector_store.query(
+            vector=vector,
+            top_k=self.top_k,
+            filter_metadata=self.filter_metadata or None,
+        )
+        filtered = [
+            result for result in results if result.score >= self.score_threshold
+        ]
+        return {"results": filtered}
+
+    async def _embed(self, texts: list[str]) -> list[list[float]]:
+        embedder = self.embedding_function or self._default_embedding_function
+        result = embedder(texts)
+        if hasattr(result, "__await__"):
+            result = await result  # type: ignore[assignment]
+        if not isinstance(result, list) or not all(
+            isinstance(row, list) for row in result
+        ):
+            msg = "Embedding function must return List[List[float]]"
+            raise ValueError(msg)
+        return result
+
+    @staticmethod
+    def _default_embedding_function(texts: list[str]) -> list[list[float]]:
+        """Deterministic fallback embedding using SHA256 hashing."""
+        embeddings: list[list[float]] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode("utf-8")).digest()
+            vector = [byte / 255.0 for byte in digest[:16]]
+            embeddings.append(vector)
+        return embeddings
+
+
+@registry.register(
+    NodeMetadata(
+        name="BM25SearchNode",
+        description="Execute BM25 keyword search over a local corpus.",
+        category="conversational_search",
+    )
+)
+class BM25SearchNode(TaskNode):
+    """Lightweight BM25 implementation for chunk/document retrieval."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key in ``state.inputs`` containing the query string.",
+    )
+    source_result_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional key in ``state.results`` that contains the corpus payload."
+        ),
+    )
+    documents_field: str = Field(
+        default="chunks",
+        description="Field name within results holding documents or chunks to search.",
+    )
+    top_k: int = Field(default=10, gt=0, description="Maximum results to return")
+    score_threshold: float = Field(
+        default=0.0,
+        description="Minimum score required to include a match",
+    )
+    k1: float = Field(default=1.5, gt=0, description="BM25 term frequency scaling")
+    b: float = Field(
+        default=0.75, ge=0, description="BM25 length normalization parameter"
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Score corpus entries against the query using BM25."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = f"Missing or invalid query under inputs['{self.query_key}']"
+            raise ValueError(msg)
+
+        corpus = self._resolve_corpus(state)
+        if not corpus:
+            return {"results": []}
+
+        tokens = self._tokenize(query)
+        doc_tokens = [self._tokenize(item[1]) for item in corpus]
+        scores = self._bm25_scores(tokens, doc_tokens)
+
+        results: list[SearchResult] = []
+        for (doc_id, content, metadata), score in zip(corpus, scores, strict=True):
+            if score < self.score_threshold:
+                continue
+            results.append(
+                SearchResult(
+                    id=doc_id,
+                    content=content,
+                    metadata=metadata,
+                    score=score,
+                    source="bm25",
+                    sources=["bm25"],
+                )
+            )
+
+        results.sort(key=lambda item: item.score, reverse=True)
+        return {"results": results[: self.top_k]}
+
+    def _resolve_corpus(self, state: State) -> list[tuple[str, str, dict[str, Any]]]:
+        results = state.get("results", {})
+        payload: Any
+        if self.source_result_key:
+            source = results.get(self.source_result_key, {})
+            if isinstance(source, dict) and self.documents_field in source:
+                payload = source[self.documents_field]
+            else:
+                payload = source or results.get(self.documents_field)
+        else:
+            payload = results.get(self.documents_field)
+        if payload is None:
+            return []
+        if not isinstance(payload, list):
+            msg = f"{self.documents_field} payload must be a list"
+            raise ValueError(msg)
+
+        corpus: list[tuple[str, str, dict[str, Any]]] = []
+        for index, item in enumerate(payload):
+            doc_id, content, metadata = self._coerce_item(item, index)
+            corpus.append((doc_id, content, metadata))
+        return corpus
+
+    @staticmethod
+    def _coerce_item(item: Any, index: int) -> tuple[str, str, dict[str, Any]]:
+        if isinstance(item, DocumentChunk):
+            return item.id, item.content, item.metadata
+        if isinstance(item, Document):
+            return item.id, item.content, item.metadata
+        if isinstance(item, dict):
+            if "content" not in item:
+                msg = "Corpus entries must include 'content'"
+                raise ValueError(msg)
+            doc_id = item.get("id") or f"doc-{index}"
+            metadata = item.get("metadata") or {}
+            return doc_id, str(item["content"]), dict(metadata)
+        if isinstance(item, str):
+            return f"doc-{index}", item, {}
+        msg = "Unsupported corpus entry type"
+        raise ValueError(msg)
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return [token for token in text.lower().split() if token]
+
+    def _bm25_scores(
+        self, query_tokens: list[str], corpus_tokens: list[list[str]]
+    ) -> list[float]:
+        doc_freq: Counter[str] = Counter()
+        for tokens in corpus_tokens:
+            doc_freq.update(set(tokens))
+        num_docs = len(corpus_tokens)
+        avgdl = sum(len(tokens) for tokens in corpus_tokens) / max(num_docs, 1)
+
+        scores: list[float] = []
+        for tokens in corpus_tokens:
+            tf = Counter(tokens)
+            doc_len = len(tokens) or 1
+            score = 0.0
+            for term in query_tokens:
+                if term not in tf:
+                    continue
+                numerator = num_docs - doc_freq[term] + 0.5
+                denominator = doc_freq[term] + 0.5
+                idf = math.log(numerator / denominator + 1)
+                numerator = tf[term] * (self.k1 + 1)
+                normalization = 1 - self.b + self.b * doc_len / avgdl
+                denominator = tf[term] + self.k1 * normalization
+                score += idf * numerator / denominator
+            scores.append(score)
+        return scores
+
+
+@registry.register(
+    NodeMetadata(
+        name="HybridFusionNode",
+        description="Fuse multiple retrieval result sets via RRF or weighted sum.",
+        category="conversational_search",
+    )
+)
+class HybridFusionNode(TaskNode):
+    """Combine retrieval outputs from dense and sparse backends."""
+
+    source_result_keys: list[str] = Field(
+        default_factory=lambda: ["vector_search", "bm25_search"],
+        description="Result keys to fuse from ``state.results``.",
+    )
+    strategy: str = Field(
+        default="rrf",
+        description="Fusion strategy: 'rrf' or 'weighted_sum'",
+    )
+    weights: dict[str, float] = Field(
+        default_factory=dict,
+        description="Optional weights keyed by result source",
+    )
+    rrf_k: int = Field(default=60, gt=0, description="RRF k parameter")
+    top_k: int = Field(default=10, gt=0, description="Maximum fused results to return")
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fuse retrieval outputs using reciprocal rank or weighted scores."""
+        collected = self._collect_results(state)
+        if not collected:
+            msg = "HybridFusionNode requires at least one retrieval result set"
+            raise ValueError(msg)
+
+        fused = self._reciprocal_rank_fusion(collected)
+        if self.strategy == "weighted_sum":
+            fused = self._weighted_sum_fusion(collected)
+
+        fused.sort(key=lambda item: item.score, reverse=True)
+        return {"results": fused[: self.top_k]}
+
+    def _collect_results(self, state: State) -> dict[str, list[SearchResult]]:
+        aggregated: dict[str, list[SearchResult]] = {}
+        results = state.get("results", {})
+        for key in self.source_result_keys:
+            payload = results.get(key)
+            if payload is None:
+                continue
+            entries: Iterable[Any]
+            if isinstance(payload, dict) and "results" in payload:
+                entries = payload["results"]
+            elif isinstance(payload, list):
+                entries = payload
+            else:
+                continue
+            aggregated[key] = [SearchResult.model_validate(item) for item in entries]
+        return aggregated
+
+    def _reciprocal_rank_fusion(
+        self, collected: dict[str, list[SearchResult]]
+    ) -> list[SearchResult]:
+        fused: dict[str, SearchResult] = {}
+        scores: dict[str, float] = {}
+        for source, results in collected.items():
+            for rank, result in enumerate(results, start=1):
+                fused.setdefault(result.id, result)
+                scores.setdefault(result.id, 0.0)
+                scores[result.id] += 1 / (self.rrf_k + rank)
+                merged_sources = set(fused[result.id].sources or [])
+                merged_sources.update(result.sources or [source])
+                fused[result.id] = fused[result.id].model_copy(
+                    update={
+                        "sources": sorted(merged_sources),
+                        "source": fused[result.id].source or source,
+                    }
+                )
+        return [
+            fused[result_id].model_copy(update={"score": score})
+            for result_id, score in scores.items()
+        ]
+
+    def _weighted_sum_fusion(
+        self, collected: dict[str, list[SearchResult]]
+    ) -> list[SearchResult]:
+        fused: dict[str, SearchResult] = {}
+        scores: dict[str, float] = {}
+        for source, results in collected.items():
+            weight = self.weights.get(source, 1.0)
+            for result in results:
+                fused.setdefault(result.id, result)
+                scores.setdefault(result.id, 0.0)
+                scores[result.id] += weight * result.score
+                merged_sources = set(fused[result.id].sources or [])
+                merged_sources.update(result.sources or [source])
+                fused[result.id] = fused[result.id].model_copy(
+                    update={
+                        "sources": sorted(merged_sources),
+                        "source": fused[result.id].source or source,
+                    }
+                )
+        return [
+            fused[result_id].model_copy(update={"score": score})
+            for result_id, score in scores.items()
+        ]

--- a/src/orcheo/nodes/conversational_search/vector_store.py
+++ b/src/orcheo/nodes/conversational_search/vector_store.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
-from orcheo.nodes.conversational_search.models import VectorRecord
+from orcheo.nodes.conversational_search.models import SearchResult, VectorRecord
 
 
 class BaseVectorStore(ABC, BaseModel):
@@ -18,6 +18,15 @@ class BaseVectorStore(ABC, BaseModel):
     async def upsert(self, records: Iterable[VectorRecord]) -> None:
         """Persist ``records`` into the backing vector store."""
 
+    @abstractmethod
+    async def query(
+        self,
+        vector: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Return top ``top_k`` matches with optional metadata filtering."""
+
 
 class InMemoryVectorStore(BaseVectorStore):
     """Simple in-memory vector store useful for testing and local dev."""
@@ -28,6 +37,67 @@ class InMemoryVectorStore(BaseVectorStore):
         """Store ``records`` in the in-memory dictionary."""
         for record in records:
             self.records[record.id] = record
+
+    async def query(
+        self,
+        vector: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Return cosine-similar matches from the in-memory store."""
+        if not self.records:
+            return []
+        if not vector:
+            msg = "Query vector cannot be empty"
+            raise ValueError(msg)
+
+        filtered = list(self.records.values())
+        if filter_metadata:
+            filtered = [
+                record
+                for record in filtered
+                if self._metadata_matches(record.metadata, filter_metadata)
+            ]
+        if not filtered:
+            return []
+
+        scored = [
+            (
+                record,
+                self._cosine_similarity(vector, record.values),
+            )
+            for record in filtered
+        ]
+        scored.sort(key=lambda item: item[1], reverse=True)
+        results: list[SearchResult] = []
+        for record, score in scored[:top_k]:
+            results.append(
+                SearchResult(
+                    id=record.id,
+                    content=record.text,
+                    metadata=record.metadata,
+                    score=score,
+                    source="vector",
+                    sources=["vector"],
+                )
+            )
+        return results
+
+    @staticmethod
+    def _metadata_matches(metadata: dict[str, Any], filters: dict[str, Any]) -> bool:
+        return all(metadata.get(key) == value for key, value in filters.items())
+
+    @staticmethod
+    def _cosine_similarity(vector_a: list[float], vector_b: list[float]) -> float:
+        if len(vector_a) != len(vector_b):
+            msg = "Query vector dimension does not match stored vector"
+            raise ValueError(msg)
+        dot = sum(a * b for a, b in zip(vector_a, vector_b, strict=True))
+        norm_a = sum(a * a for a in vector_a) ** 0.5
+        norm_b = sum(b * b for b in vector_b) ** 0.5
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
 
     def list(self) -> list[VectorRecord]:  # pragma: no cover - helper
         """Return a copy of stored records for inspection."""
@@ -58,6 +128,42 @@ class PineconeVectorStore(BaseVectorStore):
         result = index.upsert(vectors=payload, namespace=self.namespace)
         if inspect.iscoroutine(result):
             await result
+
+    async def query(
+        self,
+        vector: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Query Pinecone for ``top_k`` matches using the provided vector."""
+        client = self._resolve_client()
+        index = self._resolve_index(client)
+        response = index.query(
+            namespace=self.namespace,
+            top_k=top_k,
+            vector=vector,
+            filter=filter_metadata or None,
+            include_metadata=True,
+            include_values=False,
+        )
+        if inspect.iscoroutine(response):
+            response = await response
+        matches = getattr(response, "matches", []) or response.get("matches", [])
+        results: list[SearchResult] = []
+        for match in matches:
+            metadata = match.get("metadata", {}) or {}
+            text = metadata.get("text", "")
+            results.append(
+                SearchResult(
+                    id=str(match.get("id")),
+                    content=text,
+                    metadata=metadata,
+                    score=float(match.get("score", 0.0)),
+                    source="vector",
+                    sources=["vector"],
+                )
+            )
+        return results
 
     def _resolve_client(self) -> Any:
         if self.client is not None:

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -1,0 +1,153 @@
+import pytest
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.models import SearchResult, VectorRecord
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+async def _embed_first_dimension(texts: list[str]) -> list[list[float]]:
+    return [[1.0, 0.0] for _ in texts]
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_returns_ranked_results() -> None:
+    store = InMemoryVectorStore()
+    await store.upsert(
+        [
+            VectorRecord(
+                id="a", values=[1.0, 0.0], text="alpha", metadata={"tag": "first"}
+            ),
+            VectorRecord(
+                id="b", values=[0.2, 0.8], text="bravo", metadata={"tag": "second"}
+            ),
+        ]
+    )
+    node = VectorSearchNode(
+        name="vector_search",
+        vector_store=store,
+        embedding_function=_embed_first_dimension,
+        top_k=2,
+    )
+    state = State(inputs={"query": "alpha"}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    matches = result["results"]
+    assert [match.id for match in matches] == ["a", "b"]
+    assert matches[0].metadata["tag"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_applies_metadata_filters() -> None:
+    store = InMemoryVectorStore()
+    await store.upsert(
+        [
+            VectorRecord(
+                id="a", values=[1.0, 0.0], text="alpha", metadata={"tag": "keep"}
+            ),
+            VectorRecord(
+                id="b", values=[1.0, 0.0], text="bravo", metadata={"tag": "skip"}
+            ),
+        ]
+    )
+    node = VectorSearchNode(
+        name="vector_search",
+        vector_store=store,
+        embedding_function=_embed_first_dimension,
+        filter_metadata={"tag": "keep"},
+    )
+    state = State(inputs={"query": "alpha"}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    assert [match.id for match in result["results"]] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_node_ranks_corpus() -> None:
+    corpus = [
+        {"id": "doc-1", "content": "apple banana apple"},
+        {"id": "doc-2", "content": "apple"},
+        {"id": "doc-3", "content": "banana orange"},
+    ]
+    node = BM25SearchNode(name="bm25_search", documents_field="documents", top_k=2)
+    state = State(
+        inputs={"query": "apple banana"},
+        results={"documents": corpus},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    matches = result["results"]
+    assert matches[0].id == "doc-1"
+    assert len(matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_rejects_non_list_payload() -> None:
+    node = BM25SearchNode(name="bm25_search", documents_field="documents")
+    state = State(
+        inputs={"query": "test"}, results={"documents": "bad"}, structured_response=None
+    )
+
+    with pytest.raises(ValueError, match="documents payload must be a list"):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_rrf_combines_sources() -> None:
+    vector_results = [
+        SearchResult(id="a", content="alpha", score=0.9, sources=["vector"]),
+        SearchResult(id="b", content="bravo", score=0.8, sources=["vector"]),
+    ]
+    bm25_results = [
+        SearchResult(id="b", content="bravo", score=1.5, sources=["bm25"]),
+        SearchResult(id="c", content="charlie", score=1.0, sources=["bm25"]),
+    ]
+    node = HybridFusionNode(name="hybrid", top_k=3)
+    state = State(
+        inputs={},
+        results={
+            "vector_search": {"results": vector_results},
+            "bm25_search": {"results": bm25_results},
+        },
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    fused = result["results"]
+    assert fused[0].id in {"a", "b"}
+    assert "bm25" in fused[0].sources or "vector" in fused[0].sources
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_weighted_sum_prefers_weighted_source() -> None:
+    vector_results = [
+        SearchResult(id="a", content="alpha", score=0.2, sources=["vector"])
+    ]
+    bm25_results = [SearchResult(id="a", content="alpha", score=1.0, sources=["bm25"])]
+    node = HybridFusionNode(
+        name="hybrid",
+        strategy="weighted_sum",
+        weights={"vector_search": 3.0, "bm25_search": 1.0},
+    )
+    state = State(
+        inputs={},
+        results={
+            "vector_search": {"results": vector_results},
+            "bm25_search": {"results": bm25_results},
+        },
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    fused = result["results"]
+    assert fused[0].id == "a"
+    assert fused[0].score == pytest.approx(1.6)


### PR DESCRIPTION
## Summary
- add conversational search retrieval nodes for vector, BM25, and hybrid fusion flows
- extend vector store abstractions with query support and shared search result model
- update documentation checklist for Task 1.2 and add coverage for retrieval behaviors

## Testing
- make lint
- uv run pytest tests/nodes/conversational_search -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c5e6137483279a40622b801252b7)