### PR TITLE
Add grounded generator node and reference graph for conversational search

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -33,9 +33,9 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [x] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.
-- [ ] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
+- [x] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
   - Dependencies: Retrieved context from Task 1.2; LLM provider access.
-- [ ] Task 1.5: Provide reference graph and integration tests under `tests/nodes/conversational_search/` covering ingestion → retrieval → generation.
+- [x] Task 1.5: Provide reference graph and integration tests under `tests/nodes/conversational_search/` covering ingestion → retrieval → generation.
   - Dependencies: Tasks 1.1-1.4.
 
 ---

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -1,5 +1,6 @@
 """Conversational search nodes and utilities."""
 
+from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
 from orcheo.nodes.conversational_search.ingestion import (
     ChunkingStrategyNode,
     DocumentLoaderNode,
@@ -11,6 +12,9 @@ from orcheo.nodes.conversational_search.query_processing import (
     CoreferenceResolverNode,
     QueryClassifierNode,
     QueryRewriteNode,
+)
+from orcheo.nodes.conversational_search.reference_graph import (
+    build_reference_conversational_search_graph,
 )
 from orcheo.nodes.conversational_search.retrieval import (
     BM25SearchNode,
@@ -32,6 +36,8 @@ __all__ = [
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "GroundedGeneratorNode",
+    "build_reference_conversational_search_graph",
     "QueryRewriteNode",
     "CoreferenceResolverNode",
     "QueryClassifierNode",

--- a/src/orcheo/nodes/conversational_search/generation.py
+++ b/src/orcheo/nodes/conversational_search/generation.py
@@ -1,0 +1,192 @@
+"""Grounded generation node with citations and retry semantics."""
+
+from __future__ import annotations
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.triggers.retry import RetryPolicyConfig
+
+
+GenerationFunction = Callable[[str, list[SearchResult]], str | Awaitable[str]]
+
+
+@registry.register(
+    NodeMetadata(
+        name="GroundedGeneratorNode",
+        description="Generate answers grounded in retrieved context with citations.",
+        category="conversational_search",
+    )
+)
+class GroundedGeneratorNode(TaskNode):
+    """Synthesise answers while emitting citations and retries."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key within ``state.inputs`` containing the user query.",
+    )
+    context_result_key: str = Field(
+        default="retrieval_results",
+        description="Key under ``state.results`` holding retrieval payloads.",
+    )
+    context_field: str = Field(
+        default="results",
+        description=(
+            "Field that contains ``SearchResult`` entries within the context payload."
+        ),
+    )
+    history_key: str = Field(
+        default="history",
+        description="Optional conversation history key within ``state.inputs``.",
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a grounded answer generator. Use the provided context to respond"
+            " concisely and include citations."
+        ),
+        description="Instruction prefix injected ahead of user prompts.",
+    )
+    citation_style: Literal["inline", "footnote", "endnote"] = Field(
+        default="inline", description="Presentation style for citation markers."
+    )
+    generator: GenerationFunction | None = Field(
+        default=None,
+        description="Custom callable used to synthesise responses.",
+    )
+    retry_policy: RetryPolicyConfig = Field(
+        default_factory=lambda: RetryPolicyConfig(
+            max_attempts=3,
+            initial_delay_seconds=0.05,
+            backoff_factor=2.0,
+            max_delay_seconds=0.2,
+            jitter_factor=0.0,
+        ),
+        description="Retry policy applied to generation failures.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Generate a grounded response from retrieved context."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "GroundedGeneratorNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        context = self._resolve_context(state)
+        if not context:
+            msg = "GroundedGeneratorNode requires at least one context result"
+            raise ValueError(msg)
+
+        history = state.get("inputs", {}).get(self.history_key, []) or []
+        if not isinstance(history, list):
+            msg = "history must be a list of messages"
+            raise ValueError(msg)
+        prompt = self._build_prompt(query, context, history)
+
+        response = await self._generate_with_retries(prompt, context)
+        citations = self._build_citations(context)
+
+        return {
+            "response": response,
+            "citations": citations,
+            "tokens_used": self._token_count(response),
+            "prompt": prompt,
+        }
+
+    def _resolve_context(self, state: State) -> list[SearchResult]:
+        results = state.get("results", {})
+        payload = results.get(self.context_result_key) or results.get(
+            self.context_field
+        )
+
+        if payload is None:
+            return []
+
+        if isinstance(payload, dict) and self.context_field in payload:
+            entries = payload[self.context_field]
+        else:
+            entries = payload
+
+        if not isinstance(entries, list):
+            msg = "context results must be provided as a list"
+            raise ValueError(msg)
+
+        return [SearchResult.model_validate(item) for item in entries]
+
+    def _build_prompt(
+        self, query: str, context: list[SearchResult], history: list[Any]
+    ) -> str:
+        formatted_context = "\n".join(
+            f"[{index}] {result.text}" for index, result in enumerate(context, start=1)
+        )
+        formatted_history = "\n".join(
+            str(entry.get("content", entry)) if isinstance(entry, dict) else str(entry)
+            for entry in history
+        ).strip()
+
+        prompt_sections = [self.system_prompt.strip(), f"Query: {query.strip()}"]
+        if formatted_history:
+            prompt_sections.append(f"History:\n{formatted_history}")
+        prompt_sections.append(f"Context:\n{formatted_context}")
+
+        return "\n\n".join(section for section in prompt_sections if section)
+
+    async def _generate_with_retries(
+        self, prompt: str, context: list[SearchResult]
+    ) -> str:
+        generator = self.generator or self._default_generator
+        last_error: Exception | None = None
+
+        for attempt_index in range(self.retry_policy.max_attempts):
+            try:
+                output = generator(prompt, context)
+                if inspect.isawaitable(output):
+                    output = await output  # type: ignore[assignment]
+                if not isinstance(output, str) or not output.strip():
+                    msg = "Generation function must return a non-empty string"
+                    raise ValueError(msg)
+                return output.strip()
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt_index >= self.retry_policy.max_attempts - 1:
+                    raise
+
+                delay = self.retry_policy.compute_delay_seconds(
+                    attempt_index=attempt_index
+                )
+                if delay:
+                    await asyncio.sleep(delay)
+
+        assert last_error is not None  # for mypy
+        raise last_error
+
+    def _default_generator(self, prompt: str, context: list[SearchResult]) -> str:
+        _ = prompt  # prompt is kept for parity with custom generators
+        inline_markers = " ".join(
+            f"[{index}]" if self.citation_style == "inline" else str(index)
+            for index in range(1, len(context) + 1)
+        ).strip()
+        summary = " ".join(result.text for result in context)
+        return f"{summary} {inline_markers}".strip()
+
+    def _build_citations(self, context: list[SearchResult]) -> list[dict[str, Any]]:
+        citations: list[dict[str, Any]] = []
+        for index, result in enumerate(context, start=1):
+            citations.append(
+                {
+                    "id": str(index),
+                    "source_id": result.id,
+                    "snippet": result.text[:160],
+                    "sources": result.sources,
+                }
+            )
+        return citations
+
+    @staticmethod
+    def _token_count(text: str) -> int:
+        return len(text.split())

--- a/src/orcheo/nodes/conversational_search/reference_graph.py
+++ b/src/orcheo/nodes/conversational_search/reference_graph.py
@@ -1,0 +1,50 @@
+"""Reference conversational search graph wiring ingestion to generation."""
+
+from __future__ import annotations
+from langgraph.graph import END, START, StateGraph
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
+from orcheo.nodes.conversational_search.ingestion import (
+    ChunkingStrategyNode,
+    DocumentLoaderNode,
+    EmbeddingIndexerNode,
+)
+from orcheo.nodes.conversational_search.retrieval import VectorSearchNode
+from orcheo.nodes.conversational_search.vector_store import (
+    BaseVectorStore,
+    InMemoryVectorStore,
+)
+
+
+def build_reference_conversational_search_graph(
+    *, vector_store: BaseVectorStore | None = None
+) -> StateGraph:
+    """Return a reference ingestion → retrieval → generation graph."""
+    store = vector_store or InMemoryVectorStore()
+
+    graph = StateGraph(State)
+
+    loader = DocumentLoaderNode(name="document_loader")
+    chunker = ChunkingStrategyNode(name="chunking_strategy")
+    indexer = EmbeddingIndexerNode(name="embedding_indexer", vector_store=store)
+    retriever = VectorSearchNode(name="vector_search", vector_store=store)
+    generator = GroundedGeneratorNode(
+        name="grounded_generator", context_result_key="vector_search"
+    )
+
+    graph.add_node("document_loader", loader)
+    graph.add_node("chunking_strategy", chunker)
+    graph.add_node("embedding_indexer", indexer)
+    graph.add_node("vector_search", retriever)
+    graph.add_node("grounded_generator", generator)
+
+    graph.add_edge(START, "document_loader")
+    graph.add_edge("document_loader", "chunking_strategy")
+    graph.add_edge("chunking_strategy", "embedding_indexer")
+    graph.add_edge("embedding_indexer", "vector_search")
+    graph.add_edge("vector_search", "grounded_generator")
+    graph.add_edge("grounded_generator", END)
+
+    graph.set_entry_point("document_loader")
+
+    return graph

--- a/tests/nodes/conversational_search/test_generation.py
+++ b/tests/nodes/conversational_search/test_generation.py
@@ -1,0 +1,85 @@
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.triggers.retry import RetryPolicyConfig
+
+
+def _sample_state(results: dict) -> State:
+    return State(
+        inputs={"query": "What is orcheo?"}, results=results, structured_response=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_emits_citations_and_tokens() -> None:
+    context = [
+        SearchResult(
+            id="chunk-1",
+            score=1.0,
+            text="Orcheo ships conversational search primitives.",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        ),
+        SearchResult(
+            id="chunk-2",
+            score=0.8,
+            text="GroundedGeneratorNode adds citations to responses.",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        ),
+    ]
+    state = _sample_state({"retrieval_results": {"results": context}})
+
+    node = GroundedGeneratorNode(name="generator")
+    result = await node.run(state, {})
+
+    assert result["citations"][0]["source_id"] == "chunk-1"
+    assert result["citations"][1]["source_id"] == "chunk-2"
+    assert result["tokens_used"] == len(result["response"].split())
+    assert "[1]" in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_retries_then_succeeds() -> None:
+    attempts = {"count": 0}
+
+    async def flaky_generator(prompt: str, context: list[SearchResult]) -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("temporary failure")
+        return "Recovered response"
+
+    context = [
+        SearchResult(
+            id="chunk-3",
+            score=1.0,
+            text="Reliable context",
+            metadata={},
+            source="vector",
+            sources=["vector"],
+        )
+    ]
+    state = _sample_state({"retrieval_results": {"results": context}})
+
+    retry_policy = RetryPolicyConfig(
+        max_attempts=3,
+        initial_delay_seconds=0.0,
+        backoff_factor=1.0,
+        max_delay_seconds=0.0,
+        jitter_factor=0.0,
+    )
+
+    node = GroundedGeneratorNode(
+        name="generator-retry",
+        generator=flaky_generator,
+        retry_policy=retry_policy,
+    )
+
+    result = await node.run(state, {})
+
+    assert attempts["count"] == 2
+    assert result["response"] == "Recovered response"

--- a/tests/nodes/conversational_search/test_reference_graph.py
+++ b/tests/nodes/conversational_search/test_reference_graph.py
@@ -1,0 +1,37 @@
+import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+
+from orcheo.nodes.conversational_search.reference_graph import (
+    build_reference_conversational_search_graph,
+)
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+@pytest.mark.asyncio
+async def test_reference_graph_runs_end_to_end() -> None:
+    vector_store = InMemoryVectorStore()
+    graph = build_reference_conversational_search_graph(vector_store=vector_store)
+
+    checkpointer = InMemorySaver()
+    compiled = graph.compile(checkpointer=checkpointer)
+    config = {"configurable": {"thread_id": "conv-search"}}
+
+    documents = [
+        {"content": "Orcheo ships conversational search nodes with citations."},
+        {"content": "Vector and BM25 retrievers feed the grounded generator."},
+    ]
+
+    await compiled.ainvoke(
+        {"inputs": {"documents": documents, "query": "What does Orcheo ship?"}},
+        config,
+    )
+
+    state = compiled.get_state(config)
+    results = state.values["results"]
+
+    generated = results["grounded_generator"]
+
+    assert generated["citations"]
+    assert generated["tokens_used"] > 0
+    assert "Orcheo" in generated["response"]
+    assert "vector_search" in results


### PR DESCRIPTION
## Summary
- add a GroundedGeneratorNode with citation emission, prompt construction, and retry-aware generation helpers
- introduce a reference conversational search graph wiring ingestion, retrieval, and grounded generation nodes
- add unit and integration coverage plus mark plan checklist items 1.4 and 1.5 as complete

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e68a786c8327993acee0264e2115)