### PR TITLE
Add conversational memory management nodes

### DIFF
--- a/docs/conversational_search/plan.md
+++ b/docs/conversational_search/plan.md
@@ -46,13 +46,13 @@ This plan translates the Conversational Search PRD and Design into a sequenced d
 
 #### Task Checklist
 
-- [ ] Task 2.1: Introduce conversation management nodes (ConversationStateNode, ConversationCompressorNode) with token-budgeted summaries.
+- [x] Task 2.1: Introduce conversation management nodes (ConversationStateNode, ConversationCompressorNode) with token-budgeted summaries.
   - Dependencies: Milestone 1 graph skeleton.
-- [ ] Task 2.2: Add TopicShiftDetectorNode and QueryClarificationNode for adaptive routing and ambiguity resolution.
+- [x] Task 2.2: Add TopicShiftDetectorNode and QueryClarificationNode for adaptive routing and ambiguity resolution.
   - Dependencies: Task 2.1 conversation signals.
-- [ ] Task 2.3: Implement MemorySummarizerNode writing to BaseMemoryStore with retention policies.
+- [x] Task 2.3: Implement MemorySummarizerNode writing to BaseMemoryStore with retention policies.
   - Dependencies: Memory store backend decision; Task 2.1 state schema.
-- [ ] Task 2.4: Extend integration tests for multi-turn flows, including conversation compression and topic shift branching.
+- [x] Task 2.4: Extend integration tests for multi-turn flows, including conversation compression and topic shift branching.
   - Dependencies: Tasks 2.1-2.3.
 
 ---

--- a/src/orcheo/nodes/conversational_search/__init__.py
+++ b/src/orcheo/nodes/conversational_search/__init__.py
@@ -1,11 +1,22 @@
 """Conversational search nodes and utilities."""
 
