### PR TITLE
Add conversational search demo foundations, shared data, and utilities

### DIFF
--- a/docs/conversational_search/demo_plan.md
+++ b/docs/conversational_search/demo_plan.md
@@ -27,11 +27,11 @@ Execution plan to ship the five conversational search demo workflows that showca
 
 #### Task Checklist
 
-- [ ] Task 1.1: Create demo directory structure and README scaffolds for demos 1-5.
+- [x] Task 1.1: Create demo directory structure and README scaffolds for demos 1-5.
   - Dependencies: Demo design file structure.
-- [ ] Task 1.2: Prepare sample corpora and golden datasets (docs, queries, labels) with environment templates.
+- [x] Task 1.2: Prepare sample corpora and golden datasets (docs, queries, labels) with environment templates.
   - Dependencies: Access to example content and eval labels.
-- [ ] Task 1.3: Add shared utilities (loaders, runners, config helpers) reused across demos.
+- [x] Task 1.3: Add shared utilities (loaders, runners, config helpers) reused across demos.
   - Dependencies: Node package APIs for loaders/indexers.
 
 ---

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example packages and runnable demos for Orcheo."""

--- a/examples/conversational_search/README.md
+++ b/examples/conversational_search/README.md
@@ -1,0 +1,25 @@
+# Conversational Search Demo Suite
+
+Foundational assets for five progressive conversational search demos. Milestone 1 provides runnable scaffolds, shared sample data, and utilities so later milestones can focus on full workflows and guardrails.
+
+## Quickstart
+1. Copy `.env.example` to `.env` and add your API keys (OpenAI, Anthropic, Tavily).
+2. Inspect `data/` to see the sample corpus, queries, and golden labels.
+3. Run any demo script, for example:
+   ```bash
+   uv run python examples/conversational_search/demo_1_basic_rag/run.py
+   ```
+
+## What's Included
+- Shared sample corpus (`data/docs`), baseline queries (`data/queries.json`), and golden labels (`data/golden`, `data/labels`).
+- Five demo folders with config stubs, runner scripts, README scaffolds, and placeholder notebooks.
+- `utils.py` with helpers for loading configs and datasets across demos.
+
+## Demos
+- **Demo 1: Basic RAG** – minimal ingestion and retrieval pipeline.
+- **Demo 2: Hybrid Search** – dense + sparse retrieval with fusion.
+- **Demo 3: Conversational Search** – stateful chat and query rewriting.
+- **Demo 4: Production** – caching, guardrails, and streaming hooks.
+- **Demo 5: Evaluation** – golden datasets, metrics, and feedback loops.
+
+Each demo reads from the shared sample data by default. Replace the corpus or queries with your own domain content to experiment.

--- a/examples/conversational_search/__init__.py
+++ b/examples/conversational_search/__init__.py
@@ -1,0 +1,1 @@
+"""Conversational search demo suite."""

--- a/examples/conversational_search/data/README.md
+++ b/examples/conversational_search/data/README.md
@@ -1,0 +1,13 @@
+# Conversational Search Demo Data
+
+This folder contains the shared sample corpus, queries, and labels used by the conversational search demo suite. The data is intentionally small so the demos can run locally without external dependencies.
+
+## Contents
+- `docs/`: Markdown knowledge base about the fictitious Orcheo Cloud product.
+- `queries.json`: Baseline user questions with intents and expected focus areas.
+- `golden/`: Golden queries and expected answers for evaluation-heavy demos.
+- `labels/relevance_labels.json`: Sparse relevance labels for retrieval metrics.
+
+## Usage
+- Demos point to these files by default in their `config.yaml`. You can replace the corpus or add more examples without changing the runner code.
+- Keep additions small and text-based so linting and tests stay fast.

--- a/examples/conversational_search/data/docs/authentication.md
+++ b/examples/conversational_search/data/docs/authentication.md
@@ -1,0 +1,22 @@
+# Authentication and Access Control
+
+Orcheo Cloud supports multiple authentication methods so teams can secure their workflows without sacrificing developer velocity.
+
+## OAuth2 Client Credentials
+- Create an application in the Orcheo console and download the client ID and secret.
+- Set the values in your environment as `ORCHEO_CLIENT_ID` and `ORCHEO_CLIENT_SECRET`.
+- Tokens are short lived and automatically refreshed by the SDK.
+
+## API Keys
+- API keys are scoped to a workspace and can be restricted to specific nodes.
+- Keys should be stored in your secret manager; never commit them to source control.
+- Rotate keys regularly and audit access logs from the console.
+
+## Single Sign-On
+- SSO supports SAML 2.0 and OIDC providers.
+- Map identity provider groups to Orcheo roles to control access to deployments.
+
+## Least-Privilege Recommendations
+- Grant service tokens only to automation workflows that need them.
+- Use environment-based roles (dev, staging, prod) to separate privileges.
+- Enable audit logging for all deployment actions and sensitive node executions.

--- a/examples/conversational_search/data/docs/product_overview.md
+++ b/examples/conversational_search/data/docs/product_overview.md
@@ -1,0 +1,24 @@
+# Orcheo Cloud Overview
+
+Orcheo Cloud is a managed platform for building stateful AI workflows. Teams use it to connect document ingestion, retrieval, and generation nodes into auditable graphs that can run on the edge or in the cloud.
+
+## Core Capabilities
+- **Graph Engine:** Build directed graphs with typed inputs and outputs for deterministic orchestration.
+- **Node Library:** Reusable nodes for document loading, chunking, retrieval, generation, and evaluation.
+- **Observability:** Structured traces for every node execution with metrics export.
+- **Security:** Secrets stay in vault-backed connectors and workloads run in isolated sandboxes.
+
+## Getting Started
+1. Install the Orcheo CLI and authenticate with your workspace.
+2. Define a graph in YAML or with the Python builder.
+3. Run `orcheo dev` to iterate locally, then promote to staging and production.
+
+## Documentation Map
+- Architecture: `docs/architecture.md`
+- Node Reference: `docs/nodes.md`
+- Deployment Guide: `docs/deployments.md`
+
+## Example Questions
+- How do I add a custom node to my graph?
+- What logging format does the graph engine emit?
+- Which secrets providers are supported by default?

--- a/examples/conversational_search/data/docs/troubleshooting.md
+++ b/examples/conversational_search/data/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting Guide
+
+This guide lists frequent issues encountered when running conversational search workflows with Orcheo and how to resolve them quickly.
+
+## Slow Retrieval
+- Ensure embeddings are generated for the latest documents.
+- Check that the vector store is warmed up and not using a cold cache.
+- Reduce `top_k` temporarily to verify the query path is healthy.
+
+## Hallucinated Answers
+- Confirm the generator is instructed to cite sources for every statement.
+- Increase the similarity threshold in the retrieval config to tighten context.
+- Add a hallucination guard node to validate outputs before returning them.
+
+## Missing Documents
+- Verify the loader glob patterns include the new files.
+- Re-run the ingestion pipeline after adding or renaming documents.
+- Inspect metadata extraction to ensure titles and sections are captured.
+
+## Authentication Failures
+- Make sure the correct environment variables are loaded from your `.env` file.
+- Rotate expired keys and re-run the sample demos with fresh credentials.
+- Use the built-in health check script to validate network connectivity.

--- a/examples/conversational_search/data/golden/golden_dataset.json
+++ b/examples/conversational_search/data/golden/golden_dataset.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "g1",
+    "query": "Summarize how Orcheo handles secrets and access control.",
+    "expected_answer": "Orcheo keeps secrets in a vault-backed connector and enforces least-privilege access through roles, scoped API keys, and audit logging.",
+    "expected_citations": ["docs/authentication.md"]
+  },
+  {
+    "id": "g2",
+    "query": "Give me two steps to get started with Orcheo Cloud.",
+    "expected_answer": "Install the Orcheo CLI, authenticate, and define a graph in YAML or Python before running it locally.",
+    "expected_citations": ["docs/product_overview.md"]
+  },
+  {
+    "id": "g3",
+    "query": "How can I reduce hallucinated answers in my assistant?",
+    "expected_answer": "Require grounded citations, raise the similarity threshold on retrieval, and add a hallucination guard node before returning responses.",
+    "expected_citations": ["docs/troubleshooting.md"]
+  }
+]

--- a/examples/conversational_search/data/labels/relevance_labels.json
+++ b/examples/conversational_search/data/labels/relevance_labels.json
@@ -1,0 +1,6 @@
+[
+  {"query_id": "q1", "doc_id": "authentication.md", "relevance": 3},
+  {"query_id": "q1", "doc_id": "product_overview.md", "relevance": 1},
+  {"query_id": "q2", "doc_id": "product_overview.md", "relevance": 3},
+  {"query_id": "q3", "doc_id": "troubleshooting.md", "relevance": 3}
+]

--- a/examples/conversational_search/data/queries.json
+++ b/examples/conversational_search/data/queries.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "q1",
+    "question": "How do I authenticate to Orcheo Cloud from CI?",
+    "intent": "auth",
+    "expected_context": ["client credentials", "service tokens"]
+  },
+  {
+    "id": "q2",
+    "question": "Where are observability traces emitted when a graph runs?",
+    "intent": "observability",
+    "expected_context": ["structured traces", "metrics export"]
+  },
+  {
+    "id": "q3",
+    "question": "What should I do if retrieval is slow?",
+    "intent": "troubleshooting",
+    "expected_context": ["slow retrieval", "top_k", "cache"]
+  }
+]

--- a/examples/conversational_search/demo_1_basic_rag/README.md
+++ b/examples/conversational_search/demo_1_basic_rag/README.md
@@ -1,0 +1,19 @@
+# Demo 1: Basic RAG
+
+Minimal retrieval-augmented generation pipeline using the shared sample corpus. This demo focuses on ingestion, chunking, indexing, and grounded generation with citations.
+
+## Run Locally
+1. Ensure `.env` is populated with your API keys (see `.env.example` in the parent folder).
+2. Execute the runner:
+   ```bash
+   uv run python examples/conversational_search/demo_1_basic_rag/run.py
+   ```
+
+## What to Expect
+- Uses the shared markdown corpus in `../data/docs`.
+- Loads baseline queries from `../data/queries.json`.
+- Prints a summary of the dataset and the config sections wired for ingestion and retrieval.
+
+## Next Steps
+- Swap in your own markdown files under `data/docs`.
+- Increase `top_k` or chunk sizes in `config.yaml` to explore retrieval changes.

--- a/examples/conversational_search/demo_1_basic_rag/config.yaml
+++ b/examples/conversational_search/demo_1_basic_rag/config.yaml
@@ -1,0 +1,27 @@
+dataset:
+  docs_path: ../data/docs
+  queries_path: ../data/queries.json
+
+ingestion:
+  loader:
+    source_type: file
+    file_patterns:
+      - ../data/docs/*.md
+  chunking:
+    strategy: recursive_character
+    chunk_size: 512
+    chunk_overlap: 64
+  metadata:
+    include_filename: true
+
+retrieval:
+  embedding_model: text-embedding-3-small
+  vector_store: in_memory
+  search:
+    top_k: 5
+    similarity_threshold: 0.7
+
+generation:
+  model: gpt-4o-mini
+  temperature: 0.3
+  include_citations: true

--- a/examples/conversational_search/demo_1_basic_rag/data/README.md
+++ b/examples/conversational_search/demo_1_basic_rag/data/README.md
@@ -1,0 +1,3 @@
+# Demo 1 Data
+
+This demo reads the shared sample corpus and queries from `../data`. Add demo-specific overrides here if you want to test alternative chunking or retrieval settings without affecting other demos.

--- a/examples/conversational_search/demo_1_basic_rag/notebook.ipynb
+++ b/examples/conversational_search/demo_1_basic_rag/notebook.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo 1: Basic RAG\n",
+    "\n",
+    "Placeholder notebook for the Basic RAG walkthrough. Use this space to experiment with ingestion and retrieval parameters interactively."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_search/demo_1_basic_rag/run.py
+++ b/examples/conversational_search/demo_1_basic_rag/run.py
@@ -1,0 +1,25 @@
+"""Entry point for the Basic RAG demo."""
+
+from __future__ import annotations
+from pathlib import Path
+from examples.conversational_search.utils import (
+    default_demo_paths,
+    load_demo_assets,
+    summarize_dataset,
+)
+
+
+def main() -> None:
+    """Preview the Basic RAG demo configuration and dataset."""
+    demo_root = Path(__file__).parent
+    paths = default_demo_paths(demo_root)
+    config, documents, queries = load_demo_assets(paths)
+    sections = ", ".join(sorted(config))
+
+    print("Demo 1: Basic RAG")  # noqa: T201 - demo output
+    print(f"Config sections: {sections}")  # noqa: T201 - demo output
+    print(summarize_dataset(documents, queries))  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversational_search/demo_2_hybrid_search/README.md
+++ b/examples/conversational_search/demo_2_hybrid_search/README.md
@@ -1,0 +1,13 @@
+# Demo 2: Hybrid Search
+
+Dense + sparse retrieval with reciprocal-rank fusion, optional web search, and a re-ranker. Uses the shared corpus and sample queries to illustrate how fusion changes context assembly.
+
+## Run Locally
+```bash
+uv run python examples/conversational_search/demo_2_hybrid_search/run.py
+```
+
+## Notes
+- Uses `bm25`, `vector`, and `web_search` branches defined in `config.yaml`.
+- Prints a preview of the configured retrieval stack and the sample dataset.
+- Extend `fusion.weights` to tune how each retriever contributes.

--- a/examples/conversational_search/demo_2_hybrid_search/config.yaml
+++ b/examples/conversational_search/demo_2_hybrid_search/config.yaml
@@ -1,0 +1,30 @@
+dataset:
+  docs_path: ../data/docs
+  queries_path: ../data/queries.json
+
+retrieval:
+  dense:
+    model: text-embedding-3-small
+    top_k: 8
+  bm25:
+    top_k: 8
+  web_search:
+    provider: tavily
+    max_results: 4
+    search_depth: advanced
+  fusion:
+    strategy: reciprocal_rank_fusion
+    weights:
+      vector: 0.5
+      bm25: 0.3
+      web: 0.2
+  reranker:
+    model: cross-encoder/ms-marco-MiniLM-L-6-v2
+    top_k: 5
+  compressor:
+    max_tokens: 1800
+
+generation:
+  model: gpt-4o-mini
+  temperature: 0.25
+  include_citations: true

--- a/examples/conversational_search/demo_2_hybrid_search/data/README.md
+++ b/examples/conversational_search/demo_2_hybrid_search/data/README.md
@@ -1,0 +1,3 @@
+# Demo 2 Data
+
+Hybrid search defaults to the shared corpus in `../data/docs` and queries in `../data/queries.json`. Add domain-specific corpora here if you want to experiment with different fusion settings without touching other demos.

--- a/examples/conversational_search/demo_2_hybrid_search/notebook.ipynb
+++ b/examples/conversational_search/demo_2_hybrid_search/notebook.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo 2: Hybrid Search\n",
+    "\n",
+    "Placeholder notebook for experimenting with dense + sparse retrieval, fusion weights, and re-ranking."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_search/demo_2_hybrid_search/run.py
+++ b/examples/conversational_search/demo_2_hybrid_search/run.py
@@ -1,0 +1,37 @@
+"""Entry point for the Hybrid Search demo."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+from examples.conversational_search.utils import (
+    default_demo_paths,
+    load_demo_assets,
+    summarize_dataset,
+)
+
+
+def _describe_retrieval(config: dict[str, Any]) -> str:
+    retrieval = config.get("retrieval", {})
+    branches = [
+        key for key in retrieval if key not in {"fusion", "reranker", "compressor"}
+    ]
+    extras = [key for key in retrieval if key in {"fusion", "reranker"}]
+    return (
+        f"branches={', '.join(sorted(branches)) or 'none'}, "
+        f"extras={', '.join(sorted(extras)) or 'none'}"
+    )
+
+
+def main() -> None:
+    """Preview the Hybrid Search demo configuration and dataset."""
+    demo_root = Path(__file__).parent
+    paths = default_demo_paths(demo_root)
+    config, documents, queries = load_demo_assets(paths)
+
+    print("Demo 2: Hybrid Search")  # noqa: T201 - demo output
+    print(_describe_retrieval(config))  # noqa: T201 - demo output
+    print(summarize_dataset(documents, queries))  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversational_search/demo_3_conversational/README.md
+++ b/examples/conversational_search/demo_3_conversational/README.md
@@ -1,0 +1,13 @@
+# Demo 3: Conversational Search
+
+Stateful multi-turn chat with query classification, rewriting, and topic-shift detection. This scaffold wires the sample corpus to a conversational pipeline without external dependencies.
+
+## Run Locally
+```bash
+uv run python examples/conversational_search/demo_3_conversational/run.py
+```
+
+## Notes
+- Demonstrates classifier, coreference resolver, and query rewriter configs.
+- Uses in-memory conversation state with a 20-turn limit for the preview.
+- Prints the loaded dataset summary and the conversation controls from `config.yaml`.

