### PR TITLE
Add grounded generator node and reference tests

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -33,9 +33,9 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
   - Dependencies: Task 1.1 indexed corpus; BaseVectorStore abstraction.
 - [x] Task 1.3: Add core query processing (QueryRewriteNode, CoreferenceResolverNode, QueryClassifierNode, ContextCompressorNode) to improve retrieval quality.
   - Dependencies: Conversation state schema; Task 1.2 retrievers.
-- [ ] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
+- [x] Task 1.4: Deliver GroundedGeneratorNode with citation emission and backoff/retry semantics.
   - Dependencies: Retrieved context from Task 1.2; LLM provider access.
-- [ ] Task 1.5: Provide reference graph and integration tests under `tests/nodes/conversational_search/` covering ingestion → retrieval → generation.
+- [x] Task 1.5: Provide reference graph and integration tests under `tests/nodes/conversational_search/` covering ingestion → retrieval → generation.
   - Dependencies: Tasks 1.1-1.4.
 
 ---

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -1,5 +1,6 @@
 """Conversational search nodes and utilities."""
 
+from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
 from orcheo.nodes.conversational_search.ingestion import (
     ChunkingStrategyNode,
     DocumentLoaderNode,
@@ -32,6 +33,7 @@ __all__ = [
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
+    "GroundedGeneratorNode",
     "QueryRewriteNode",
     "CoreferenceResolverNode",
     "QueryClassifierNode",

--- a/src/orcheo/nodes/conversational_search/generation.py
+++ b/src/orcheo/nodes/conversational_search/generation.py
@@ -18,9 +18,20 @@ LLMCallable = Callable[[str, int, float], str | Awaitable[str]]
 
 def _truncate_snippet(text: str, limit: int = 160) -> str:
     snippet = text.strip().replace("\n", " ")
+    if limit <= 0:
+        return ""
     if len(snippet) <= limit:
         return snippet
-    return f"{snippet[:limit].rstrip()}…"
+
+    ellipsis = "…"
+    if limit <= len(ellipsis):
+        return ellipsis if limit >= len(ellipsis) else snippet[:limit]
+
+    available = limit - len(ellipsis)
+    truncated = snippet[:available].rstrip()
+    if not truncated:
+        return ellipsis
+    return f"{truncated}{ellipsis}"
 
 
 @registry.register(

--- a/src/orcheo/nodes/conversational_search/generation.py
+++ b/src/orcheo/nodes/conversational_search/generation.py
@@ -1,0 +1,184 @@
+"""Grounded generation node for conversational search pipelines."""
+
+from __future__ import annotations
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+LLMCallable = Callable[[str, int, float], str | Awaitable[str]]
+
+
+def _truncate_snippet(text: str, limit: int = 160) -> str:
+    snippet = text.strip().replace("\n", " ")
+    if len(snippet) <= limit:
+        return snippet
+    return f"{snippet[:limit].rstrip()}…"
+
+
+@registry.register(
+    NodeMetadata(
+        name="GroundedGeneratorNode",
+        description="Generate grounded answers with citations and retry semantics.",
+        category="conversational_search",
+    )
+)
+class GroundedGeneratorNode(TaskNode):
+    """Node that generates grounded responses using retrieved context."""
+
+    query_key: str = Field(
+        default="query", description="Key within ``state.inputs`` holding the query."
+    )
+    context_result_key: str = Field(
+        default="retriever",
+        description="Name of the upstream result entry containing retrieval output.",
+    )
+    context_field: str = Field(
+        default="results",
+        description=(
+            "Field name under the retrieval result that stores SearchResult items."
+        ),
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a grounded answer generator. Use the provided context to answer "
+            "the user's query and include citation markers referencing the context "
+            "entries."
+        ),
+        description="Instruction prefix prepended to the prompt.",
+    )
+    citation_style: Literal["inline", "footnote", "endnote"] = Field(
+        default="inline", description="Style hint for formatting citations."
+    )
+    max_tokens: int = Field(default=512, gt=0, description="Token cap for generation")
+    temperature: float = Field(
+        default=0.1, ge=0.0, description="Sampling temperature used by the model"
+    )
+    max_retries: int = Field(default=2, ge=0, description="Maximum retry attempts")
+    backoff_seconds: float = Field(
+        default=0.1, ge=0.0, description="Base backoff delay between retries"
+    )
+    llm: LLMCallable | None = Field(
+        default=None,
+        description=(
+            "Optional callable invoked with ``(prompt, max_tokens, temperature)`` to "
+            "produce a completion. A deterministic fallback is used when omitted."
+        ),
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Generate a grounded response with citations and retry semantics."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "GroundedGeneratorNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        context = self._resolve_context(state)
+        if not context:
+            msg = "GroundedGeneratorNode requires at least one context document"
+            raise ValueError(msg)
+
+        prompt = self._build_prompt(query.strip(), context)
+        completion = await self._generate_with_retries(prompt)
+
+        citations = self._build_citations(context)
+        response = self._attach_citations(completion, citations)
+        tokens_used = self._estimate_tokens(prompt, response)
+
+        return {
+            "response": response,
+            "citations": citations,
+            "tokens_used": tokens_used,
+            "citation_style": self.citation_style,
+        }
+
+    def _resolve_context(self, state: State) -> list[SearchResult]:
+        results = state.get("results", {})
+        source = results.get(self.context_result_key, {})
+        if isinstance(source, dict) and self.context_field in source:
+            entries = source[self.context_field]
+        else:
+            entries = results.get(self.context_field)
+        if not entries:
+            return []
+        if not isinstance(entries, list):
+            msg = "Context payload must be a list of retrieval results"
+            raise ValueError(msg)
+        return [SearchResult.model_validate(item) for item in entries]
+
+    def _build_prompt(self, query: str, context: list[SearchResult]) -> str:
+        context_block = "\n".join(
+            f"[{index}] {entry.text}" for index, entry in enumerate(context, start=1)
+        )
+        return (
+            f"{self.system_prompt}\n\n"
+            f"Question: {query}\n"
+            f"Context:\n{context_block}\n\n"
+            f"Cite sources in {self.citation_style} style using the provided "
+            "identifiers."
+        )
+
+    async def _generate_with_retries(self, prompt: str) -> str:
+        last_error: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                return await self._invoke_llm(prompt)
+            except Exception as exc:  # pragma: no cover - exercised via tests
+                last_error = exc
+                if attempt == self.max_retries:
+                    raise
+                delay = self.backoff_seconds * (2**attempt)
+                await asyncio.sleep(delay)
+        msg = f"Generation failed after {self.max_retries + 1} attempts"
+        raise RuntimeError(msg) from last_error
+
+    async def _invoke_llm(self, prompt: str) -> str:
+        llm_callable = self.llm or self._default_llm
+        result = llm_callable(prompt, self.max_tokens, self.temperature)
+        if inspect.isawaitable(result):
+            result = await result
+        if not isinstance(result, str) or not result.strip():
+            msg = "LLM callable must return a non-empty string"
+            raise ValueError(msg)
+        return result.strip()
+
+    def _default_llm(self, prompt: str, max_tokens: int, temperature: float) -> str:
+        del max_tokens, temperature
+        return f"{prompt}\n\nResponse: See cited context for details."
+
+    def _build_citations(self, context: list[SearchResult]) -> list[dict[str, Any]]:
+        citations: list[dict[str, Any]] = []
+        for index, entry in enumerate(context, start=1):
+            citations.append(
+                {
+                    "id": str(index),
+                    "source_id": entry.id,
+                    "snippet": _truncate_snippet(entry.text),
+                    "sources": entry.sources
+                    or ([entry.source] if entry.source else []),
+                }
+            )
+        return citations
+
+    def _attach_citations(
+        self, completion: str, citations: list[dict[str, Any]]
+    ) -> str:
+        markers = " ".join(f"[{citation['id']}]" for citation in citations)
+        if not markers:
+            return completion
+        if self.citation_style == "footnote":
+            return f"{completion}\n\nFootnotes: {markers}".strip()
+        if self.citation_style == "endnote":
+            return f"{completion}\n\nEndnotes: {markers}".strip()
+        return f"{completion} {markers}".strip()
+
+    @staticmethod
+    def _estimate_tokens(prompt: str, completion: str) -> int:
+        return len((prompt + completion).split())

--- a/tests/nodes/conversational_search/test_generation.py
+++ b/tests/nodes/conversational_search/test_generation.py
@@ -1,0 +1,110 @@
+import asyncio
+import pytest
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
+from orcheo.nodes.conversational_search.models import SearchResult
+
+
+def _state_with_context(query: str) -> State:
+    results = {
+        "retriever": {
+            "results": [
+                SearchResult(
+                    id="chunk-1",
+                    score=0.9,
+                    text="Orcheo ships modular nodes for RAG workflows.",
+                    metadata={"page": 1},
+                    source="vector",
+                ),
+                SearchResult(
+                    id="chunk-2",
+                    score=0.8,
+                    text="Grounded answers include citations.",
+                    metadata={"page": 2},
+                    source="bm25",
+                ),
+            ]
+        }
+    }
+    return State(inputs={"query": query}, results=results, structured_response=None)
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_appends_citations() -> None:
+    node = GroundedGeneratorNode(name="generator")
+    state = _state_with_context("What does Orcheo provide?")
+
+    result = await node.run(state, {})
+
+    assert result["citations"]
+    assert "[1]" in result["response"]
+    assert result["tokens_used"] > 0
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_resolves_context_from_results_field() -> None:
+    node = GroundedGeneratorNode(name="generator", context_result_key="hybrid")
+    source_state = _state_with_context("How are citations handled?")
+    retrieval_results = source_state["results"]["retriever"]["results"]
+    state = State(
+        inputs=source_state["inputs"],
+        results={"results": retrieval_results, "hybrid": {}},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["citations"][0]["source_id"] == "chunk-1"
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_retries_on_failure() -> None:
+    attempts: list[int] = []
+
+    async def flaky_llm(prompt: str, max_tokens: int, temperature: float) -> str:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("temporary")
+        return f"{prompt} stable"
+
+    node = GroundedGeneratorNode(
+        name="generator", llm=flaky_llm, max_retries=1, backoff_seconds=0
+    )
+    state = _state_with_context("Explain citations")
+
+    result = await node.run(state, {})
+
+    assert len(attempts) == 2
+    assert "stable" in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_requires_query_and_context() -> None:
+    node = GroundedGeneratorNode(name="generator")
+    empty_state = State(inputs={}, results={}, structured_response=None)
+
+    with pytest.raises(
+        ValueError, match="GroundedGeneratorNode requires a non-empty query string"
+    ):
+        await node.run(empty_state, {})
+
+    state = State(inputs={"query": "hi"}, results={}, structured_response=None)
+    with pytest.raises(
+        ValueError, match="GroundedGeneratorNode requires at least one context document"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_grounded_generator_rejects_non_list_context_payload() -> None:
+    node = GroundedGeneratorNode(name="generator")
+    state = State(
+        inputs={"query": "hi"},
+        results={"retriever": {"results": "not-a-list"}},
+        structured_response=None,
+    )
+
+    with pytest.raises(
+        ValueError, match="Context payload must be a list of retrieval results"
+    ):
+        await node.run(state, {})

--- a/tests/nodes/conversational_search/test_query_processing.py
+++ b/tests/nodes/conversational_search/test_query_processing.py
@@ -1,5 +1,4 @@
 import pytest
-
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search.models import SearchResult
 from orcheo.nodes.conversational_search.query_processing import (

--- a/tests/nodes/conversational_search/test_reference_graph.py
+++ b/tests/nodes/conversational_search/test_reference_graph.py
@@ -1,0 +1,73 @@
+import pytest
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search import (
+    ChunkingStrategyNode,
+    DocumentLoaderNode,
+    EmbeddingIndexerNode,
+    GroundedGeneratorNode,
+    VectorSearchNode,
+)
+from orcheo.nodes.conversational_search.ingestion import RawDocumentInput
+from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
+
+
+@pytest.mark.asyncio
+async def test_reference_pipeline_generates_grounded_answer() -> None:
+    vector_store = InMemoryVectorStore()
+
+    loader = DocumentLoaderNode(
+        name="document_loader",
+        documents=[
+            RawDocumentInput(
+                content="Orcheo delivers modular nodes for retrieval augmented generation.",
+                metadata={"source": "primer"},
+            ),
+            RawDocumentInput(
+                content="Grounded generation should always emit citations.",
+                metadata={"source": "primer"},
+            ),
+        ],
+    )
+    chunker = ChunkingStrategyNode(
+        name="chunking_strategy", chunk_size=64, chunk_overlap=8
+    )
+    indexer = EmbeddingIndexerNode(
+        name="embedding_indexer", vector_store=vector_store, chunks_field="chunks"
+    )
+    retriever = VectorSearchNode(
+        name="retriever",
+        vector_store=vector_store,
+        query_key="query",
+        top_k=3,
+    )
+    generator = GroundedGeneratorNode(
+        name="generator", context_result_key="retriever", context_field="results"
+    )
+
+    state = State(
+        inputs={"query": "What does Orcheo deliver?"},
+        results={},
+        structured_response=None,
+    )
+
+    loader_result = await loader.run(state, {})
+    state["results"][loader.name] = loader_result
+
+    chunk_result = await chunker.run(state, {})
+    state["results"][chunker.name] = chunk_result
+
+    index_result = await indexer.run(state, {})
+    state["results"][indexer.name] = index_result
+
+    retrieval_result = await retriever.run(state, {})
+    state["results"][retriever.name] = retrieval_result
+
+    generation_result = await generator.run(state, {})
+
+    assert generation_result["citations"]
+    assert any(
+        "Orcheo delivers" in citation["snippet"]
+        for citation in generation_result["citations"]
+    )
+    assert "response" in generation_result
+    assert "[1]" in generation_result["response"]


### PR DESCRIPTION
## Summary
- implement a GroundedGeneratorNode that produces grounded responses with citations and retry support
- expose the node from the conversational search package and add focused unit coverage
- add a reference ingestion→retrieval→generation pipeline test and mark plan tasks 1.4/1.5 complete

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e68a786c8327993acee0264e2115)