+from orcheo.nodes.conversational_search.conversation import (
+    ConversationCompressorNode,
+    ConversationStateNode,
+    MemorySummarizerNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
+)
 from orcheo.nodes.conversational_search.generation import GroundedGeneratorNode
 from orcheo.nodes.conversational_search.ingestion import (
     ChunkingStrategyNode,
     DocumentLoaderNode,
     EmbeddingIndexerNode,
     MetadataExtractorNode,
+)
+from orcheo.nodes.conversational_search.memory import (
+    BaseMemoryStore,
+    InMemoryMemoryStore,
 )
 from orcheo.nodes.conversational_search.query_processing import (
     ContextCompressorNode,
@@ -29,11 +40,18 @@ __all__ = [
     "BaseVectorStore",
     "InMemoryVectorStore",
     "PineconeVectorStore",
+    "BaseMemoryStore",
+    "InMemoryMemoryStore",
     "DocumentLoaderNode",
     "ChunkingStrategyNode",
     "MetadataExtractorNode",
     "EmbeddingIndexerNode",
     "GroundedGeneratorNode",
+    "ConversationStateNode",
+    "ConversationCompressorNode",
+    "TopicShiftDetectorNode",
+    "QueryClarificationNode",
+    "MemorySummarizerNode",
     "QueryRewriteNode",
     "CoreferenceResolverNode",
     "QueryClassifierNode",

--- a/src/orcheo/nodes/conversational_search/conversation.py
+++ b/src/orcheo/nodes/conversational_search/conversation.py
@@ -1,0 +1,364 @@
+"""Conversation management nodes for conversational search."""
+
+from __future__ import annotations
+import re
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from pydantic import ConfigDict, Field
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.conversational_search.memory import BaseMemoryStore, Turn
+from orcheo.nodes.conversational_search.models import ConversationTurn
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+def _tokenize(text: str) -> set[str]:
+    tokens = re.findall(r"\b\w+\b", text.lower())
+    stopwords = {"the", "a", "an", "and", "or", "of", "to", "in"}
+    return {token for token in tokens if token not in stopwords}
+
+
+@registry.register(
+    NodeMetadata(
+        name="ConversationStateNode",
+        description="Normalize and retain conversation history with metadata.",
+        category="conversational_search",
+    )
+)
+class ConversationStateNode(TaskNode):
+    """Aggregate conversation history and enforce turn budgets."""
+
+    session_id_key: str = Field(
+        default="session_id",
+        description="Key in ``state.inputs`` containing the session identifier.",
+    )
+    history_key: str = Field(
+        default="history",
+        description="Key in ``state.inputs`` that holds prior turns.",
+    )
+    user_message_key: str = Field(
+        default="user_message",
+        description="Key in ``state.inputs`` holding the latest user message.",
+    )
+    assistant_message_key: str = Field(
+        default="assistant_message",
+        description="Optional assistant reply to append to the state.",
+    )
+    max_turns: int = Field(default=50, gt=0, description="Maximum turns to retain.")
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return normalized conversation history bounded by ``max_turns``."""
+        session_id = state.get("inputs", {}).get(self.session_id_key)
+        if not isinstance(session_id, str) or not session_id.strip():
+            msg = "ConversationStateNode requires a non-empty session_id"
+            raise ValueError(msg)
+
+        raw_history = state.get("inputs", {}).get(self.history_key, []) or []
+        if not isinstance(raw_history, list):
+            msg = "history must be a list of conversation turns"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(item) for item in raw_history]
+
+        user_message = state.get("inputs", {}).get(self.user_message_key)
+        if isinstance(user_message, str) and user_message.strip():
+            turns.append(
+                ConversationTurn(role="user", content=user_message.strip(), metadata={})
+            )
+
+        assistant_message = state.get("inputs", {}).get(self.assistant_message_key)
+        if isinstance(assistant_message, str) and assistant_message.strip():
+            turns.append(
+                ConversationTurn(
+                    role="assistant", content=assistant_message.strip(), metadata={}
+                )
+            )
+
+        trimmed = turns[-self.max_turns :]
+        total_tokens = sum(turn.token_count for turn in trimmed)
+
+        return {
+            "session_id": session_id,
+            "conversation_history": trimmed,
+            "metadata": {"turn_count": len(trimmed), "total_tokens": total_tokens},
+        }
+
+
+@registry.register(
+    NodeMetadata(
+        name="ConversationCompressorNode",
+        description="Summarize conversation history with a token budget.",
+        category="conversational_search",
+    )
+)
+class ConversationCompressorNode(TaskNode):
+    """Compress conversation history into a short summary."""
+
+    history_key: str = Field(
+        default="conversation_history",
+        description="Key containing the list of :class:`ConversationTurn` objects.",
+    )
+    max_tokens: int = Field(
+        default=120,
+        gt=0,
+        description="Maximum approximate tokens to keep when summarizing.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return a compressed summary and retained turns under ``max_tokens``."""
+        history = state.get("results", {}).get(self.history_key)
+        if history is None:
+            history = self._extract_history_from_results(state.get("results", {}))
+
+        if history is None:
+            history = state.get("inputs", {}).get(self.history_key)
+
+        if history is None:
+            msg = "ConversationCompressorNode requires conversation_history"
+            raise ValueError(msg)
+
+        if not isinstance(history, list):
+            msg = "conversation_history must be provided as a list"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(item) for item in history]
+        retained: list[ConversationTurn] = []
+        total_tokens = 0
+        truncated = False
+
+        for turn in reversed(turns):
+            tokens = turn.token_count
+            if total_tokens + tokens > self.max_tokens:
+                truncated = True
+                break
+            retained.append(turn)
+            total_tokens += tokens
+
+        retained.reverse()
+        summary = self._build_summary(retained)
+
+        return {
+            "summary": summary,
+            "retained_turns": retained,
+            "truncated": truncated,
+            "total_tokens": total_tokens,
+        }
+
+    @staticmethod
+    def _extract_history_from_results(results: dict[str, Any]) -> list[Any] | None:
+        for value in results.values():
+            if isinstance(value, dict) and "conversation_history" in value:
+                return value.get("conversation_history")
+        return None
+
+    @staticmethod
+    def _build_summary(turns: list[ConversationTurn]) -> str:
+        parts = [f"{turn.role}: {turn.content}" for turn in turns]
+        return " | ".join(parts)
+
+
+@registry.register(
+    NodeMetadata(
+        name="TopicShiftDetectorNode",
+        description="Detect topic shifts between the current query and history.",
+        category="conversational_search",
+    )
+)
+class TopicShiftDetectorNode(TaskNode):
+    """Detect when the current query diverges from recent history."""
+
+    query_key: str = Field(
+        default="query", description="Key holding the active user query."
+    )
+    history_key: str = Field(
+        default="conversation_history",
+        description="Key holding prior :class:`ConversationTurn` entries.",
+    )
+    overlap_threshold: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Minimum token overlap to consider the topic unchanged.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return topic shift signals derived from lexical overlap."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "TopicShiftDetectorNode requires a non-empty query"
+            raise ValueError(msg)
+
+        history = state.get("results", {}).get(self.history_key)
+        if history is None:
+            history = state.get("inputs", {}).get(self.history_key, [])
+
+        if not isinstance(history, list):
+            msg = "conversation_history must be provided as a list"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(item) for item in history]
+        last_user = next(
+            (turn for turn in reversed(turns) if turn.role == "user"), None
+        )
+
+        current_tokens = _tokenize(query)
+        reference = last_user.content if last_user else None
+        previous_tokens = _tokenize(reference) if reference else set()
+
+        if not current_tokens or not previous_tokens:
+            return {"topic_shift": False, "overlap": 0.0, "reference": reference}
+
+        overlap = len(current_tokens & previous_tokens) / max(len(current_tokens), 1)
+        topic_shift = overlap < self.overlap_threshold
+
+        return {
+            "topic_shift": topic_shift,
+            "overlap": overlap,
+            "reference": reference,
+        }
+
+
+@registry.register(
+    NodeMetadata(
+        name="QueryClarificationNode",
+        description=(
+            "Emit a clarification prompt when ambiguity or topic shifts are detected."
+        ),
+        category="conversational_search",
+    )
+)
+class QueryClarificationNode(TaskNode):
+    """Produce clarifying guidance when routing requires more context."""
+
+    query_key: str = Field(
+        default="query", description="Key containing the current user query."
+    )
+    topic_shift_key: str = Field(
+        default="topic_shift", description="Key containing the topic shift flag."
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return a clarifying question suggestion when needed."""
+        query = state.get("inputs", {}).get(self.query_key)
+        if not isinstance(query, str) or not query.strip():
+            msg = "QueryClarificationNode requires a non-empty query"
+            raise ValueError(msg)
+
+        topic_signal = state.get("results", {}).get(self.topic_shift_key)
+        if isinstance(topic_signal, dict) and "topic_shift" in topic_signal:
+            topic_shift = bool(topic_signal.get("topic_shift"))
+        elif isinstance(topic_signal, bool):
+            topic_shift = topic_signal
+        else:
+            topic_shift = False
+
+        ambiguous = self._is_ambiguous(query)
+        needs_clarification = topic_shift or ambiguous
+
+        prompt = (
+            "Can you clarify what you'd like to explore next?"
+            if needs_clarification
+            else "Proceed with retrieval."
+        )
+
+        return {
+            "needs_clarification": needs_clarification,
+            "clarification_prompt": prompt,
+            "topic_shift": topic_shift,
+            "ambiguous": ambiguous,
+        }
+
+    @staticmethod
+    def _is_ambiguous(query: str) -> bool:
+        tokens = _tokenize(query)
+        return len(tokens) <= 2
+
+
+@registry.register(
+    NodeMetadata(
+        name="MemorySummarizerNode",
+        description="Persist summarized conversation turns to a memory store.",
+        category="conversational_search",
+    )
+)
+class MemorySummarizerNode(TaskNode):
+    """Write conversation turns to a :class:`BaseMemoryStore` with retention."""
+
+    memory_store: BaseMemoryStore = Field(
+        description="Backing store used to persist conversation turns.",
+    )
+    session_id_key: str = Field(
+        default="session_id", description="Key holding the conversation session id."
+    )
+    history_key: str = Field(
+        default="conversation_history",
+        description="Key containing the list of conversation turns to persist.",
+    )
+    max_turns: int = Field(
+        default=50, gt=0, description="Maximum number of turns to retain in memory."
+    )
+    retention_tokens: int = Field(
+        default=400,
+        gt=0,
+        description="Approximate token budget for returned summaries.",
+    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Persist conversation history and return a compact summary."""
+        session_id = state.get("inputs", {}).get(self.session_id_key)
+        if not isinstance(session_id, str) or not session_id.strip():
+            msg = "MemorySummarizerNode requires a non-empty session_id"
+            raise ValueError(msg)
+
+        history = state.get("results", {}).get(self.history_key)
+        if history is None:
+            history = state.get("inputs", {}).get(self.history_key)
+
+        if not isinstance(history, list):
+            msg = "conversation_history must be provided as a list"
+            raise ValueError(msg)
+
+        turns = [ConversationTurn.model_validate(item) for item in history]
+        persisted = 0
+
+        for turn in turns[-self.max_turns :]:
+            await self.memory_store.save_turn(
+                session_id,
+                Turn(
+                    session_id=session_id,
+                    role=turn.role,
+                    content=turn.content,
+                    metadata=turn.metadata,
+                ),
+            )
+            persisted += 1
+
+        retained_history = await self.memory_store.get_history(
+            session_id, self.max_turns
+        )
+        summary, truncated = self._summarize(retained_history)
+
+        return {
+            "session_id": session_id,
+            "summary": summary,
+            "persisted_turns": persisted,
+            "truncated": truncated,
+        }
+
+    def _summarize(self, turns: list[Turn]) -> tuple[str, bool]:
+        tokens = 0
+        kept: list[Turn] = []
+        truncated = False
+
+        for turn in reversed(turns):
+            token_count = len(turn.content.split())
+            if tokens + token_count > self.retention_tokens:
+                truncated = True
+                break
+            kept.append(turn)
+            tokens += token_count
+
+        kept.reverse()
+        summary = " | ".join(f"{turn.role}: {turn.content}" for turn in kept)
+        return summary, truncated

--- a/src/orcheo/nodes/conversational_search/memory.py
+++ b/src/orcheo/nodes/conversational_search/memory.py
@@ -1,0 +1,77 @@
+"""Memory abstractions for conversational search."""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Any
+from pydantic import BaseModel, Field
+
+
+class Turn(BaseModel):
+    """Canonical representation of a persisted conversation turn."""
+
+    session_id: str = Field(description="Conversation session identifier")
+    role: str = Field(description="Speaker role for this turn")
+    content: str = Field(description="Turn payload")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured metadata captured alongside the turn",
+    )
+
+
+class MemorySession(BaseModel):
+    """In-memory representation of a conversation session."""
+
+    session_id: str
+    turns: list[Turn] = Field(default_factory=list)
+    summary: str | None = None
+
+
+class BaseMemoryStore(ABC):
+    """Abstract interface for conversation memory storage backends."""
+
+    @abstractmethod
+    async def get_session(self, session_id: str) -> MemorySession:
+        """Return the session associated with ``session_id``."""
+
+    @abstractmethod
+    async def save_turn(self, session_id: str, turn: Turn) -> None:
+        """Persist a turn for the given session."""
+
+    @abstractmethod
+    async def get_history(self, session_id: str, limit: int) -> list[Turn]:
+        """Return the most recent ``limit`` turns for the session."""
+
+    @abstractmethod
+    async def cleanup(self, session_id: str) -> None:
+        """Remove all state for ``session_id``."""
+
+
+class InMemoryMemoryStore(BaseMemoryStore):
+    """Simple in-memory memory store for testing and local graphs."""
+
+    def __init__(self, max_turns: int | None = None) -> None:
+        """Initialize the store with an optional retention budget."""
+        self._sessions: dict[str, MemorySession] = {}
+        self._max_turns = max_turns
+
+    async def get_session(self, session_id: str) -> MemorySession:
+        """Return the session, initializing it when missing."""
+        if session_id not in self._sessions:
+            self._sessions[session_id] = MemorySession(session_id=session_id)
+        return self._sessions[session_id]
+
+    async def save_turn(self, session_id: str, turn: Turn) -> None:
+        """Save a turn and enforce the optional retention limit."""
+        session = await self.get_session(session_id)
+        session.turns.append(turn)
+        if self._max_turns is not None and len(session.turns) > self._max_turns:
+            session.turns = session.turns[-self._max_turns :]
+
+    async def get_history(self, session_id: str, limit: int) -> list[Turn]:
+        """Return the most recent ``limit`` turns for the session."""
+        session = await self.get_session(session_id)
+        return session.turns[-limit:]
+
+    async def cleanup(self, session_id: str) -> None:
+        """Remove session data entirely."""
+        self._sessions.pop(session_id, None)