--- a/examples/conversational_search/demo_3_conversational/config.yaml
+++ b/examples/conversational_search/demo_3_conversational/config.yaml
@@ -1,0 +1,31 @@
+dataset:
+  docs_path: ../data/docs
+  queries_path: ../data/queries.json
+
+conversation:
+  max_turns: 20
+  memory_store: in_memory
+
+query_processing:
+  classifier:
+    model: gpt-4o-mini
+    categories: [search, clarify, finalize]
+  coreference:
+    model: coref-distilroberta-base
+  rewrite:
+    strategy: conversational_expansion
+    include_last_n_turns: 3
+  topic_shift:
+    threshold: 0.6
+    action_on_shift: summarize_previous
+
+retrieval:
+  vector:
+    model: text-embedding-3-small
+    top_k: 6
+  fallback_similarity_threshold: 0.72
+
+generation:
+  model: gpt-4o-mini
+  temperature: 0.35
+  include_citations: true

--- a/examples/conversational_search/demo_3_conversational/data/README.md
+++ b/examples/conversational_search/demo_3_conversational/data/README.md
@@ -1,0 +1,3 @@
+# Demo 3 Data
+
+Uses the shared corpus in `../data/docs` and shared queries in `../data/queries.json`. Add conversation-specific samples here (e.g., follow-ups) to test classifier and rewrite behavior without changing the shared set.

