### PR TITLE
Add conversational query processing nodes

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -31,7 +31,7 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
   - Dependencies: Access to embedding model provider and Pinecone credentials.
 - [x] Task 1.2: Ship retrieval stack (VectorSearchNode, BM25SearchNode) plus HybridFusionNode with RRF/weighted strategies.
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
-- [ ] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
+- [x] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.
 - [ ] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
   - Dependencies: Retrieved context from Task 1.2; LLM provider access.

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -6,6 +6,12 @@ from orcheo.nodes.conversational_search.ingestion import (
     EmbeddingIndexerNode,
     MetadataExtractorNode,
 )
+from orcheo.nodes.conversational_search.query_processing import (
+    ContextCompressorNode,
+    CoreferenceResolverNode,
+    QueryClassifierNode,
+    QueryRewriteNode,
+)
 from orcheo.nodes.conversational_search.retrieval import (
     BM25SearchNode,
     HybridFusionNode,
@@ -29,4 +35,8 @@ __all__ = [
     "VectorSearchNode",
     "BM25SearchNode",
     "HybridFusionNode",
+    "QueryRewriteNode",
+    "CoreferenceResolverNode",
+    "QueryClassifierNode",
+    "ContextCompressorNode",
 ]

--- a/src/orcheo/nodes/conversational_search/query_processing.py
+++ b/src/orcheo/nodes/conversational_search/query_processing.py
@@ -1,0 +1,286 @@
+"""Query processing nodes for conversational search pipelines."""
+
+from __future__ import annotations
+import re
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+PRONOUN_PATTERN = re.compile(
+    r"\b(it|this|that|they|them|those|these|he|she)\b", re.IGNORECASE
+)
+
+
+def _coerce_history_entries(history: list[Any]) -> list[str]:
+    """Return normalized text entries extracted from conversation history."""
+    normalized: list[str] = []
+    for entry in history:
+        if isinstance(entry, str):
+            candidate = entry.strip()
+        elif isinstance(entry, dict):
+            candidate = str(entry.get("content", "")).strip()
+        else:
+            candidate = ""
+
+        if candidate:
+            normalized.append(candidate)
+    return normalized
+
+
+def _derive_referent(history_entries: list[str]) -> str | None:
+    """Attempt to derive a referent phrase from the most recent history entry."""
+    if not history_entries:
+        return None
+
+    most_recent = history_entries[0]
+    match = re.findall(r"([A-Z][a-z0-9]+(?: [A-Z][a-z0-9]+)*)", most_recent)
+    if match:
+        referent = match[-1]
+        referent = re.sub(r"^(The|A|An)\s+", "", referent).strip()
+        if referent and referent.lower() not in {"the", "a", "an"}:
+            return referent
+        referent = ""
+
+    tokens = [
+        token
+        for token in most_recent.split()
+        if token and token.lower() not in {"the", "a", "an"}
+    ]
+    if tokens:
+        return tokens[-1]
+    return None
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryRewriteNode",
+        description=(
+            "Rewrite or expand a user query using recent conversation history to"
+            " improve retrieval recall."
+        ),
+        category="conversational_search",
+    )
+)
+class QueryRewriteNode(TaskNode):
+    """Node that rewrites a query using conversation snippets."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key inside ``state.inputs`` containing the user query.",
+    )
+    history_key: str = Field(
+        default="history",
+        description="Key inside ``state.inputs`` containing conversation history.",
+    )
+    max_history_messages: int = Field(
+        default=3, gt=0, description="Maximum number of history turns to consider."
+    )
+    joiner: str = Field(
+        default=" ",
+        description="Separator used when appending contextual snippets to the query.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return a rewritten query that incorporates recent history."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryRewriteNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        raw_history = state.get("inputs", {}).get(self.history_key, [])
+        if raw_history and not isinstance(raw_history, list):
+            msg = "history payload must be a list when provided"
+            raise ValueError(msg)
+
+        normalized_history = _coerce_history_entries(raw_history)[
+            : self.max_history_messages
+        ]
+        rewritten = query.strip()
+
+        if normalized_history and PRONOUN_PATTERN.search(rewritten):
+            context = self.joiner.join(normalized_history)
+            rewritten = f"{rewritten} ({context})"
+        elif normalized_history:
+            context = normalized_history[0]
+            rewritten = f"{rewritten} — context: {context}"
+
+        return {"rewritten_query": rewritten, "history_used": normalized_history}
+
+
+@registry.register(
+    NodeMetadata(
+        name="CoreferenceResolverNode",
+        description="Resolve pronouns using recent conversation context.",
+        category="conversational_search",
+    )
+)
+class CoreferenceResolverNode(TaskNode):
+    """Node that replaces ambiguous pronouns with derived referents."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key inside ``state.inputs`` containing the user query.",
+    )
+    history_key: str = Field(
+        default="history",
+        description="Key inside ``state.inputs`` containing conversation history.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Replace detected pronouns with a best-effort referent."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "CoreferenceResolverNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        raw_history = state.get("inputs", {}).get(self.history_key, [])
+        if raw_history and not isinstance(raw_history, list):
+            msg = "history payload must be a list when provided"
+            raise ValueError(msg)
+
+        normalized_history = _coerce_history_entries(raw_history)
+        referent = _derive_referent(normalized_history)
+
+        resolved_query = query.strip()
+        if referent and PRONOUN_PATTERN.search(resolved_query):
+            resolved_query = PRONOUN_PATTERN.sub(referent, resolved_query)
+
+        return {
+            "resolved_query": resolved_query,
+            "referent": referent,
+            "history_used": normalized_history[:3],
+        }
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryClassifierNode",
+        description="Classify the user's intent to control downstream routing.",
+        category="conversational_search",
+    )
+)
+class QueryClassifierNode(TaskNode):
+    """Heuristic query classifier for conversational routing."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key inside ``state.inputs`` containing the user query.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return an intent label and confidence score."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryClassifierNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        normalized = query.strip().lower()
+        intent = "search"
+        confidence = 0.55
+
+        if any(
+            phrase in normalized
+            for phrase in ["thanks", "that is all", "that's all", "goodbye", "bye"]
+        ):
+            intent = "finalization"
+            confidence = 0.9
+        elif any(
+            keyword in normalized
+            for keyword in [
+                "clarify",
+                "mean",
+                "which one",
+                "more detail",
+                "what do you mean",
+            ]
+        ):
+            intent = "clarification"
+            confidence = 0.72
+        elif normalized.endswith("?") or any(
+            normalized.startswith(prefix)
+            for prefix in ["what", "how", "why", "where", "who", "when"]
+        ):
+            intent = "search"
+            confidence = 0.78
+
+        return {"intent": intent, "confidence": confidence}
+
+
+@registry.register(
+    NodeMetadata(
+        name="ContextCompressorNode",
+        description="Deduplicate and trim retrieved context within a token budget.",
+        category="conversational_search",
+    )
+)
+class ContextCompressorNode(TaskNode):
+    """Node that compresses retrieval results into a token-limited set."""
+
+    source_result_key: str = Field(
+        default="retrieval_results",
+        description="Key inside ``state.results`` containing retrieval outputs.",
+    )
+    results_field: str = Field(
+        default="results",
+        description="Field name containing the list of SearchResult entries.",
+    )
+    max_tokens: int = Field(
+        default=400,
+        gt=0,
+        description="Maximum approximate token budget for returned results.",
+    )
+    deduplicate: bool = Field(
+        default=True, description="Whether to drop results with duplicate text."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return a compressed list of :class:`SearchResult` entries."""
+        results = self._resolve_results(state)
+        if not results:
+            msg = "ContextCompressorNode requires at least one SearchResult"
+            raise ValueError(msg)
+
+        sorted_results = sorted(results, key=lambda entry: entry.score, reverse=True)
+        compressed: list[SearchResult] = []
+        seen_texts: set[str] = set()
+        token_count = 0
+
+        for entry in sorted_results:
+            if self.deduplicate:
+                fingerprint = entry.text.strip().lower()
+                if fingerprint in seen_texts:
+                    continue
+                seen_texts.add(fingerprint)
+
+            entry_tokens = len(entry.text.split())
+            if token_count + entry_tokens > self.max_tokens:
+                break
+
+            compressed.append(entry)
+            token_count += entry_tokens
+
+        return {
+            "results": compressed,
+            "dropped": len(sorted_results) - len(compressed),
+            "token_count": token_count,
+        }
+
+    def _resolve_results(self, state: State) -> list[SearchResult]:
+        results = state.get("results", {}).get(self.source_result_key)
+        if isinstance(results, dict) and self.results_field in results:
+            payload = results[self.results_field]
+        else:
+            payload = results
+
+        if payload is None:
+            return []
+        if not isinstance(payload, list):
+            msg = "retrieval results must be provided as a list"
+            raise ValueError(msg)
+
+        return [SearchResult.model_validate(item) for item in payload]

