### PR TITLE
Add conversational search query processing nodes

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -31,7 +31,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
   - Dependencies: Access to embedding model provider and Pinecone credentials.
 - [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
-- [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
+- [x] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.
 - [ ] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
   - Dependencies: Retrieved context from Task 1.2; LLM provider access.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,12 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.query_processing import (
+    ContextCompressorNode,
+    CoreferenceResolverNode,
+    QueryClassifierNode,
+    QueryRewriteNode,
+)
 from orcheo.nodes.conversational_search.retrieval import (
     BM25SearchNode,
     HybridFusionNode,
@@ -26,6 +32,10 @@ __all__ = [
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "QueryRewriteNode",
+    "CoreferenceResolverNode",
+    "QueryClassifierNode",
+    "ContextCompressorNode",
     "VectorSearchNode",
     "BM25SearchNode",
     "HybridFusionNode",

--- a/src/orcheo/nodes/conversational_search/query_processing.py
+++ b/src/orcheo/nodes/conversational_search/query_processing.py
@@ -1,0 +1,263 @@
+"""Query processing nodes for conversational search pipelines."""
+
+from __future__ import annotations
+import re
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+def _normalize_messages(history: list[Any]) -> list[str]:
+    messages: list[str] = []
+    for entry in history:
+        if isinstance(entry, str):
+            content = entry
+        elif isinstance(entry, dict):
+            content = str(entry.get("content", "")).strip()
+        else:
+            continue
+        if content:
+            messages.append(content)
+    return messages
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryRewriteNode",
+        description=(
+            "Rewrite or expand a query using recent conversation context to"
+            " improve recall."
+        ),
+        category="conversational_search",
+    )
+)
+class QueryRewriteNode(TaskNode):
+    """Rewrite queries using conversation history and simple heuristics."""
+
+    query_key: str = Field(
+        default="query", description="Key within ``state.inputs`` holding the query."
+    )
+    history_key: str = Field(
+        default="history",
+        description="Key within ``state.inputs`` containing conversation history.",
+    )
+    max_history_messages: int = Field(
+        default=3, gt=0, description="Number of prior messages to consider."
+    )
+
+    pronouns: set[str] = Field(
+        default_factory=lambda: {
+            "it",
+            "they",
+            "them",
+            "this",
+            "that",
+            "these",
+            "those",
+            "he",
+            "she",
+        },
+        description="Pronouns that trigger contextual rewriting.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Rewrite queries using recent history when pronouns are detected."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryRewriteNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        history = state.get("inputs", {}).get(self.history_key, []) or []
+        if not isinstance(history, list):
+            msg = "history must be a list of messages"
+            raise ValueError(msg)
+
+        messages = _normalize_messages(history)[-self.max_history_messages :]
+        context = " ".join(messages)
+        needs_rewrite = self._contains_pronoun(query) and bool(context)
+
+        rewritten = query.strip()
+        if needs_rewrite:
+            rewritten = f"{rewritten}. Context: {context}".strip()
+
+        return {
+            "original_query": query,
+            "query": rewritten,
+            "used_history": needs_rewrite,
+            "context": context,
+        }
+
+    def _contains_pronoun(self, query: str) -> bool:
+        tokens = re.findall(r"\b\w+\b", query.lower())
+        return any(token in self.pronouns for token in tokens)
+
+
+@registry.register(
+    NodeMetadata(
+        name="CoreferenceResolverNode",
+        description="Resolve simple pronouns using prior conversation turns.",
+        category="conversational_search",
+    )
+)
+class CoreferenceResolverNode(TaskNode):
+    """Resolve pronouns in queries using the latest referenced entity."""
+
+    query_key: str = Field(
+        default="query", description="Key within ``state.inputs`` holding the query."
+    )
+    history_key: str = Field(
+        default="history",
+        description="Key within ``state.inputs`` containing conversation history.",
+    )
+    pronouns: set[str] = Field(
+        default_factory=lambda: {"it", "they", "this", "that", "those", "them"},
+        description="Pronouns that should be resolved when context exists.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Replace pronouns in the query using a recent referent if available."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "CoreferenceResolverNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        history = state.get("inputs", {}).get(self.history_key, []) or []
+        if not isinstance(history, list):
+            msg = "history must be a list of messages"
+            raise ValueError(msg)
+
+        referent = self._last_referent(history)
+        resolved_query, resolved = self._resolve(query, referent)
+
+        return {
+            "query": resolved_query,
+            "resolved": resolved,
+            "antecedent": referent if resolved else None,
+        }
+
+    def _last_referent(self, history: list[Any]) -> str | None:
+        messages = _normalize_messages(history)
+        if not messages:
+            return None
+        return messages[-1]
+
+    def _resolve(self, query: str, referent: str | None) -> tuple[str, bool]:
+        if not referent:
+            return query.strip(), False
+
+        tokens = query.strip().split()
+        resolved = False
+        for index, token in enumerate(tokens):
+            stripped = token.rstrip(".,?!").lower()
+            if stripped in self.pronouns:
+                suffix = token[len(stripped) :]
+                tokens[index] = f"{referent}{suffix}"
+                resolved = True
+                break
+        return " ".join(tokens), resolved
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryClassifierNode",
+        description="Classify a query intent to support routing decisions.",
+        category="conversational_search",
+    )
+)
+class QueryClassifierNode(TaskNode):
+    """Heuristic classifier for determining query intent."""
+
+    query_key: str = Field(
+        default="query", description="Key within ``state.inputs`` holding the query."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Classify the query as search, clarification, or finalization."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryClassifierNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        normalized = query.strip().lower()
+        classification = "search"
+        confidence = 0.6
+
+        if any(
+            token in normalized for token in {"clarify", "more detail", "which one"}
+        ):
+            classification = "clarification"
+            confidence = 0.8
+        elif normalized.startswith(("thanks", "thank you", "that helps")):
+            classification = "finalization"
+            confidence = 0.9
+
+        return {"classification": classification, "confidence": confidence}
+
+
+@registry.register(
+    NodeMetadata(
+        name="ContextCompressorNode",
+        description="Deduplicate and budget retrieval results for downstream nodes.",
+        category="conversational_search",
+    )
+)
+class ContextCompressorNode(TaskNode):
+    """Deduplicate and trim retrieval results to a token budget."""
+
+    results_field: str = Field(
+        default="retrieval_results",
+        description="Key in ``state.results`` that holds retrieval payloads.",
+    )
+    max_tokens: int = Field(
+        default=800, gt=0, description="Maximum whitespace token budget for context."
+    )
+    deduplicate: bool = Field(
+        default=True, description="Whether to drop duplicate result identifiers."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return a token-budgeted subset of retrieval results."""
+        results_payload = state.get("results", {}).get(self.results_field)
+        if results_payload is None:
+            msg = "ContextCompressorNode requires retrieval results to compress"
+            raise ValueError(msg)
+
+        if isinstance(results_payload, dict) and "results" in results_payload:
+            entries = results_payload["results"]
+        else:
+            entries = results_payload
+
+        if not isinstance(entries, list):
+            msg = "retrieval results must be provided as a list"
+            raise ValueError(msg)
+
+        results = [SearchResult.model_validate(item) for item in entries]
+        sorted_results = sorted(results, key=lambda item: item.score, reverse=True)
+
+        kept: list[SearchResult] = []
+        seen_ids: set[str] = set()
+        total_tokens = 0
+        truncated = False
+
+        for result in sorted_results:
+            if self.deduplicate and result.id in seen_ids:
+                continue
+
+            tokens = self._token_count(result.text)
+            if total_tokens + tokens > self.max_tokens:
+                truncated = True
+                break
+
+            kept.append(result)
+            total_tokens += tokens
+            seen_ids.add(result.id)
+
+        return {"results": kept, "total_tokens": total_tokens, "truncated": truncated}
+
+    @staticmethod
+    def _token_count(text: str) -> int:
+        return len(text.split())

--- a/tests/nodes/conversational_search/test_query_processing.py
+++ b/tests/nodes/conversational_search/test_query_processing.py
@@ -1,0 +1,289 @@
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.conversational_search.query_processing import (
+    ContextCompressorNode,
+    CoreferenceResolverNode,
+    QueryClassifierNode,
+    QueryRewriteNode,
+    _normalize_messages,
+)
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_appends_context_for_pronoun() -> None:
+    node = QueryRewriteNode(name="rewrite", max_history_messages=2)
+    state = State(
+        inputs={
+            "query": "How does it scale?",
+            "history": [
+                {"role": "user", "content": "Tell me about the vector store"},
+                {"role": "assistant", "content": "It supports namespaces"},
+            ],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["used_history"] is True
+    assert "Context: Tell me about the vector store" in result["query"]
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolution_replaces_first_pronoun() -> None:
+    node = CoreferenceResolverNode(name="coref")
+    state = State(
+        inputs={
+            "query": "How does it work?",
+            "history": [{"role": "user", "content": "The retriever pipeline"}],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["resolved"] is True
+    assert result["antecedent"] == "The retriever pipeline"
+    assert "The retriever pipeline" in result["query"]
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_uses_heuristics() -> None:
+    node = QueryClassifierNode(name="classifier")
+    state = State(
+        inputs={"query": "Can you clarify which one to use?"},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["classification"] == "clarification"
+    assert result["confidence"] == pytest.approx(0.8)
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_defaults_to_search() -> None:
+    node = QueryClassifierNode(name="classifier-default")
+    state = State(
+        inputs={"query": "List retrieval options"},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result == {"classification": "search", "confidence": 0.6}
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_finalization_branch() -> None:
+    node = QueryClassifierNode(name="classifier-finalize")
+    state = State(
+        inputs={"query": "Thanks for the help!"},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result == {"classification": "finalization", "confidence": 0.9}
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_deduplicates_and_budgets() -> None:
+    node = ContextCompressorNode(name="compress", max_tokens=4)
+    results = [
+        SearchResult(id="a", score=0.9, text="first chunk", metadata={}),
+        SearchResult(id="a", score=0.8, text="duplicate chunk", metadata={}),
+        SearchResult(id="b", score=0.5, text="second chunk here", metadata={}),
+    ]
+    state = State(
+        inputs={},
+        results={"retrieval_results": results},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert [item.id for item in result["results"]] == ["a"]
+    assert result["total_tokens"] == 2
+    assert result["truncated"] is True
+
+
+def test_normalize_messages_handles_mixed_payloads() -> None:
+    history = ["hello", {"content": "world"}, {"missing": "content"}, 42]
+
+    assert _normalize_messages(history) == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_handles_non_pronoun_query() -> None:
+    node = QueryRewriteNode(name="rewrite-no-context")
+    state = State(
+        inputs={"query": "Tell me about graphs", "history": ["previous turn"]},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["query"] == "Tell me about graphs"
+    assert result["used_history"] is False
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_validates_history_type() -> None:
+    node = QueryRewriteNode(name="rewrite-error")
+    state = State(
+        inputs={"query": "hello", "history": "not-a-list"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="history must be a list of messages"):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_requires_query() -> None:
+    node = QueryRewriteNode(name="rewrite-empty")
+    state = State(inputs={"query": "   "}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="QueryRewriteNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_handles_missing_referent() -> None:
+    node = CoreferenceResolverNode(name="coref-none")
+    state = State(
+        inputs={"query": "Where is it?", "history": []},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result == {"query": "Where is it?", "resolved": False, "antecedent": None}
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_without_matching_pronoun() -> None:
+    node = CoreferenceResolverNode(name="coref-no-pronoun")
+    state = State(
+        inputs={
+            "query": "Explain the architecture",
+            "history": ["Vector store overview"],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result == {
+        "query": "Explain the architecture",
+        "resolved": False,
+        "antecedent": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_validates_history_type() -> None:
+    node = CoreferenceResolverNode(name="coref-error")
+    state = State(
+        inputs={"query": "hello", "history": "oops"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="history must be a list of messages"):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_requires_query() -> None:
+    node = CoreferenceResolverNode(name="coref-empty")
+    state = State(inputs={"query": ""}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="CoreferenceResolverNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_requires_query() -> None:
+    node = QueryClassifierNode(name="classifier-empty")
+    state = State(inputs={"query": ""}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="QueryClassifierNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_handles_results_mapping() -> None:
+    node = ContextCompressorNode(name="compress-mapping", max_tokens=10)
+    search_result = SearchResult(id="a", score=0.5, text="small chunk", metadata={})
+    state = State(
+        inputs={},
+        results={"retrieval_results": {"results": [search_result]}},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["results"][0].id == "a"
+    assert result["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_requires_results() -> None:
+    node = ContextCompressorNode(name="compress-missing")
+    state = State(inputs={}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="ContextCompressorNode requires retrieval results to compress"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_validates_entries_type() -> None:
+    node = ContextCompressorNode(name="compress-type")
+    state = State(
+        inputs={}, results={"retrieval_results": "not-a-list"}, structured_response=None
+    )
+
+    with pytest.raises(
+        ValueError, match="retrieval results must be provided as a list"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_without_deduplication() -> None:
+    node = ContextCompressorNode(
+        name="compress-no-dedup", max_tokens=10, deduplicate=False
+    )
+    results = [
+        SearchResult(id="a", score=0.2, text="alpha beta", metadata={}),
+        SearchResult(id="a", score=0.1, text="gamma delta", metadata={}),
+    ]
+    state = State(
+        inputs={}, results={"retrieval_results": results}, structured_response=None
+    )
+
+    result = await node.run(state, {})
+
+    assert [item.text for item in result["results"]] == ["alpha beta", "gamma delta"]
+    assert result["truncated"] is False


### PR DESCRIPTION
## Summary
- add query processing nodes for conversational search with validation, rewriting, classification, and context compression helpers
- expose the new nodes via the conversational search package and mark Task 1.3 complete in the plan
- add comprehensive unit tests covering the new query processing behaviors

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922dd0b3f908327a81b0053b509066a)