--- a/examples/conversational_search/demo_3_conversational/notebook.ipynb
+++ b/examples/conversational_search/demo_3_conversational/notebook.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo 3: Conversational Search\n",
+    "\n",
+    "Placeholder notebook for exploring multi-turn chat, query classification, and rewriting."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_search/demo_3_conversational/run.py
+++ b/examples/conversational_search/demo_3_conversational/run.py
@@ -1,0 +1,37 @@
+"""Entry point for the Conversational Search demo."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+from examples.conversational_search.utils import (
+    default_demo_paths,
+    load_demo_assets,
+    summarize_dataset,
+)
+
+
+def _conversation_settings(config: dict[str, Any]) -> str:
+    conversation = config.get("conversation", {})
+    max_turns = conversation.get("max_turns", "n/a")
+    memory_store = conversation.get("memory_store", "unknown")
+    query_processing = config.get("query_processing", {})
+    processors = ", ".join(sorted(query_processing)) or "none"
+    return (
+        f"conversation: max_turns={max_turns}, memory_store={memory_store}; "
+        f"processors={processors}"
+    )
+
+
+def main() -> None:
+    """Preview the Conversational Search demo configuration and dataset."""
+    demo_root = Path(__file__).parent
+    paths = default_demo_paths(demo_root)
+    config, documents, queries = load_demo_assets(paths)
+
+    print("Demo 3: Conversational Search")  # noqa: T201 - demo output
+    print(_conversation_settings(config))  # noqa: T201 - demo output
+    print(summarize_dataset(documents, queries))  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversational_search/demo_4_production/README.md
+++ b/examples/conversational_search/demo_4_production/README.md
@@ -1,0 +1,13 @@
+# Demo 4: Production-Ready Pipeline
+
+Production-focused scaffold with caching, guardrails, streaming, and incremental indexing hooks. The config is tuned for local experimentation against the shared sample corpus.
+
+## Run Locally
+```bash
+uv run python examples/conversational_search/demo_4_production/run.py
+```
+
+## Notes
+- Shows how to toggle caching, hallucination guards, and policy checks.
+- Includes session controls and streaming defaults for fast iteration.
+- Prints dataset summary plus the key production toggles defined in `config.yaml`.

--- a/examples/conversational_search/demo_4_production/config.yaml
+++ b/examples/conversational_search/demo_4_production/config.yaml
@@ -1,0 +1,39 @@
+dataset:
+  docs_path: ../data/docs
+  queries_path: ../data/queries.json
+
+production:
+  session:
+    max_concurrent_sessions: 100
+    timeout_minutes: 30
+  caching:
+    enabled: true
+    similarity_threshold: 0.92
+    ttl_seconds: 3600
+  streaming:
+    enabled: true
+    buffer_size: 10
+    flush_interval_ms: 100
+  guardrails:
+    hallucination:
+      model: gpt-4o
+      threshold: 0.8
+      action_on_failure: fallback
+    policy_compliance:
+      filters: [pii, toxicity, profanity]
+      pii_redaction: true
+  incremental_indexer:
+    sync_interval_minutes: 60
+    change_detection: checksum
+
+retrieval:
+  vector:
+    model: text-embedding-3-small
+    top_k: 6
+  router:
+    strategies: [vector]
+
+generation:
+  model: gpt-4o-mini
+  temperature: 0.2
+  include_citations: true

--- a/examples/conversational_search/demo_4_production/data/README.md
+++ b/examples/conversational_search/demo_4_production/data/README.md
@@ -1,0 +1,3 @@
+# Demo 4 Data
+
+Uses the shared corpus and queries from `../data`. Add larger datasets or streaming-specific fixtures here when testing throughput or caching behavior.

--- a/examples/conversational_search/demo_4_production/notebook.ipynb
+++ b/examples/conversational_search/demo_4_production/notebook.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo 4: Production Pipeline\n",
+    "\n",
+    "Placeholder notebook for experimenting with caching, guardrails, and streaming settings."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_search/demo_4_production/run.py
+++ b/examples/conversational_search/demo_4_production/run.py
@@ -1,0 +1,39 @@
+"""Entry point for the Production demo."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+from examples.conversational_search.utils import (
+    default_demo_paths,
+    load_demo_assets,
+    summarize_dataset,
+)
+
+
+def _production_toggles(config: dict[str, Any]) -> str:
+    production = config.get("production", {})
+    caching = production.get("caching", {})
+    streaming = production.get("streaming", {})
+    guardrails = production.get("guardrails", {})
+    toggles = {
+        "caching": caching.get("enabled", False),
+        "streaming": streaming.get("enabled", False),
+        "hallucination_guard": "hallucination" in guardrails,
+        "policy_compliance": "policy_compliance" in guardrails,
+    }
+    return ", ".join(f"{key}={value}" for key, value in toggles.items())
+
+
+def main() -> None:
+    """Preview the Production demo configuration and dataset."""
+    demo_root = Path(__file__).parent
+    paths = default_demo_paths(demo_root)
+    config, documents, queries = load_demo_assets(paths)
+
+    print("Demo 4: Production Pipeline")  # noqa: T201 - demo output
+    print(_production_toggles(config))  # noqa: T201 - demo output
+    print(summarize_dataset(documents, queries))  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversational_search/demo_5_evaluation/README.md
+++ b/examples/conversational_search/demo_5_evaluation/README.md
@@ -1,0 +1,13 @@
+# Demo 5: Evaluation & Research
+
+Evaluation-focused scaffold with golden datasets, relevance labels, and variant definitions for retrieval A/B tests. Use this as the starting point for metrics, analytics, and feedback loops.
+
+## Run Locally
+```bash
+uv run python examples/conversational_search/demo_5_evaluation/run.py
+```
+
+## Notes
+- Golden queries live in `../data/golden/golden_dataset.json` with paired relevance labels in `../data/labels/relevance_labels.json`.
+- Config includes variant definitions for comparing retrieval strategies.
+- Runner prints dataset and variant summaries to validate the setup before wiring full evaluators.