--- a/tests/nodes/conversational_search/test_conversation.py
+++ b/tests/nodes/conversational_search/test_conversation.py
@@ -1,0 +1,120 @@
+import pytest
+from orcheo.graph.state import State
+from orcheo.nodes.conversational_search.conversation import (
+    ConversationCompressorNode,
+    ConversationStateNode,
+    MemorySummarizerNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
+)
+from orcheo.nodes.conversational_search.memory import InMemoryMemoryStore
+
+
+@pytest.mark.asyncio
+async def test_conversation_state_appends_messages_and_bounds_turns() -> None:
+    node = ConversationStateNode(name="conversation_state", max_turns=2)
+    state = State(
+        inputs={
+            "session_id": "sess-1",
+            "history": [
+                {"role": "user", "content": "Tell me about retrievers."},
+                {"role": "assistant", "content": "They combine vector and BM25."},
+            ],
+            "user_message": "What about hybrid?",
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["metadata"]["turn_count"] == 2
+    assert result["conversation_history"][-1].content == "What about hybrid?"
+
+
+@pytest.mark.asyncio
+async def test_conversation_compressor_limits_tokens_and_summarizes() -> None:
+    node = ConversationCompressorNode(name="compressor", max_tokens=5)
+    state = State(
+        inputs={
+            "conversation_history": [
+                {"role": "user", "content": "Explain vector search."},
+                {"role": "assistant", "content": "It uses embeddings."},
+                {"role": "user", "content": "Also BM25."},
+            ]
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["truncated"] is True
+    assert "user: Also BM25." in result["summary"]
+    assert result["total_tokens"] <= 5
+
+
+@pytest.mark.asyncio
+async def test_topic_shift_detector_flags_low_overlap() -> None:
+    node = TopicShiftDetectorNode(name="topic_shift")
+    state = State(
+        inputs={
+            "query": "Tell me pricing tiers",
+            "conversation_history": [
+                {"role": "user", "content": "Explain vector stores"},
+                {"role": "assistant", "content": "They index embeddings."},
+            ],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["topic_shift"] is True
+    assert 0 <= result["overlap"] <= 1
+
+
+@pytest.mark.asyncio
+async def test_query_clarification_respects_topic_signal() -> None:
+    node = QueryClarificationNode(name="clarifier")
+    state = State(
+        inputs={"query": "More"},
+        results={"topic_shift": {"topic_shift": True}},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    assert result["needs_clarification"] is True
+    assert "clarify" in result["clarification_prompt"].lower()
+
+
+@pytest.mark.asyncio
+async def test_memory_summarizer_persists_with_retention() -> None:
+    store = InMemoryMemoryStore(max_turns=2)
+    node = MemorySummarizerNode(
+        name="memory",
+        memory_store=store,
+        max_turns=2,
+        retention_tokens=10,
+    )
+    state = State(
+        inputs={
+            "session_id": "sess-2",
+            "conversation_history": [
+                {"role": "user", "content": "First question"},
+                {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Second question"},
+            ],
+        },
+        results={},
+        structured_response=None,
+    )
+
+    result = await node.run(state, {})
+
+    history = await store.get_history("sess-2", limit=10)
+    assert len(history) == 2
+    assert result["persisted_turns"] == 2
+    assert "user: Second question" in result["summary"]

--- a/tests/nodes/conversational_search/test_reference_graph.py
+++ b/tests/nodes/conversational_search/test_reference_graph.py
@@ -2,9 +2,13 @@ import pytest
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search import (
     ChunkingStrategyNode,
+    ConversationCompressorNode,
+    ConversationStateNode,
     DocumentLoaderNode,
     EmbeddingIndexerNode,
     GroundedGeneratorNode,
+    QueryClarificationNode,
+    TopicShiftDetectorNode,
     VectorSearchNode,
 )
 from orcheo.nodes.conversational_search.ingestion import RawDocumentInput
@@ -71,3 +75,50 @@ async def test_reference_pipeline_generates_grounded_answer() -> None:
     )
     assert "response" in generation_result
     assert "[1]" in generation_result["response"]
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_flow_handles_compression_and_topic_shift() -> None:
+    state = State(
+        inputs={
+            "session_id": "sess-graph",
+            "history": [
+                {"role": "user", "content": "Summarize vector search"},
+                {"role": "assistant", "content": "Vector search uses embeddings."},
+            ],
+            "user_message": "Now pricing tiers",
+        },
+        results={},
+        structured_response=None,
+    )
+
+    conversation = ConversationStateNode(name="conversation_state", max_turns=5)
+    compression = ConversationCompressorNode(name="compress_conversation", max_tokens=8)
+    topic_detector = TopicShiftDetectorNode(name="topic_detector")
+    clarification = QueryClarificationNode(name="clarifier")
+
+    convo_result = await conversation.run(state, {})
+    state["results"][conversation.name] = convo_result
+    compression_result = await compression.run(state, {})
+    state["results"][compression.name] = compression_result
+    topic_result = await topic_detector.run(
+        State(
+            inputs={"query": "What about pricing?"},
+            results={"conversation_history": convo_result["conversation_history"]},
+            structured_response=None,
+        ),
+        {},
+    )
+    state["results"][topic_detector.name] = topic_result
+    clarification_result = await clarification.run(
+        State(
+            inputs={"query": "What about pricing?"},
+            results={"topic_shift": topic_result},
+            structured_response=None,
+        ),
+        {},
+    )
+
+    assert compression_result["truncated"] is True
+    assert topic_result["topic_shift"] is True
+    assert clarification_result["needs_clarification"] is True


### PR DESCRIPTION
## Summary
- add conversation management, topic shift, and clarification nodes for conversational search
- introduce in-memory memory store and summarizer with retention-aware persistence
- expand conversational search tests and mark milestone 2 tasks as complete in the plan

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f41a1724832793f8d2cbf25bdb79)