--- a/tests/nodes/conversational_search/test_query_processing.py
+++ b/tests/nodes/conversational_search/test_query_processing.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search import query_processing
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.conversational_search.query_processing import (
+    ContextCompressorNode,
+    CoreferenceResolverNode,
+    QueryClassifierNode,
+    QueryRewriteNode,
+)
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_appends_context_when_pronoun_present() -> None:
+    node = QueryRewriteNode(name="rewrite")
+    state = State(
+        inputs={
+            "query": "How does it work?",
+            "history": [
+                {"role": "assistant", "content": "Apollo program landed on the moon"},
+                {"role": "user", "content": "Tell me about Apollo"},
+            ],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert "Apollo program landed on the moon" in result["rewritten_query"]
+    assert result["history_used"][0] == "Apollo program landed on the moon"
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_replaces_pronoun_with_referent() -> None:
+    node = CoreferenceResolverNode(name="coref")
+    state = State(
+        inputs={
+            "query": "When did it launch?",
+            "history": ["The Apollo program was NASA's moonshot initiative"],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["referent"] == "Apollo"
+    assert "Apollo" in result["resolved_query"]
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_detects_finalization_and_clarification() -> None:
+    classifier = QueryClassifierNode(name="classifier")
+
+    final_state = State(
+        inputs={"query": "Thanks, that's all"}, results={}, structured_response=None
+    )
+    final_result = await classifier.run(final_state, {})
+
+    clarify_state = State(
+        inputs={"query": "Can you clarify the timeline?"},
+        results={},
+        structured_response=None,
+    )
+    clarify_result = await classifier.run(clarify_state, {})
+
+    assert final_result["intent"] == "finalization"
+    assert clarify_result["intent"] == "clarification"
+
+
+def test_helpers_cover_normalization_and_empty_history() -> None:
+    history = ["  Trim me  ", {"content": "Keep me"}, 99]
+    assert query_processing._coerce_history_entries(history) == ["Trim me", "Keep me"]
+    assert query_processing._derive_referent([]) is None
+    assert query_processing._derive_referent(["   "]) is None
+    assert query_processing._derive_referent(["The"]) is None
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_deduplicates_and_respects_budget() -> None:
+    compressor = ContextCompressorNode(name="compressor", max_tokens=4)
+    results = [
+        SearchResult(
+            id="chunk-1",
+            score=0.9,
+            text="alpha beta gamma delta",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        ),
+        SearchResult(
+            id="chunk-2",
+            score=0.5,
+            text="alpha beta gamma delta",
+            metadata={},
+            source="bm25",
+            sources=["bm25"],
+        ),
+    ]
+    state = State(
+        inputs={},
+        results={"retrieval_results": {"results": results}},
+        structured_response=None,
+    )
+
+    result = await compressor.run(state, {})
+
+    assert len(result["results"]) == 1
+    assert result["dropped"] == 1
+    assert result["token_count"] == 4
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_appends_context_without_pronoun() -> None:
+    node = QueryRewriteNode(name="rewrite-context")
+    state = State(
+        inputs={
+            "query": "Explain the retrieval pipeline",
+            "history": [
+                "First note about hybrid search",
+                123,
+            ],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["rewritten_query"].endswith("First note about hybrid search")
+    assert len(result["history_used"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_requires_non_empty_query() -> None:
+    node = QueryRewriteNode(name="rewrite-empty")
+    state = State(inputs={"query": "   "}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="QueryRewriteNode requires a non-empty query string"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_returns_original_without_history() -> None:
+    node = QueryRewriteNode(name="rewrite-original")
+    state = State(inputs={"query": "Stand-alone"}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    assert result["rewritten_query"] == "Stand-alone"
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_validates_history_type() -> None:
+    node = QueryRewriteNode(name="rewrite-history-type")
+    state = State(
+        inputs={"query": "Check", "history": "oops"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="history payload must be a list"):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_validates_history_type_and_fallback() -> None:
+    node = CoreferenceResolverNode(name="coref-invalid")
+    state = State(
+        inputs={"query": "What is it?", "history": "bad"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(ValueError, match="history payload must be a list"):
+        await node.run(state, {})
+
+    with pytest.raises(
+        ValueError, match="CoreferenceResolverNode requires a non-empty query string"
+    ):
+        await node.run(
+            State(inputs={"query": "  "}, results={}, structured_response=None),
+            {},
+        )
+
+    fallback_state = State(
+        inputs={
+            "query": "Where was it used?",
+            "history": ["used in production systems"],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    fallback_result = await node.run(fallback_state, {})
+
+    assert fallback_result["referent"] == "systems"
+    assert "systems" in fallback_result["resolved_query"]
+
+
+@pytest.mark.asyncio
+async def test_coreference_resolver_handles_empty_history() -> None:
+    node = CoreferenceResolverNode(name="coref-empty")
+    state = State(
+        inputs={"query": "What is it?", "history": []},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["referent"] is None
+    assert result["resolved_query"] == "What is it?"
+
+
+@pytest.mark.asyncio
+async def test_query_classifier_handles_search_intent_and_validation() -> None:
+    classifier = QueryClassifierNode(name="classifier-search")
+
+    state = State(
+        inputs={"query": "What is Orcheo?"}, results={}, structured_response=None
+    )
+    result = await classifier.run(state, {})
+
+    assert result["intent"] == "search"
+
+    invalid_state = State(inputs={"query": ""}, results={}, structured_response=None)
+    with pytest.raises(
+        ValueError, match="QueryClassifierNode requires a non-empty query string"
+    ):
+        await classifier.run(invalid_state, {})
+
+    neutral_state = State(
+        inputs={"query": "Provide summary"}, results={}, structured_response=None
+    )
+    neutral_result = await classifier.run(neutral_state, {})
+
+    assert neutral_result["intent"] == "search"
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_validates_results_and_budget_breaks() -> None:
+    compressor = ContextCompressorNode(name="compressor-empty", max_tokens=5)
+    empty_state = State(inputs={}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="ContextCompressorNode requires at least one SearchResult"
+    ):
+        await compressor.run(empty_state, {})
+
+    invalid_payload_state = State(
+        inputs={},
+        results={"retrieval_results": {"results": "invalid"}},
+        structured_response=None,
+    )
+
+    with pytest.raises(
+        ValueError, match="retrieval results must be provided as a list"
+    ):
+        await compressor.run(invalid_payload_state, {})
+
+    rich_state = State(
+        inputs={},
+        results={
+            "retrieval_results": {
+                "results": [
+                    SearchResult(
+                        id="chunk-1",
+                        score=0.9,
+                        text="alpha beta gamma",
+                        metadata={},
+                        source="vector",
+                        sources=["vector"],
+                    ),
+                    SearchResult(
+                        id="chunk-2",
+                        score=0.8,
+                        text="delta epsilon zeta eta",
+                        metadata={},
+                        source="bm25",
+                        sources=["bm25"],
+                    ),
+                ]
+            }
+        },
+        structured_response=None,
+    )
+
+    budgeted = await compressor.run(rich_state, {})
+
+    assert [item.id for item in budgeted["results"]] == ["chunk-1"]
+    assert budgeted["dropped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_context_compressor_handles_duplicates_without_deduplication() -> None:
+    compressor = ContextCompressorNode(
+        name="compressor-no-dedup", deduplicate=False, max_tokens=6
+    )
+    state = State(
+        inputs={},
+        results={
+            "retrieval_results": {
+                "results": [
+                    SearchResult(
+                        id="chunk-1",
+                        score=0.9,
+                        text="alpha beta",
+                        metadata={},
+                        source="vector",
+                        sources=["vector"],
+                    ),
+                    SearchResult(
+                        id="chunk-2",
+                        score=0.8,
+                        text="gamma delta epsilon",
+                        metadata={},
+                        source="bm25",
+                        sources=["bm25"],
+                    ),
+                ]
+            }
+        },
+        structured_response=None,
+    )
+
+    result = await compressor.run(state, {})
+
+    assert [item.id for item in result["results"]] == ["chunk-1", "chunk-2"]


### PR DESCRIPTION
## Summary
- add query processing nodes for conversational search including rewrite, coreference resolution, classification, and context compression
- export new nodes and document milestone progress
- add comprehensive tests covering new query processing behaviors

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922dd0b3f908327a81b0053b509066a)