--- a/examples/conversational_search/demo_5_evaluation/config.yaml
+++ b/examples/conversational_search/demo_5_evaluation/config.yaml
@@ -1,0 +1,23 @@
+dataset:
+  golden_path: ../data/golden/golden_dataset.json
+  labels_path: ../data/labels/relevance_labels.json
+  docs_path: ../data/docs
+
+variants:
+  - name: vector_only
+    retriever: vector
+  - name: hybrid_fusion
+    retriever: hybrid
+
+evaluation:
+  retrieval_metrics: [recall@5, recall@10, mrr, ndcg@10]
+  answer_quality_metrics: [faithfulness, relevance, completeness]
+  llm_judge_model: gpt-4o
+
+feedback:
+  explicit: [thumbs, rating]
+  implicit: [dwell_time, reformulation]
+  export:
+    destination: bigquery
+    batch_size: 100
+    flush_interval_seconds: 300

--- a/examples/conversational_search/demo_5_evaluation/data/README.md
+++ b/examples/conversational_search/demo_5_evaluation/data/README.md
@@ -1,0 +1,3 @@
+# Demo 5 Data
+
+Golden dataset and relevance labels live in `../data/golden` and `../data/labels`. Use this folder to stage larger evaluation corpora or experiment-specific feedback exports while keeping the shared samples intact.

