### PR TITLE
Add conversational search retrieval stack

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -29,7 +29,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 - [x] Task 1.1: Implement ingestion primitives (DocumentLoaderNode, ChunkingStrategyNode, MetadataExtractorNode, EmbeddingIndexerNode) with schema validation and Pinecone adapter.
   - Dependencies: Access to embedding model provider and Pinecone credentials.
-- [ ] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
+- [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,11 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
 from orcheo.nodes.conversational_search.vector_store import (
     BaseVectorStore,
     InMemoryVectorStore,
@@ -21,4 +26,7 @@ __all__ = [
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "VectorSearchNode",
+    "BM25SearchNode",
+    "HybridFusionNode",
 ]

--- a/src/orcheo/nodes/conversational_search/models.py
+++ b/src/orcheo/nodes/conversational_search/models.py
@@ -71,3 +71,23 @@ class VectorRecord(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+class SearchResult(BaseModel):
+    """Normalized retrieval result emitted by search nodes."""
+
+    id: str = Field(description="Identifier of the matching record")
+    score: float = Field(description="Relevance score (higher is better)")
+    text: str = Field(description="Content associated with the record")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Metadata returned by the retriever"
+    )
+    source: str | None = Field(
+        default=None, description="Origin retriever name (e.g., 'vector', 'bm25')"
+    )
+    sources: list[str] = Field(
+        default_factory=list,
+        description="List of retrievers contributing to this result",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -1,0 +1,333 @@
+"""Retrieval nodes for conversational search workflows."""
+
+from __future__ import annotations
+import inspect
+import math
+from collections import defaultdict
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.ingestion import (
+    EmbeddingFunction,
+    deterministic_embedding_function,
+)
+from orcheo.nodes.conversational_search.models import (
+    DocumentChunk,
+    SearchResult,
+)
+from orcheo.nodes.conversational_search.vector_store import (
+    BaseVectorStore,
+    InMemoryVectorStore,
+)
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="VectorSearchNode",
+        description="Perform dense similarity search using a configured vector store.",
+        category="conversational_search",
+    )
+)
+class VectorSearchNode(TaskNode):
+    """Node that performs dense retrieval against a vector store."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key within ``state.inputs`` containing the user query string.",
+    )
+    vector_store: BaseVectorStore = Field(
+        default_factory=InMemoryVectorStore,
+        description="Vector store adapter that will be queried.",
+    )
+    embedding_function: EmbeddingFunction | None = Field(
+        default=None,
+        description="Callable that embeds the query into a vector for retrieval.",
+    )
+    top_k: int = Field(
+        default=5, gt=0, description="Maximum number of results to return"
+    )
+    score_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Minimum score required for a result to be returned.",
+    )
+    filter_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional metadata filters applied to the vector store query.",
+    )
+    source_name: str = Field(
+        default="vector",
+        description="Label used to annotate the originating retriever",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Embed the query and perform similarity search."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "VectorSearchNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        embeddings = await self._embed([query])
+        results = await self.vector_store.search(
+            query=embeddings[0],
+            top_k=self.top_k,
+            filter_metadata=self.filter_metadata or None,
+        )
+
+        normalized = [
+            SearchResult(
+                id=result.id,
+                score=result.score,
+                text=result.text,
+                metadata=result.metadata,
+                source=result.source or self.source_name,
+                sources=result.sources or [result.source or self.source_name],
+            )
+            for result in results
+            if result.score >= self.score_threshold
+        ]
+
+        return {"results": normalized}
+
+    async def _embed(self, texts: list[str]) -> list[list[float]]:
+        embedder = self.embedding_function or deterministic_embedding_function
+        output = embedder(texts)
+        if inspect.isawaitable(output):
+            output = await output  # type: ignore[assignment]
+        if not isinstance(output, list) or not all(
+            isinstance(row, list) for row in output
+        ):
+            msg = "Embedding function must return List[List[float]]"
+            raise ValueError(msg)
+        return output
+
+
+@registry.register(
+    NodeMetadata(
+        name="BM25SearchNode",
+        description="Perform sparse keyword retrieval using BM25 scoring.",
+        category="conversational_search",
+    )
+)
+class BM25SearchNode(TaskNode):
+    """Node that computes BM25 scores over in-memory chunks."""
+
+    source_result_key: str = Field(
+        default="chunking_strategy",
+        description="Name of the upstream result containing chunks.",
+    )
+    chunks_field: str = Field(
+        default="chunks", description="Field containing chunk payloads"
+    )
+    query_key: str = Field(
+        default="query", description="Key within inputs holding the user query"
+    )
+    top_k: int = Field(
+        default=5, gt=0, description="Maximum number of results to return"
+    )
+    score_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Minimum BM25 score required for inclusion",
+    )
+    k1: float = Field(default=1.5, gt=0)
+    b: float = Field(default=0.75, ge=0.0, le=1.0)
+    source_name: str = Field(
+        default="bm25", description="Label for the sparse retriever"
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Score document chunks with BM25 and return the top matches."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "BM25SearchNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        chunks = self._resolve_chunks(state)
+        if not chunks:
+            msg = "BM25SearchNode requires at least one chunk to search"
+            raise ValueError(msg)
+
+        tokenized_corpus = [self._tokenize(chunk.content) for chunk in chunks]
+        avg_length = sum(len(doc) for doc in tokenized_corpus) / len(tokenized_corpus)
+
+        scores: list[tuple[DocumentChunk, float]] = []
+        query_tokens = self._tokenize(query)
+        for chunk, tokens in zip(chunks, tokenized_corpus, strict=True):
+            score = self._bm25_score(tokens, query_tokens, tokenized_corpus, avg_length)
+            scores.append((chunk, score))
+
+        ranked = [
+            SearchResult(
+                id=chunk.id,
+                score=score,
+                text=chunk.content,
+                metadata=chunk.metadata,
+                source=self.source_name,
+                sources=[self.source_name],
+            )
+            for chunk, score in sorted(scores, key=lambda item: item[1], reverse=True)
+            if score >= self.score_threshold
+        ][: self.top_k]
+
+        return {"results": ranked}
+
+    def _resolve_chunks(self, state: State) -> list[DocumentChunk]:
+        results = state.get("results", {})
+        source = results.get(self.source_result_key, {})
+        if isinstance(source, dict) and self.chunks_field in source:
+            chunks = source[self.chunks_field]
+        else:
+            chunks = results.get(self.chunks_field)
+        if not chunks:
+            return []
+        if not isinstance(chunks, list):
+            msg = "chunks payload must be a list"
+            raise ValueError(msg)
+        return [DocumentChunk.model_validate(chunk) for chunk in chunks]
+
+    def _bm25_score(
+        self,
+        document_tokens: list[str],
+        query_tokens: list[str],
+        corpus: list[list[str]],
+        avg_length: float,
+    ) -> float:
+        score = 0.0
+        doc_len = len(document_tokens)
+        token_freq: dict[str, int] = defaultdict(int)
+        for token in document_tokens:
+            token_freq[token] += 1
+
+        for token in query_tokens:
+            idf = self._idf(token, corpus)
+            freq = token_freq.get(token, 0)
+            numerator = freq * (self.k1 + 1)
+            denominator = freq + self.k1 * (
+                1 - self.b + self.b * (doc_len / avg_length)
+            )
+            if denominator == 0:
+                continue
+            score += idf * (numerator / denominator)
+        return score
+
+    @staticmethod
+    def _idf(token: str, corpus: list[list[str]]) -> float:
+        doc_count = sum(1 for document in corpus if token in document)
+        return math.log(((len(corpus) - doc_count + 0.5) / (doc_count + 0.5)) + 1)
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return [token for token in text.lower().split() if token]
+
+
+@registry.register(
+    NodeMetadata(
+        name="HybridFusionNode",
+        description="Fuse results from multiple retrievers using RRF or weighted sum.",
+        category="conversational_search",
+    )
+)
+class HybridFusionNode(TaskNode):
+    """Merge retrieval results using Reciprocal Rank Fusion or weighted scores."""
+
+    results_field: str = Field(
+        default="retrieval_results",
+        description="Key within results containing retriever outputs to fuse.",
+    )
+    strategy: str = Field(
+        default="rrf",
+        description="Fusion strategy: either 'rrf' or 'weighted_sum'.",
+    )
+    weights: dict[str, float] = Field(
+        default_factory=dict,
+        description="Optional per-retriever weights for weighted_sum fusion.",
+    )
+    rrf_k: int = Field(
+        default=60, gt=0, description="RRF constant to dampen rank impact"
+    )
+    top_k: int = Field(
+        default=10, gt=0, description="Number of fused results to return"
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fuse retriever outputs according to the configured strategy."""
+        results_map = state.get("results", {}).get(self.results_field)
+        if not isinstance(results_map, dict) or not results_map:
+            msg = "HybridFusionNode requires a mapping of retriever results"
+            raise ValueError(msg)
+
+        if self.strategy not in {"rrf", "weighted_sum"}:
+            msg = "strategy must be either 'rrf' or 'weighted_sum'"
+            raise ValueError(msg)
+
+        normalized: dict[str, list[SearchResult]] = {}
+        for source, payload in results_map.items():
+            if isinstance(payload, dict) and "results" in payload:
+                entries = payload["results"]
+            else:
+                entries = payload
+            if not isinstance(entries, list):
+                msg = f"Retriever results for {source} must be a list"
+                raise ValueError(msg)
+            normalized[source] = [SearchResult.model_validate(item) for item in entries]
+
+        fused = (
+            self._reciprocal_rank_fusion(normalized)
+            if self.strategy == "rrf"
+            else self._weighted_sum_fusion(normalized)
+        )
+
+        ranked = sorted(fused.values(), key=lambda item: item.score, reverse=True)
+        return {"results": ranked[: self.top_k]}
+
+    def _reciprocal_rank_fusion(
+        self, results: dict[str, list[SearchResult]]
+    ) -> dict[str, SearchResult]:
+        fused: dict[str, SearchResult] = {}
+        for source, entries in results.items():
+            for rank, entry in enumerate(entries, start=1):
+                score = 1 / (self.rrf_k + rank)
+                fused.setdefault(
+                    entry.id,
+                    SearchResult(
+                        id=entry.id,
+                        score=0.0,
+                        text=entry.text,
+                        metadata=entry.metadata,
+                        source="hybrid",
+                        sources=[source],
+                    ),
+                )
+                fused_entry = fused[entry.id]
+                fused_entry.score += score
+                if source not in fused_entry.sources:
+                    fused_entry.sources.append(source)
+        return fused
+
+    def _weighted_sum_fusion(
+        self, results: dict[str, list[SearchResult]]
+    ) -> dict[str, SearchResult]:
+        fused: dict[str, SearchResult] = {}
+        for source, entries in results.items():
+            weight = self.weights.get(source, 1.0)
+            for entry in entries:
+                fused.setdefault(
+                    entry.id,
+                    SearchResult(
+                        id=entry.id,
+                        score=0.0,
+                        text=entry.text,
+                        metadata=entry.metadata,
+                        source="hybrid",
+                        sources=[source],
+                    ),
+                )
+                fused_entry = fused[entry.id]
+                fused_entry.score += weight * entry.score
+                if source not in fused_entry.sources:
+                    fused_entry.sources.append(source)
+        return fused

--- a/src/orcheo/nodes/conversational_search/vector_store.py
+++ b/src/orcheo/nodes/conversational_search/vector_store.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 import inspect
+import math
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
-from orcheo.nodes.conversational_search.models import VectorRecord
+from orcheo.nodes.conversational_search.models import SearchResult, VectorRecord
 
 
 class BaseVectorStore(ABC, BaseModel):
@@ -17,6 +18,15 @@ class BaseVectorStore(ABC, BaseModel):
     @abstractmethod
     async def upsert(self, records: Iterable[VectorRecord]) -> None:
         """Persist ``records`` into the backing vector store."""
+
+    @abstractmethod
+    async def search(
+        self,
+        query: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Return the top matching records for ``query``."""
 
 
 class InMemoryVectorStore(BaseVectorStore):
@@ -29,9 +39,63 @@ class InMemoryVectorStore(BaseVectorStore):
         for record in records:
             self.records[record.id] = record
 
+    async def search(
+        self,
+        query: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Perform cosine similarity search over in-memory vectors."""
+        candidates = list(self.records.values())
+        if filter_metadata:
+            candidates = [
+                record
+                for record in candidates
+                if all(
+                    record.metadata.get(key) == value
+                    for key, value in filter_metadata.items()
+                )
+            ]
+
+        scored: list[SearchResult] = []
+        for record in candidates:
+            score = self._cosine_similarity(query, record.values)
+            scored.append(
+                SearchResult(
+                    id=record.id,
+                    score=score,
+                    text=record.text,
+                    metadata=record.metadata,
+                )
+            )
+
+        scored.sort(key=lambda item: item.score, reverse=True)
+        return scored[:top_k]
+
     def list(self) -> list[VectorRecord]:  # pragma: no cover - helper
         """Return a copy of stored records for inspection."""
         return list(self.records.values())
+
+    @staticmethod
+    def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+        left_vector = list(left)
+        right_vector = list(right)
+
+        if not left_vector or not right_vector:
+            return 0.0
+        if len(left_vector) != len(right_vector):
+            msg = "Vector dimensions must match for similarity search"
+            raise ValueError(msg)
+
+        dot = 0.0
+        for left_value, right_value in zip(left_vector, right_vector, strict=True):
+            dot += left_value * right_value
+
+        left_norm = math.sqrt(sum(value * value for value in left_vector))
+        right_norm = math.sqrt(sum(value * value for value in right_vector))
+        if left_norm == 0.0 or right_norm == 0.0:
+            return 0.0
+        return dot / (left_norm * right_norm)
 
 
 class PineconeVectorStore(BaseVectorStore):
@@ -58,6 +122,57 @@ class PineconeVectorStore(BaseVectorStore):
         result = index.upsert(vectors=payload, namespace=self.namespace)
         if inspect.iscoroutine(result):
             await result
+
+    async def search(
+        self,
+        query: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Query Pinecone for the most similar vectors."""
+        client = self._resolve_client()
+        index = self._resolve_index(client)
+        result = index.query(
+            vector=query,
+            top_k=top_k,
+            namespace=self.namespace,
+            include_metadata=True,
+            filter=filter_metadata or None,
+        )
+        if inspect.iscoroutine(result):
+            result = await result
+
+        matches = getattr(result, "matches", None)
+        if matches is None and isinstance(result, dict):
+            matches = result.get("matches", [])
+        matches = matches or []
+        normalized: list[SearchResult] = []
+        for match in matches:
+            metadata = getattr(match, "metadata", None)
+            if metadata is None and isinstance(match, dict):
+                metadata = match.get("metadata", {})
+            metadata = metadata or {}
+
+            score = getattr(match, "score", None)
+            if score is None and isinstance(match, dict):
+                score = match.get("score", 0.0)
+
+            text = metadata.get("text", "")
+            match_id = getattr(match, "id", None)
+            if match_id is None and isinstance(match, dict):
+                match_id = match.get("id")
+            if match_id is None:
+                continue
+
+            normalized.append(
+                SearchResult(
+                    id=match_id,
+                    score=float(score) if score is not None else 0.0,
+                    text=text,
+                    metadata=metadata,
+                )
+            )
+        return normalized
 
     def _resolve_client(self) -> Any:
         if self.client is not None:

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -1,0 +1,150 @@
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.ingestion import (
+    deterministic_embedding_function,
+)
+from orcheo.nodes.conversational_search.models import (
+    DocumentChunk,
+    SearchResult,
+    VectorRecord,
+)
+from orcheo.nodes.conversational_search.retrieval import (
+    BM25SearchNode,
+    HybridFusionNode,
+    VectorSearchNode,
+)
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_returns_ranked_results() -> None:
+    store = InMemoryVectorStore()
+    texts = ["orcheo improves graphs", "another passage"]
+    embeddings = deterministic_embedding_function(texts)
+    await store.upsert(
+        [
+            VectorRecord(
+                id=f"vec-{index}",
+                values=embedding,
+                text=text,
+                metadata={"source": "demo", "index": index},
+            )
+            for index, (embedding, text) in enumerate(
+                zip(embeddings, texts, strict=True)
+            )
+        ]
+    )
+
+    node = VectorSearchNode(
+        name="vector",
+        vector_store=store,
+        top_k=2,
+        filter_metadata={"source": "demo"},
+    )
+    state = State(
+        inputs={"query": "orcheo improves graphs"}, results={}, structured_response=None
+    )
+
+    result = await node.run(state, {})
+
+    assert [item.id for item in result["results"]] == ["vec-0", "vec-1"]
+    assert all("vector" in item.sources for item in result["results"])
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_orders_chunks_by_score() -> None:
+    chunks = [
+        DocumentChunk(
+            id="chunk-1",
+            document_id="doc-1",
+            index=0,
+            content="bananas bananas apples",
+            metadata={"page": 1},
+        ),
+        DocumentChunk(
+            id="chunk-2",
+            document_id="doc-2",
+            index=0,
+            content="apples only",
+            metadata={"page": 2},
+        ),
+    ]
+    state = State(
+        inputs={"query": "bananas"},
+        results={"chunking_strategy": {"chunks": chunks}},
+        structured_response=None,
+    )
+    node = BM25SearchNode(name="bm25", top_k=1)
+
+    result = await node.run(state, {})
+
+    assert [item.id for item in result["results"]] == ["chunk-1"]
+    assert result["results"][0].metadata["page"] == 1
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_rrf_combines_sources() -> None:
+    vector_results = [
+        SearchResult(
+            id="chunk-1",
+            score=0.8,
+            text="vector",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        ),
+        SearchResult(
+            id="chunk-2",
+            score=0.7,
+            text="vector2",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        ),
+    ]
+    bm25_results = [
+        SearchResult(
+            id="chunk-2",
+            score=2.0,
+            text="bm25",
+            metadata={},
+            source="bm25",
+            sources=["bm25"],
+        )
+    ]
+    state = State(
+        inputs={},
+        results={"retrieval_results": {"vector": vector_results, "bm25": bm25_results}},
+        structured_response=None,
+    )
+    node = HybridFusionNode(name="hybrid", strategy="rrf", top_k=2)
+
+    result = await node.run(state, {})
+
+    assert [item.id for item in result["results"]] == ["chunk-2", "chunk-1"]
+    assert set(result["results"][0].sources) == {"vector", "bm25"}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_weighted_sum_respects_weights() -> None:
+    retrievers = {
+        "vector": [
+            SearchResult(id="r1", score=0.5, text="", metadata={}, source="vector")
+        ],
+        "bm25": [SearchResult(id="r1", score=2.0, text="", metadata={}, source="bm25")],
+    }
+    state = State(
+        inputs={}, results={"retrieval_results": retrievers}, structured_response=None
+    )
+    node = HybridFusionNode(
+        name="hybrid-weighted",
+        strategy="weighted_sum",
+        weights={"vector": 0.5, "bm25": 2.0},
+        top_k=1,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["results"][0].score == pytest.approx(4.25)
+    assert set(result["results"][0].sources) == {"vector", "bm25"}

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -1,5 +1,4 @@
 import pytest
-
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search.ingestion import (
     deterministic_embedding_function,
@@ -53,6 +52,45 @@ async def test_vector_search_node_returns_ranked_results() -> None:
 
 
 @pytest.mark.asyncio
+async def test_vector_search_node_requires_non_empty_query() -> None:
+    node = VectorSearchNode(name="vector-empty", vector_store=InMemoryVectorStore())
+    state = State(inputs={"query": ""}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="VectorSearchNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_async_embedder_returns_nested_list() -> None:
+    async def embed(texts: list[str]) -> list[list[float]]:
+        return [[1.0, 2.0]]
+
+    node = VectorSearchNode(
+        name="vector-async",
+        vector_store=InMemoryVectorStore(),
+        embedding_function=embed,
+    )
+
+    assert await node._embed(["test"]) == [[1.0, 2.0]]
+
+
+@pytest.mark.asyncio
+async def test_vector_search_node_embedder_validates_output_type() -> None:
+    node = VectorSearchNode(
+        name="vector-bad-embed",
+        vector_store=InMemoryVectorStore(),
+        embedding_function=lambda texts: [text for text in texts],
+    )
+
+    with pytest.raises(
+        ValueError, match="Embedding function must return List\\[List\\[float\\]\\]"
+    ):
+        await node._embed(["test"])
+
+
+@pytest.mark.asyncio
 async def test_bm25_search_orders_chunks_by_score() -> None:
     chunks = [
         DocumentChunk(
@@ -81,6 +119,50 @@ async def test_bm25_search_orders_chunks_by_score() -> None:
 
     assert [item.id for item in result["results"]] == ["chunk-1"]
     assert result["results"][0].metadata["page"] == 1
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_requires_non_empty_query() -> None:
+    node = BM25SearchNode(name="bm25")
+    state = State(inputs={"query": "   "}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="BM25SearchNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_bm25_search_requires_chunks() -> None:
+    node = BM25SearchNode(name="bm25")
+    state = State(inputs={"query": "bananas"}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="BM25SearchNode requires at least one chunk to search"
+    ):
+        await node.run(state, {})
+
+
+def test_bm25_resolve_chunks_rejects_non_list_payload() -> None:
+    node = BM25SearchNode(name="bm25")
+    state = State(
+        inputs={},
+        results={"chunking_strategy": {"chunks": {"not": "a list"}}},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="chunks payload must be a list"):
+        node._resolve_chunks(state)
+
+
+def test_bm25_score_skips_zero_denominator() -> None:
+    node = BM25SearchNode(name="bm25", b=1.0)
+    document_tokens: list[str] = []
+    query_tokens = ["missing"]
+    corpus = [document_tokens, ["present"]]
+    avg_length = (len(document_tokens) + len(corpus[1])) / len(corpus)
+
+    assert node._bm25_score(document_tokens, query_tokens, corpus, avg_length) == 0.0
 
 
 @pytest.mark.asyncio
@@ -148,3 +230,73 @@ async def test_hybrid_fusion_weighted_sum_respects_weights() -> None:
 
     assert result["results"][0].score == pytest.approx(4.25)
     assert set(result["results"][0].sources) == {"vector", "bm25"}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_requires_results_mapping() -> None:
+    node = HybridFusionNode(name="hybrid")
+    state = State(
+        inputs={}, results={"retrieval_results": {}}, structured_response=None
+    )
+
+    with pytest.raises(
+        ValueError, match="HybridFusionNode requires a mapping of retriever results"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_requires_valid_strategy() -> None:
+    node = HybridFusionNode(name="hybrid", strategy="bad")
+    state = State(
+        inputs={},
+        results={
+            "retrieval_results": {
+                "vector": [
+                    SearchResult(
+                        id="r1", score=1.0, text="", metadata={}, source="vector"
+                    )
+                ]
+            }
+        },
+        structured_response=None,
+    )
+
+    with pytest.raises(
+        ValueError, match="strategy must be either 'rrf' or 'weighted_sum'"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_rejects_non_list_entries() -> None:
+    node = HybridFusionNode(name="hybrid")
+    state = State(
+        inputs={},
+        results={"retrieval_results": {"vector": {"results": "not a list"}}},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="Retriever results for vector must be a list"):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fusion_handles_payload_with_results_key() -> None:
+    retrievers = {
+        "vector": {
+            "results": [
+                SearchResult(
+                    id="r2", score=0.5, text="payload", metadata={}, source="vector"
+                )
+            ]
+        }
+    }
+    state = State(
+        inputs={}, results={"retrieval_results": retrievers}, structured_response=None
+    )
+    node = HybridFusionNode(name="hybrid", strategy="rrf", top_k=1)
+
+    result = await node.run(state, {})
+
+    assert result["results"][0].id == "r2"


### PR DESCRIPTION
## Summary
- add VectorSearchNode, BM25SearchNode, and HybridFusionNode for the conversational search retrieval pipeline
- extend vector store abstractions with search support and deterministic embeddings shared across nodes
- document Task 1.2 completion and add unit tests for retrieval and vector store behaviors

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c5e6137483279a40622b801252b7)