### PR TITLE
Add conversational memory and routing nodes

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -46,13 +46,13 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 #### Task Checklist
 
-- [ ] Task 2.1: Introduce conversation management nodes (ConversationStateNode, ConversationCompressorNode) with token-budgeted summaries.
+- [x] Task 2.1: Introduce conversation management nodes (ConversationStateNode, ConversationCompressorNode) with token-budgeted summaries.
   - Dependencies: Milestone 1 graph skeleton.
-- [ ] Task 2.2: Add TopicShiftDetectorNode and QueryClarificationNode for adaptive routing and ambiguity resolution.
+- [x] Task 2.2: Add TopicShiftDetectorNode and QueryClarificationNode for adaptive routing and ambiguity resolution.
   - Dependencies: Task 2.1 conversation signals.
-- [ ] Task 2.3: Implement MemorySummarizerNode writing to BaseMemoryStore with retention policies.
+- [x] Task 2.3: Implement MemorySummarizerNode writing to BaseMemoryStore with retention policies.
   - Dependencies: Memory store backend decision; Task 2.1 state schema.
-- [ ] Task 2.4: Extend integration tests for multi-turn flows, including conversation compression and topic shift branching.
+- [x] Task 2.4: Extend integration tests for multi-turn flows, including conversation compression and topic shift branching.
   - Dependencies: Tasks 2.1-2.3.
 
 ---

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -5,11 +5,17 @@ from orcheo.nodes.code import PythonCode
 from orcheo.nodes.communication import DiscordWebhookNode, EmailNode
 from orcheo.nodes.conversational_search import (
     ChunkingStrategyNode,
+    ConversationCompressorNode,
+    ConversationStateNode,
     DocumentLoaderNode,
     EmbeddingIndexerNode,
+    InMemoryMemoryStore,
     InMemoryVectorStore,
+    MemorySummarizerNode,
     MetadataExtractorNode,
     PineconeVectorStore,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
 )
 from orcheo.nodes.data import (
     DataTransformNode,
@@ -77,4 +83,10 @@ __all__ = [
     "EmbeddingIndexerNode",
     "InMemoryVectorStore",
     "PineconeVectorStore",
+    "ConversationStateNode",
+    "ConversationCompressorNode",
+    "TopicShiftDetectorNode",
+    "QueryClarificationNode",
+    "MemorySummarizerNode",
+    "InMemoryMemoryStore",
 ]

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -1,5 +1,13 @@
 """Conversational search nodes and utilities."""
 
+from orcheo.nodes.conversational_search.conversation import (
+    ConversationCompressorNode,
+    ConversationStateNode,
+    InMemoryMemoryStore,
+    MemorySummarizerNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
+)
 from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
 from orcheo.nodes.conversational_search.ingestion import (
     ChunkingStrategyNode,
@@ -29,6 +37,12 @@ __all__ = [
     "BaseVectorStore",
     "InMemoryVectorStore",
     "PineconeVectorStore",
+    "ConversationStateNode",
+    "ConversationCompressorNode",
+    "TopicShiftDetectorNode",
+    "QueryClarificationNode",
+    "MemorySummarizerNode",
+    "InMemoryMemoryStore",
     "DocumentLoaderNode",
     "ChunkingStrategyNode",
     "MetadataExtractorNode",

--- a/src/orcheo/nodes/conversational_search/conversation.py
+++ b/src/orcheo/nodes/conversational_search/conversation.py
@@ -1,0 +1,413 @@
+"""Conversation management nodes for conversational search pipelines."""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
+from pydantic import ConfigDict, Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.models import ConversationTurn
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+class BaseMemoryStore(ABC):
+    """Abstract interface for conversation memory storage."""
+
+    @abstractmethod
+    async def get_session(self, session_id: str) -> dict[str, Any]:
+        """Return session payload containing history and metadata."""
+
+    @abstractmethod
+    async def save_turn(self, session_id: str, turn: ConversationTurn) -> None:
+        """Persist a new conversation turn for the session."""
+
+    @abstractmethod
+    async def get_history(self, session_id: str, limit: int) -> list[ConversationTurn]:
+        """Return the most recent turns for ``session_id`` up to ``limit``."""
+
+    @abstractmethod
+    async def save_summary(self, session_id: str, summary: str) -> None:
+        """Persist a textual summary for retention and personalization."""
+
+    @abstractmethod
+    async def cleanup(self, session_id: str) -> None:
+        """Remove session state and associated metadata."""
+
+
+class InMemoryMemoryStore(BaseMemoryStore):
+    """Simple in-memory memory store for tests and local execution."""
+
+    def __init__(self) -> None:
+        """Initialize the session container."""
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    async def get_session(self, session_id: str) -> dict[str, Any]:
+        """Return the session payload, creating it when missing."""
+        return self._sessions.setdefault(session_id, {"history": [], "summaries": []})
+
+    async def save_turn(self, session_id: str, turn: ConversationTurn) -> None:
+        """Append a turn to the session history."""
+        session = await self.get_session(session_id)
+        session["history"].append(turn)
+
+    async def get_history(self, session_id: str, limit: int) -> list[ConversationTurn]:
+        """Return the most recent ``limit`` turns for the session."""
+        session = await self.get_session(session_id)
+        if limit <= 0:
+            return []
+        return session["history"][-limit:]
+
+    async def save_summary(self, session_id: str, summary: str) -> None:
+        """Persist a summary associated with the session."""
+        session = await self.get_session(session_id)
+        session["summaries"].append(summary)
+
+    async def cleanup(self, session_id: str) -> None:
+        """Remove all in-memory data for the session."""
+        self._sessions.pop(session_id, None)
+
+
+@registry.register(
+    NodeMetadata(
+        name="ConversationStateNode",
+        description="Maintain per-session conversation history with turn budgeting.",
+        category="conversational_search",
+    )
+)
+class ConversationStateNode(TaskNode):
+    """Node that materializes and updates conversation state."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    session_id_key: str = Field(
+        default="session_id",
+        description="Key in ``state.inputs`` containing the session id.",
+    )
+    message_key: str = Field(
+        default="user_message",
+        description="Key in ``state.inputs`` containing the latest user message.",
+    )
+    role: Literal["user", "assistant", "system"] = Field(
+        default="user", description="Role to attribute to the incoming turn."
+    )
+    max_turns: int = Field(
+        default=50, gt=0, description="Maximum turns to return in history."
+    )
+    memory_store: BaseMemoryStore = Field(
+        default_factory=InMemoryMemoryStore,
+        description="Backing store used to persist conversation state.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Persist the latest turn and emit bounded history."""
+        del config
+        session_id = state.get("inputs", {}).get(self.session_id_key)
+        if not isinstance(session_id, str) or not session_id.strip():
+            msg = "ConversationStateNode requires a non-empty session_id"
+            raise ValueError(msg)
+
+        message = state.get("inputs", {}).get(self.message_key)
+        if not isinstance(message, str) or not message.strip():
+            msg = "ConversationStateNode requires a non-empty user message"
+            raise ValueError(msg)
+
+        turn = ConversationTurn(role=self.role, content=message.strip())
+        await self.memory_store.save_turn(session_id, turn)
+
+        history = await self.memory_store.get_history(session_id, self.max_turns)
+        metadata = {
+            "turn_count": len(
+                (await self.memory_store.get_session(session_id))["history"]
+            ),
+            "session_id": session_id,
+        }
+
+        return {
+            "session_id": session_id,
+            "conversation_history": history,
+            "metadata": metadata,
+        }
+
+
+@registry.register(
+    NodeMetadata(
+        name="ConversationCompressorNode",
+        description="Summarize long conversation histories within a token budget.",
+        category="conversational_search",
+    )
+)
+class ConversationCompressorNode(TaskNode):
+    """Compress conversation history by summarizing older turns."""
+
+    history_result_key: str = Field(
+        default="conversation_state",
+        description=(
+            "Result key holding conversation state output; defaults to "
+            "``conversation_state``."
+        ),
+    )
+    history_field: str = Field(
+        default="conversation_history",
+        description="Field containing conversation turns within the result payload.",
+    )
+    max_tokens: int = Field(default=800, gt=0, description="Token budget for history.")
+    summary_max_tokens: int = Field(
+        default=120,
+        gt=0,
+        description="Maximum tokens to allocate for the summary block.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return compressed conversation history within a token budget."""
+        del config
+        history_payload = state.get("results", {}).get(self.history_result_key, {})
+        history_entries = history_payload.get(self.history_field, history_payload)
+        if not isinstance(history_entries, list):
+            msg = "Conversation history must be provided as a list"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(entry) for entry in history_entries]
+        total_tokens = sum(turn.token_count for turn in turns)
+        if total_tokens <= self.max_tokens:
+            return {
+                "conversation_history": turns,
+                "summary": None,
+                "truncated": False,
+                "total_tokens": total_tokens,
+            }
+
+        retained: list[ConversationTurn] = []
+        truncated: list[ConversationTurn] = []
+        running_tokens = 0
+
+        for turn in reversed(turns):
+            if running_tokens + turn.token_count > self.max_tokens:
+                truncated.append(turn)
+                continue
+            retained.append(turn)
+            running_tokens += turn.token_count
+
+        summary_text = self._build_summary(list(reversed(truncated)))
+        summary_turn = ConversationTurn(
+            role="system",
+            content=f"Summary: {summary_text}",
+            metadata={"summary": True, "compressed_turns": len(truncated)},
+        )
+
+        compressed_history = [summary_turn] + list(reversed(retained))
+        compressed_tokens = sum(turn.token_count for turn in compressed_history)
+
+        return {
+            "conversation_history": compressed_history,
+            "summary": summary_turn.content,
+            "truncated": True,
+            "total_tokens": compressed_tokens,
+        }
+
+    def _build_summary(self, turns: list[ConversationTurn]) -> str:
+        if not turns:
+            return ""
+        text = "; ".join(f"{turn.role}: {turn.content}" for turn in turns)
+        tokens = text.split()
+        if len(tokens) <= self.summary_max_tokens:
+            return text
+        shortened = tokens[: self.summary_max_tokens]
+        return " ".join(shortened).rstrip() + "…"
+
+
+@registry.register(
+    NodeMetadata(
+        name="TopicShiftDetectorNode",
+        description="Detect topic shifts between the latest query and prior turns.",
+        category="conversational_search",
+    )
+)
+class TopicShiftDetectorNode(TaskNode):
+    """Heuristic detector for topic shifts in a conversation."""
+
+    query_key: str = Field(
+        default="query",
+        description="Key within ``state.inputs`` holding the latest query.",
+    )
+    history_result_key: str = Field(
+        default="conversation_compressor",
+        description="Result key containing compressed history to evaluate.",
+    )
+    history_field: str = Field(
+        default="conversation_history",
+        description="Field holding conversation turns within the history payload.",
+    )
+    min_overlap_ratio: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        description="Minimum token overlap ratio to consider the topic unchanged.",
+    )
+    shift_markers: set[str] = Field(
+        default_factory=lambda: {"new topic", "another question", "switching"},
+        description="Phrases that explicitly indicate a topic change.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Detect whether the latest query indicates a topic shift."""
+        del config
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "TopicShiftDetectorNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        history_payload = state.get("results", {}).get(self.history_result_key, {})
+        history_entries = history_payload.get(self.history_field, history_payload)
+        if not isinstance(history_entries, list):
+            msg = "Conversation history must be provided as a list"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(entry) for entry in history_entries]
+        last_user_turn = next(
+            (turn for turn in reversed(turns) if turn.role == "user"), None
+        )
+        overlap_ratio = self._overlap_ratio(
+            query, last_user_turn.content if last_user_turn else ""
+        )
+        marker_present = any(marker in query.lower() for marker in self.shift_markers)
+        topic_shift = marker_present or overlap_ratio < self.min_overlap_ratio
+
+        reason = "explicit marker" if marker_present else "low overlap"
+
+        return {
+            "topic_shift": topic_shift,
+            "overlap_ratio": overlap_ratio,
+            "last_topic": last_user_turn.content if last_user_turn else None,
+            "reason": reason if topic_shift else "stable",
+        }
+
+    @staticmethod
+    def _overlap_ratio(current: str, previous: str) -> float:
+        current_tokens = {token for token in current.lower().split() if token}
+        previous_tokens = {token for token in previous.lower().split() if token}
+        if not current_tokens or not previous_tokens:
+            return 0.0
+        intersection = current_tokens & previous_tokens
+        return len(intersection) / max(len(current_tokens), 1)
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryClarificationNode",
+        description=(
+            "Produce clarifying questions when queries are ambiguous or shifted."
+        ),
+        category="conversational_search",
+    )
+)
+class QueryClarificationNode(TaskNode):
+    """Node that emits clarification prompts for ambiguous user queries."""
+
+    query_key: str = Field(
+        default="query", description="Key within ``state.inputs`` containing the query."
+    )
+    topic_result_key: str | None = Field(
+        default="topic_detector",
+        description="Optional key to read topic shift signals from ``state.results``.",
+    )
+    ambiguity_pronouns: set[str] = Field(
+        default_factory=lambda: {"it", "that", "this", "those", "they"},
+        description="Pronouns that often require clarification in isolation.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Emit a clarifying question when ambiguity is detected."""
+        del config
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryClarificationNode requires a non-empty query string"
+            raise ValueError(msg)
+
+        topic_shift = False
+        last_topic: str | None = None
+        if self.topic_result_key:
+            topic_payload = state.get("results", {}).get(self.topic_result_key, {})
+            if isinstance(topic_payload, dict):
+                topic_shift = bool(topic_payload.get("topic_shift", False))
+                last_topic = topic_payload.get("last_topic")
+
+        needs_clarification = topic_shift or self._has_ambiguous_pronoun(query)
+        clarifying_question = None
+        if needs_clarification:
+            prefix = "I noticed a topic change" if topic_shift else "To clarify"
+            context_hint = f" about '{last_topic}'" if last_topic else ""
+            clarifying_question = (
+                f"{prefix}{context_hint}. Could you specify what you're referring to?"
+            )
+
+        return {
+            "needs_clarification": needs_clarification,
+            "clarifying_question": clarifying_question,
+        }
+
+    def _has_ambiguous_pronoun(self, query: str) -> bool:
+        tokens = {token.strip(".,?!").lower() for token in query.split()}
+        return bool(tokens & self.ambiguity_pronouns)
+
+
+@registry.register(
+    NodeMetadata(
+        name="MemorySummarizerNode",
+        description="Persist conversation summaries with retention policies.",
+        category="conversational_search",
+    )
+)
+class MemorySummarizerNode(TaskNode):
+    """Node that stores conversation summaries into a memory store."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    session_id_key: str = Field(
+        default="session_id",
+        description="Key within ``state.inputs`` for the session id.",
+    )
+    summary_result_key: str = Field(
+        default="conversation_compressor",
+        description="Result key containing the generated summary text.",
+    )
+    summary_field: str = Field(
+        default="summary",
+        description="Field holding the summary string inside the result payload.",
+    )
+    retention_summaries: int = Field(
+        default=5,
+        gt=0,
+        description="Maximum number of summaries to retain per session.",
+    )
+    memory_store: BaseMemoryStore = Field(
+        default_factory=InMemoryMemoryStore,
+        description="Backing store used to persist summaries.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Persist summaries while enforcing retention policies."""
+        del config
+        session_id = state.get("inputs", {}).get(self.session_id_key)
+        if not isinstance(session_id, str) or not session_id.strip():
+            msg = "MemorySummarizerNode requires a non-empty session_id"
+            raise ValueError(msg)
+
+        summary_payload = state.get("results", {}).get(self.summary_result_key, {})
+        summary_text = summary_payload.get(self.summary_field)
+        if not isinstance(summary_text, str) or not summary_text.strip():
+            msg = "MemorySummarizerNode requires a non-empty summary to persist"
+            raise ValueError(msg)
+
+        await self.memory_store.save_summary(session_id, summary_text.strip())
+        session = await self.memory_store.get_session(session_id)
+        summaries: list[str] = session.get("summaries", [])
+        if len(summaries) > self.retention_summaries:
+            excess = len(summaries) - self.retention_summaries
+            del summaries[0:excess]
+
+        return {
+            "session_id": session_id,
+            "summary": summary_text.strip(),
+            "summary_count": len(summaries),
+        }

--- a/tests/nodes/conversational_search/test_conversation.py
+++ b/tests/nodes/conversational_search/test_conversation.py
@@ -1,0 +1,123 @@
+import pytest
+
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.conversation import (
+    ConversationCompressorNode,
+    ConversationStateNode,
+    InMemoryMemoryStore,
+    MemorySummarizerNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
+)
+from orcheo.nodes.conversational_search.models import ConversationTurn
+
+
+@pytest.mark.asyncio
+async def test_conversation_state_appends_and_limits_history() -> None:
+    memory_store = InMemoryMemoryStore()
+    node = ConversationStateNode(
+        name="conversation_state", memory_store=memory_store, max_turns=2
+    )
+
+    await memory_store.save_turn("sess", ConversationTurn(role="user", content="hello"))
+    await memory_store.save_turn(
+        "sess", ConversationTurn(role="assistant", content="hi there")
+    )
+
+    state = State(
+        inputs={"session_id": "sess", "user_message": "new message"},
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["metadata"]["turn_count"] == 3
+    assert [turn.content for turn in result["conversation_history"]] == [
+        "hello",
+        "hi there",
+        "new message",
+    ][1:]
+
+
+@pytest.mark.asyncio
+async def test_conversation_compressor_summarizes_when_over_budget() -> None:
+    turns = [
+        ConversationTurn(role="user", content="Tell me about Orcheo"),
+        ConversationTurn(role="assistant", content="Orcheo ships graph-native nodes"),
+        ConversationTurn(role="user", content="How does the retrieval work?"),
+    ]
+    state = State(
+        inputs={},
+        results={"conversation_state": {"conversation_history": turns}},
+        structured_response=None,
+    )
+    node = ConversationCompressorNode(
+        name="conversation_compressor", max_tokens=5, summary_max_tokens=4
+    )
+
+    result = await node.run(state, {})
+
+    assert result["truncated"] is True
+    assert result["conversation_history"][0].metadata["summary"] is True
+    assert "Summary:" in result["summary"]
+
+
+@pytest.mark.asyncio
+async def test_topic_shift_detector_flags_low_overlap() -> None:
+    history = [
+        ConversationTurn(role="user", content="Discuss the retriever architecture"),
+        ConversationTurn(role="assistant", content="We use hybrid retrieval"),
+    ]
+    state = State(
+        inputs={"query": "Switching to pricing"},
+        results={"conversation_compressor": {"conversation_history": history}},
+        structured_response=None,
+    )
+    node = TopicShiftDetectorNode(name="topic_detector", min_overlap_ratio=0.5)
+
+    result = await node.run(state, {})
+
+    assert result["topic_shift"] is True
+    assert result["reason"] == "explicit marker"
+
+
+@pytest.mark.asyncio
+async def test_query_clarification_uses_topic_shift_signal() -> None:
+    state = State(
+        inputs={"query": "How does it work?"},
+        results={"topic_detector": {"topic_shift": True, "last_topic": "retrieval"}},
+        structured_response=None,
+    )
+    node = QueryClarificationNode(name="clarifier")
+
+    result = await node.run(state, {})
+
+    assert result["needs_clarification"] is True
+    assert "retrieval" in result["clarifying_question"]
+
+
+@pytest.mark.asyncio
+async def test_memory_summarizer_persists_with_retention() -> None:
+    memory_store = InMemoryMemoryStore()
+    node = MemorySummarizerNode(
+        name="memory_summarizer",
+        memory_store=memory_store,
+        retention_summaries=2,
+    )
+    state = State(
+        inputs={"session_id": "sess"},
+        results={"conversation_compressor": {"summary": "Summary: first"}},
+        structured_response=None,
+    )
+
+    await node.run(state, {})
+    state["results"]["conversation_compressor"] = {"summary": "Summary: second"}
+    await node.run(state, {})
+    state["results"]["conversation_compressor"] = {"summary": "Summary: third"}
+    result = await node.run(state, {})
+
+    session = await memory_store.get_session("sess")
+
+    assert result["summary_count"] == 2
+    assert session["summaries"] == ["Summary: second", "Summary: third"]

--- a/tests/nodes/conversational_search/test_reference_graph.py
+++ b/tests/nodes/conversational_search/test_reference_graph.py
@@ -1,13 +1,19 @@
 import pytest
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search import (
+    ConversationCompressorNode,
+    ConversationStateNode,
     ChunkingStrategyNode,
     DocumentLoaderNode,
     EmbeddingIndexerNode,
     GroundedGeneratorNode,
+    MemorySummarizerNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
     VectorSearchNode,
 )
 from orcheo.nodes.conversational_search.ingestion import RawDocumentInput
+from orcheo.nodes.conversational_search.conversation import InMemoryMemoryStore
 from orcheo.nodes.conversational_search.vector_store import InMemoryVectorStore
 
 
@@ -71,3 +77,109 @@ async def test_reference_pipeline_generates_grounded_answer() -> None:
     )
     assert "response" in generation_result
     assert "[1]" in generation_result["response"]
+
+
+@pytest.mark.asyncio
+async def test_reference_pipeline_supports_multi_turn_with_compression_and_routing() -> (
+    None
+):
+    vector_store = InMemoryVectorStore()
+
+    memory_store = InMemoryMemoryStore()
+    conversation_state = ConversationStateNode(
+        name="conversation_state", memory_store=memory_store, max_turns=5
+    )
+    conversation_compressor = ConversationCompressorNode(
+        name="conversation_compressor", max_tokens=5, summary_max_tokens=6
+    )
+    topic_detector = TopicShiftDetectorNode(
+        name="topic_detector", min_overlap_ratio=0.4
+    )
+    clarifier = QueryClarificationNode(name="clarifier")
+    memory_summarizer = MemorySummarizerNode(
+        name="memory_summarizer", memory_store=memory_store, retention_summaries=2
+    )
+
+    loader = DocumentLoaderNode(
+        name="document_loader",
+        documents=[
+            RawDocumentInput(
+                content="Orcheo uses hybrid retrieval across vector and BM25 indices.",
+                metadata={"source": "primer"},
+            ),
+            RawDocumentInput(
+                content="Topic shifts can route users to fresh retrieval flows.",
+                metadata={"source": "primer"},
+            ),
+        ],
+    )
+    chunker = ChunkingStrategyNode(
+        name="chunking_strategy", chunk_size=64, chunk_overlap=8
+    )
+    indexer = EmbeddingIndexerNode(
+        name="embedding_indexer", vector_store=vector_store, chunks_field="chunks"
+    )
+    retriever = VectorSearchNode(
+        name="retriever",
+        vector_store=vector_store,
+        query_key="query",
+        top_k=2,
+    )
+    generator = GroundedGeneratorNode(
+        name="generator", context_result_key="retriever", context_field="results"
+    )
+
+    state = State(
+        inputs={
+            "query": "How does retrieval work?",
+            "session_id": "sess",
+            "user_message": "How does retrieval work?",
+        },
+        results={},
+        structured_response=None,
+    )
+
+    loader_result = await loader.run(state, {})
+    state["results"][loader.name] = loader_result
+    chunk_result = await chunker.run(state, {})
+    state["results"][chunker.name] = chunk_result
+    index_result = await indexer.run(state, {})
+    state["results"][indexer.name] = index_result
+
+    convo_result = await conversation_state.run(state, {})
+    state["results"][conversation_state.name] = convo_result
+    compressor_result = await conversation_compressor.run(state, {})
+    state["results"][conversation_compressor.name] = compressor_result
+    topic_result = await topic_detector.run(state, {})
+    state["results"][topic_detector.name] = topic_result
+    clarifier_result = await clarifier.run(state, {})
+    state["results"][clarifier.name] = clarifier_result
+
+    retrieval_result = await retriever.run(state, {})
+    state["results"][retriever.name] = retrieval_result
+    generation_result = await generator.run(state, {})
+
+    assert compressor_result["summary"] is None
+    assert topic_result["topic_shift"] is False
+    assert clarifier_result["needs_clarification"] is False
+    assert generation_result["citations"]
+
+    # New topic turn triggers topic shift and clarification prompt
+    state["inputs"]["query"] = "Switching to pricing details"
+    state["inputs"]["user_message"] = "Switching to pricing details"
+
+    convo_result = await conversation_state.run(state, {})
+    state["results"][conversation_state.name] = convo_result
+    compressor_result = await conversation_compressor.run(state, {})
+    state["results"][conversation_compressor.name] = compressor_result
+    topic_result = await topic_detector.run(state, {})
+    state["results"][topic_detector.name] = topic_result
+    clarifier_result = await clarifier.run(state, {})
+
+    assert compressor_result["summary"] is not None
+    assert topic_result["topic_shift"] is True
+    assert clarifier_result["needs_clarification"] is True
+
+    summary_result = await memory_summarizer.run(state, {})
+
+    assert summary_result["summary_count"] >= 1


### PR DESCRIPTION
## Summary
- add conversation management, topic detection, clarification, and memory summarization nodes plus in-memory store support for conversational search
- extend conversational search models and tests with multi-turn coverage and reference pipeline branching
- mark milestone 2 tasks complete in the conversational search plan

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f41a1724832793f8d2cbf25bdb79)