--- a/examples/conversational_search/demo_5_evaluation/notebook.ipynb
+++ b/examples/conversational_search/demo_5_evaluation/notebook.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo 5: Evaluation & Research\n",
+    "\n",
+    "Placeholder notebook for running metrics, A/B tests, and feedback analyses."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_search/demo_5_evaluation/run.py
+++ b/examples/conversational_search/demo_5_evaluation/run.py
@@ -1,0 +1,36 @@
+"""Entry point for the Evaluation & Research demo."""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+from examples.conversational_search.utils import (
+    default_demo_paths,
+    load_demo_assets,
+    load_golden_examples,
+    load_relevance_labels,
+    summarize_dataset,
+)
+
+
+def _variant_summary(config: dict[str, Any]) -> str:
+    variants = config.get("variants", [])
+    names = [variant.get("name", "unnamed") for variant in variants]
+    return f"variants={', '.join(names) or 'none'}"
+
+
+def main() -> None:
+    """Preview the Evaluation demo configuration and datasets."""
+    demo_root = Path(__file__).parent
+    paths = default_demo_paths(demo_root)
+    config, documents, queries = load_demo_assets(paths)
+    golden = load_golden_examples(paths.golden) if paths.golden else []
+    labels = load_relevance_labels(paths.labels) if paths.labels else []
+
+    print("Demo 5: Evaluation & Research")  # noqa: T201 - demo output
+    print(_variant_summary(config))  # noqa: T201 - demo output
+    print(f"Golden examples={len(golden)}, relevance labels={len(labels)}")  # noqa: T201 - demo output
+    print(summarize_dataset(documents, queries))  # noqa: T201 - demo output
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversational_search/utils.py
+++ b/examples/conversational_search/utils.py
@@ -1,0 +1,164 @@
+"""Shared helpers for conversational search demos."""
+
+from __future__ import annotations
+import json
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+import yaml
+from orcheo.nodes.conversational_search.models import Document
+
+
+@dataclass(frozen=True)
+class QueryExample:
+    """Structured representation of a sample query."""
+
+    id: str
+    question: str
+    intent: str | None = None
+    expected_context: Sequence[str] | None = None
+
+
+@dataclass(frozen=True)
+class GoldenExample:
+    """Golden query with an expected answer and citations."""
+
+    id: str
+    query: str
+    expected_answer: str
+    expected_citations: Sequence[str]
+
+
+@dataclass(frozen=True)
+class RelevanceLabel:
+    """Sparse relevance label for retrieval evaluation."""
+
+    query_id: str
+    doc_id: str
+    relevance: int
+
+
+@dataclass(frozen=True)
+class DemoPaths:
+    """Resolved paths for a demo configuration and its assets."""
+
+    config: Path
+    docs_dir: Path
+    queries: Path | None = None
+    golden: Path | None = None
+    labels: Path | None = None
+
+
+def load_yaml_config(config_path: Path) -> dict[str, Any]:
+    """Load a YAML configuration file into a dictionary."""
+    with config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def load_documents(docs_dir: Path) -> list[Document]:
+    """Load markdown documents from a directory into :class:`Document` objects."""
+    documents: list[Document] = []
+    for path in sorted(docs_dir.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        documents.append(
+            Document(
+                id=path.stem,
+                content=text,
+                metadata={"filename": path.name, "path": str(path)},
+                source=str(path),
+            )
+        )
+    return documents
+
+
+def load_queries(queries_path: Path) -> list[QueryExample]:
+    """Load sample queries from a JSON list."""
+    with queries_path.open("r", encoding="utf-8") as handle:
+        raw_queries: Iterable[dict[str, Any]] = json.load(handle)
+    queries: list[QueryExample] = []
+    for item in raw_queries:
+        queries.append(
+            QueryExample(
+                id=item["id"],
+                question=item["question"],
+                intent=item.get("intent"),
+                expected_context=item.get("expected_context"),
+            )
+        )
+    return queries
+
+
+def load_golden_examples(golden_path: Path) -> list[GoldenExample]:
+    """Load golden queries used for evaluation demos."""
+    with golden_path.open("r", encoding="utf-8") as handle:
+        raw_examples: Iterable[dict[str, Any]] = json.load(handle)
+    examples: list[GoldenExample] = []
+    for item in raw_examples:
+        examples.append(
+            GoldenExample(
+                id=item["id"],
+                query=item["query"],
+                expected_answer=item["expected_answer"],
+                expected_citations=item.get("expected_citations", []),
+            )
+        )
+    return examples
+
+
+def load_relevance_labels(labels_path: Path) -> list[RelevanceLabel]:
+    """Load sparse relevance labels for retrieval evaluation."""
+    with labels_path.open("r", encoding="utf-8") as handle:
+        raw_labels: Iterable[dict[str, Any]] = json.load(handle)
+    labels: list[RelevanceLabel] = []
+    for item in raw_labels:
+        labels.append(
+            RelevanceLabel(
+                query_id=item["query_id"],
+                doc_id=item["doc_id"],
+                relevance=int(item["relevance"]),
+            )
+        )
+    return labels
+
+
+def load_demo_assets(
+    paths: DemoPaths,
+) -> tuple[dict[str, Any], list[Document], list[QueryExample]]:
+    """Load config and sample data for a demo."""
+    config = load_yaml_config(paths.config)
+    documents = load_documents(paths.docs_dir)
+    queries: list[QueryExample] = []
+    if paths.queries and paths.queries.exists():
+        queries = load_queries(paths.queries)
+    return config, documents, queries
+
+
+def summarize_dataset(
+    documents: Sequence[Document], queries: Sequence[QueryExample]
+) -> str:
+    """Return a human-readable summary of the loaded dataset."""
+    doc_names = ", ".join(
+        document.metadata.get("filename", document.id) for document in documents
+    )
+    query_ids = ", ".join(query.id for query in queries)
+    return (
+        f"Loaded {len(documents)} documents [{doc_names}] and "
+        f"{len(queries)} queries [{query_ids}]"
+    )
+
+
+def default_demo_paths(demo_root: Path) -> DemoPaths:
+    """Construct default paths for a demo based on its root directory."""
+    config = demo_root / "config.yaml"
+    docs_dir = demo_root.parent / "data" / "docs"
+    queries = demo_root.parent / "data" / "queries.json"
+    golden = demo_root.parent / "data" / "golden" / "golden_dataset.json"
+    labels = demo_root.parent / "data" / "labels" / "relevance_labels.json"
+    return DemoPaths(
+        config=config,
+        docs_dir=docs_dir,
+        queries=queries,
+        golden=golden,
+        labels=labels,
+    )


### PR DESCRIPTION
* Scaffolded five conversational search demo folders with config stubs, runner scripts, README placeholders, and notebooks.
* Added shared sample corpus, queries, golden set, and relevance labels under `examples/conversational_search/data`.
* Introduced reusable demo utilities for loading configs/documents/queries and wired runners to preview key settings.
* Updated demo plan to mark Milestone 1 tasks complete.