### PR TITLE
Finish Milestone 1 tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ After installation, restart your shell or source your shell configuration file.
 | `orcheo agent-tool show <tool>` | Display detailed tool schema and parameter information. |
 | `orcheo workflow list [--include-archived]` | List workflows with owner, last run, and status. |
 | `orcheo workflow show <workflow>` | Print workflow summary, publish status/details, Mermaid graph, and latest runs. |
-| `orcheo workflow run <workflow> [--inputs <json>]` | Trigger a workflow execution and stream status to the console. |
+| `orcheo workflow run <workflow> [--inputs <json> \| --inputs-file <path>] [--config <json> \| --config-file <path>]` | Trigger a workflow execution and stream status to the console. |
 | `orcheo workflow upload <file> [--name <name>]` | Upload a workflow from Python or JSON file. |
 | `orcheo workflow download <workflow> [-o <file>]` | Download workflow definition as Python or JSON. |
 | `orcheo workflow delete <workflow> [--force]` | Delete a workflow with confirmation safeguards. |
@@ -142,6 +142,8 @@ After installation, restart your shell or source your shell configuration file.
 | `orcheo code scaffold <workflow>` | Generate Python SDK code snippets to invoke an existing workflow. |
 
 Published workflows remain accessible until you run `orcheo workflow unpublish <workflow>` or toggle the `--require-login` flag to gate public chats behind OAuth.
+
+Pass workflow inputs inline with `--inputs` or from disk via `--inputs-file`. Use `--config` or `--config-file` to provide LangChain runnable configuration for the execution (each pair is mutually exclusive).
 
 #### Offline Mode
 

--- a/apps/backend/src/orcheo_backend/app/_core_exports.py
+++ b/apps/backend/src/orcheo_backend/app/_core_exports.py
@@ -108,6 +108,8 @@ from orcheo_backend.app.workflow_execution import (
     _log_step_debug,
     _should_log_sensitive_debug,
     execute_workflow,
+    execute_workflow_evaluation,
+    execute_workflow_training,
 )
 from orcheo_backend.app.workflow_execution import logger as workflow_logger
 
@@ -123,6 +125,8 @@ __all__ = [
     "create_app",
     "create_checkpointer",
     "execute_workflow",
+    "execute_workflow_evaluation",
+    "execute_workflow_training",
     "get_chatkit_server",
     "get_credential_service",
     "get_repository",

--- a/apps/backend/src/orcheo_backend/app/_router_exports.py
+++ b/apps/backend/src/orcheo_backend/app/_router_exports.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 from orcheo_backend.app.routers import (
+    agentensor as _agentensor_routes,
+)
+from orcheo_backend.app.routers import (
     chatkit as _chatkit_routes,
 )
 from orcheo_backend.app.routers import (
@@ -100,6 +103,8 @@ configure_cron_trigger = _triggers_routes.configure_cron_trigger
 get_cron_trigger_config = _triggers_routes.get_cron_trigger_config
 
 execute_node_endpoint = _nodes_routes.execute_node_endpoint
+list_agentensor_checkpoints = _agentensor_routes.list_agentensor_checkpoints
+get_agentensor_checkpoint = _agentensor_routes.get_agentensor_checkpoint
 
 __all__ = [
     "acknowledge_governance_alert",
@@ -123,6 +128,7 @@ __all__ = [
     "dispatch_manual_runs",
     "execute_node_endpoint",
     "get_cron_trigger_config",
+    "get_agentensor_checkpoint",
     "get_credential_template",
     "get_execution_history",
     "get_webhook_trigger_config",
@@ -140,6 +146,7 @@ __all__ = [
     "list_workflow_runs",
     "list_workflow_versions",
     "list_workflows",
+    "list_agentensor_checkpoints",
     "mark_run_cancelled",
     "mark_run_failed",
     "mark_run_started",

--- a/apps/backend/src/orcheo_backend/app/agentensor/checkpoint_store.py
+++ b/apps/backend/src/orcheo_backend/app/agentensor/checkpoint_store.py
@@ -1,0 +1,310 @@
+"""Persistence backends for Agentensor training checkpoints."""
+
+from __future__ import annotations
+import asyncio
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+import aiosqlite
+from orcheo.agentensor.checkpoints import (
+    AgentensorCheckpoint,
+    AgentensorCheckpointNotFoundError,
+    AgentensorCheckpointStore,
+)
+from orcheo_backend.app.history.sqlite_utils import (
+    connect_sqlite,
+    ensure_sqlite_schema,
+)
+
+
+POSTGRES_CHECKPOINT_MIGRATION = """
+CREATE TABLE IF NOT EXISTS agentensor_checkpoints (
+    id TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    config_version INTEGER NOT NULL,
+    runnable_config JSONB NOT NULL,
+    metrics JSONB NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    artifact_url TEXT NULL,
+    is_best BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_workflow
+    ON agentensor_checkpoints (workflow_id, config_version);
+CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_best
+    ON agentensor_checkpoints (workflow_id, is_best);
+"""
+
+
+class InMemoryAgentensorCheckpointStore(AgentensorCheckpointStore):
+    """Async-safe in-memory checkpoint store."""
+
+    def __init__(self) -> None:
+        """Initialize the in-memory store."""
+        self._lock = asyncio.Lock()
+        self._checkpoints: dict[str, AgentensorCheckpoint] = {}
+        self._by_workflow: dict[str, list[str]] = {}
+
+    async def record_checkpoint(
+        self,
+        *,
+        workflow_id: str,
+        runnable_config: Mapping[str, object],
+        metrics: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+        artifact_url: str | None = None,
+        is_best: bool = False,
+        config_version: int | None = None,
+    ) -> AgentensorCheckpoint:
+        """Persist a checkpoint and return the stored record."""
+        async with self._lock:
+            version = config_version or self._next_version(workflow_id)
+            checkpoint = AgentensorCheckpoint(
+                workflow_id=workflow_id,
+                config_version=version,
+                runnable_config=dict(runnable_config),
+                metrics=dict(metrics),
+                metadata=dict(metadata or {}),
+                artifact_url=artifact_url,
+                is_best=is_best,
+            )
+            self._checkpoints[checkpoint.id] = checkpoint
+            self._by_workflow.setdefault(workflow_id, []).append(checkpoint.id)
+            if is_best:
+                self._clear_other_best(workflow_id, checkpoint.id)
+            return checkpoint
+
+    async def list_checkpoints(
+        self,
+        workflow_id: str,
+        *,
+        limit: int | None = None,
+    ) -> list[AgentensorCheckpoint]:
+        """Return checkpoints for the workflow ordered newest-first."""
+        async with self._lock:
+            identifiers = list(reversed(self._by_workflow.get(workflow_id, [])))
+            if limit is not None:
+                identifiers = identifiers[:limit]
+            return [self._checkpoints[identifier] for identifier in identifiers]
+
+    async def get_checkpoint(self, checkpoint_id: str) -> AgentensorCheckpoint:
+        """Return the checkpoint by identifier or raise when missing."""
+        async with self._lock:
+            checkpoint = self._checkpoints.get(checkpoint_id)
+            if checkpoint is None:
+                msg = f"Checkpoint {checkpoint_id!r} not found."
+                raise AgentensorCheckpointNotFoundError(msg)
+            return checkpoint
+
+    async def latest_checkpoint(
+        self,
+        workflow_id: str,
+    ) -> AgentensorCheckpoint | None:
+        """Return the most recent checkpoint for the workflow if present."""
+        async with self._lock:
+            identifiers = self._by_workflow.get(workflow_id, [])
+            if not identifiers:
+                return None
+            return self._checkpoints[identifiers[-1]]
+
+    def _next_version(self, workflow_id: str) -> int:
+        identifiers = self._by_workflow.get(workflow_id, [])
+        if not identifiers:
+            return 1
+        latest = self._checkpoints[identifiers[-1]]
+        return latest.config_version + 1
+
+    def _clear_other_best(self, workflow_id: str, checkpoint_id: str) -> None:
+        for identifier in self._by_workflow.get(workflow_id, []):
+            if identifier == checkpoint_id:
+                continue
+            checkpoint = self._checkpoints.get(identifier)
+            if checkpoint is None:
+                continue
+            checkpoint.is_best = False
+
+
+class SqliteAgentensorCheckpointStore(AgentensorCheckpointStore):
+    """SQLite-backed checkpoint store shared across backend workers."""
+
+    def __init__(self, database_path: str | Path) -> None:
+        """Initialize the SQLite store with the given database path."""
+        self._database_path = Path(database_path).expanduser()
+        self._lock = asyncio.Lock()
+        self._init_lock = asyncio.Lock()
+        self._initialized = False
+
+    async def record_checkpoint(
+        self,
+        *,
+        workflow_id: str,
+        runnable_config: Mapping[str, object],
+        metrics: Mapping[str, object],
+        metadata: Mapping[str, object] | None = None,
+        artifact_url: str | None = None,
+        is_best: bool = False,
+        config_version: int | None = None,
+    ) -> AgentensorCheckpoint:
+        """Persist a checkpoint row and return the stored domain object."""
+        await self._ensure_initialized()
+        async with self._lock:
+            async with connect_sqlite(self._database_path) as conn:
+                await conn.execute("BEGIN")
+                try:
+                    version = await self._resolve_version(
+                        conn, workflow_id, config_version
+                    )
+                    checkpoint = AgentensorCheckpoint(
+                        workflow_id=workflow_id,
+                        config_version=version,
+                        runnable_config=dict(runnable_config),
+                        metrics=dict(metrics),
+                        metadata=dict(metadata or {}),
+                        artifact_url=artifact_url,
+                        is_best=is_best,
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO agentensor_checkpoints (
+                            id,
+                            workflow_id,
+                            config_version,
+                            runnable_config,
+                            metrics,
+                            metadata,
+                            artifact_url,
+                            is_best,
+                            created_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            checkpoint.id,
+                            checkpoint.workflow_id,
+                            checkpoint.config_version,
+                            json.dumps(checkpoint.runnable_config),
+                            json.dumps(checkpoint.metrics),
+                            json.dumps(checkpoint.metadata),
+                            checkpoint.artifact_url,
+                            1 if checkpoint.is_best else 0,
+                            checkpoint.created_at.isoformat(),
+                        ),
+                    )
+                    if is_best:
+                        await conn.execute(
+                            """
+                            UPDATE agentensor_checkpoints
+                               SET is_best = 0
+                             WHERE workflow_id = ?
+                               AND id != ?
+                            """,
+                            (workflow_id, checkpoint.id),
+                        )
+                    await conn.commit()
+                except Exception:
+                    await conn.rollback()
+                    raise
+                return checkpoint
+
+    async def list_checkpoints(
+        self,
+        workflow_id: str,
+        *,
+        limit: int | None = None,
+    ) -> list[AgentensorCheckpoint]:
+        """Return persisted checkpoints ordered by config_version."""
+        await self._ensure_initialized()
+        query = (
+            "SELECT id, workflow_id, config_version, runnable_config, metrics, "
+            "metadata, artifact_url, is_best, created_at "
+            "FROM agentensor_checkpoints WHERE workflow_id = ? "
+            "ORDER BY config_version DESC"
+        )
+        params: list[object] = [workflow_id]
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        async with connect_sqlite(self._database_path) as conn:
+            cursor = await conn.execute(query, tuple(params))
+            rows = await cursor.fetchall()
+        return [self._row_to_checkpoint(row) for row in rows]
+
+    async def get_checkpoint(self, checkpoint_id: str) -> AgentensorCheckpoint:
+        """Return a checkpoint by identifier or raise when missing."""
+        await self._ensure_initialized()
+        async with connect_sqlite(self._database_path) as conn:
+            cursor = await conn.execute(
+                """
+                SELECT id, workflow_id, config_version, runnable_config, metrics,
+                       metadata, artifact_url, is_best, created_at
+                  FROM agentensor_checkpoints
+                 WHERE id = ?
+                """,
+                (checkpoint_id,),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            msg = f"Checkpoint {checkpoint_id!r} not found."
+            raise AgentensorCheckpointNotFoundError(msg)
+        return self._row_to_checkpoint(row)
+
+    async def latest_checkpoint(
+        self,
+        workflow_id: str,
+    ) -> AgentensorCheckpoint | None:
+        """Return the newest checkpoint if one exists for the workflow."""
+        checkpoints = await self.list_checkpoints(workflow_id, limit=1)
+        return checkpoints[0] if checkpoints else None
+
+    async def _resolve_version(
+        self,
+        conn: aiosqlite.Connection,
+        workflow_id: str,
+        provided_version: int | None,
+    ) -> int:
+        """Resolve the next config version for the workflow."""
+        if provided_version is not None:
+            return provided_version
+        cursor = await conn.execute(
+            """
+            SELECT COALESCE(MAX(config_version), 0) AS max_version
+              FROM agentensor_checkpoints
+             WHERE workflow_id = ?
+            """,
+            (workflow_id,),
+        )
+        row = await cursor.fetchone()
+        max_version = row["max_version"] if row else 0
+        return int(max_version) + 1
+
+    async def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            await ensure_sqlite_schema(self._database_path)
+            self._initialized = True
+
+    @staticmethod
+    def _row_to_checkpoint(row: aiosqlite.Row) -> AgentensorCheckpoint:
+        return AgentensorCheckpoint(
+            id=row["id"],
+            workflow_id=row["workflow_id"],
+            config_version=int(row["config_version"]),
+            runnable_config=json.loads(row["runnable_config"]),
+            metrics=json.loads(row["metrics"]),
+            metadata=json.loads(row["metadata"]),
+            artifact_url=row["artifact_url"],
+            is_best=bool(row["is_best"]),
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+
+__all__ = [
+    "AgentensorCheckpointNotFoundError",
+    "InMemoryAgentensorCheckpointStore",
+    "POSTGRES_CHECKPOINT_MIGRATION",
+    "SqliteAgentensorCheckpointStore",
+]

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -34,6 +34,7 @@ from orcheo_backend.app.history import RunHistoryStore
 from orcheo_backend.app.logging_config import configure_logging
 from orcheo_backend.app.repository import WorkflowRepository
 from orcheo_backend.app.routers import (
+    agentensor,
     auth,
     credential_alerts,
     credential_health,
@@ -81,6 +82,7 @@ def _build_api_router() -> APIRouter:
     protected_router.include_router(runs.router)
     protected_router.include_router(triggers.router)
     protected_router.include_router(nodes.router)
+    protected_router.include_router(agentensor.router)
 
     router.include_router(chatkit_router.router)
     router.include_router(auth.router)

--- a/apps/backend/src/orcheo_backend/app/history/models.py
+++ b/apps/backend/src/orcheo_backend/app/history/models.py
@@ -38,6 +38,11 @@ class RunHistoryRecord(BaseModel):
     workflow_id: str
     execution_id: str
     inputs: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    callbacks: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    run_name: str | None = None
     status: str = "running"
     started_at: datetime = Field(default_factory=_utcnow)
     completed_at: datetime | None = None
@@ -97,6 +102,11 @@ class RunHistoryStore(Protocol):
         workflow_id: str,
         execution_id: str,
         inputs: Mapping[str, Any] | None = None,
+        runnable_config: Mapping[str, Any] | None = None,
+        tags: list[str] | None = None,
+        callbacks: list[Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        run_name: str | None = None,
         trace_id: str | None = None,
         trace_started_at: datetime | None = None,
     ) -> RunHistoryRecord:

--- a/apps/backend/src/orcheo_backend/app/history/sqlite_utils.py
+++ b/apps/backend/src/orcheo_backend/app/history/sqlite_utils.py
@@ -16,6 +16,11 @@ CREATE TABLE IF NOT EXISTS execution_history (
     execution_id TEXT PRIMARY KEY,
     workflow_id TEXT NOT NULL,
     inputs TEXT NOT NULL,
+    runnable_config TEXT NOT NULL DEFAULT '{}',
+    tags TEXT NOT NULL DEFAULT '[]',
+    callbacks TEXT NOT NULL DEFAULT '[]',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    run_name TEXT,
     status TEXT NOT NULL,
     started_at TEXT NOT NULL,
     completed_at TEXT,
@@ -44,6 +49,11 @@ INSERT INTO execution_history (
     execution_id,
     workflow_id,
     inputs,
+    runnable_config,
+    tags,
+    callbacks,
+    metadata,
+    run_name,
     status,
     started_at,
     completed_at,
@@ -53,7 +63,7 @@ INSERT INTO execution_history (
     trace_completed_at,
     trace_last_span_at
 )
-VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)
 """
 
 SELECT_CURRENT_STEP_INDEX_SQL = """
@@ -73,7 +83,8 @@ VALUES (?, ?, ?, ?)
 """
 
 LIST_HISTORIES_SQL = (
-    "SELECT execution_id, workflow_id, inputs, status, started_at, completed_at, "
+    "SELECT execution_id, workflow_id, inputs, runnable_config, tags, callbacks, "
+    "metadata, run_name, status, started_at, completed_at, "
     "error, trace_id, trace_started_at, trace_completed_at, trace_last_span_at "
     "FROM execution_history WHERE workflow_id = ? ORDER BY started_at DESC"
 )
@@ -106,6 +117,17 @@ _TRACE_COLUMN_ALTERS: dict[str, str] = {
         "ALTER TABLE execution_history ADD COLUMN trace_last_span_at TEXT"
     ),
 }
+_OPTIONAL_COLUMN_ALTERS: dict[str, str] = {
+    "runnable_config": (
+        "ALTER TABLE execution_history ADD COLUMN runnable_config TEXT DEFAULT '{}'"
+    ),
+    "tags": "ALTER TABLE execution_history ADD COLUMN tags TEXT DEFAULT '[]'",
+    "callbacks": (
+        "ALTER TABLE execution_history ADD COLUMN callbacks TEXT DEFAULT '[]'"
+    ),
+    "metadata": ("ALTER TABLE execution_history ADD COLUMN metadata TEXT DEFAULT '{}'"),
+    "run_name": "ALTER TABLE execution_history ADD COLUMN run_name TEXT",
+}
 
 
 @asynccontextmanager
@@ -136,7 +158,8 @@ async def fetch_record_row(
     """Return the raw execution history row if present."""
     cursor = await conn.execute(
         """
-        SELECT execution_id, workflow_id, inputs, status, started_at,
+        SELECT execution_id, workflow_id, inputs, runnable_config, tags, callbacks,
+               metadata, run_name, status, started_at,
                completed_at, error, trace_id, trace_started_at,
                trace_completed_at, trace_last_span_at
           FROM execution_history
@@ -191,6 +214,11 @@ def row_to_record(
         workflow_id=row["workflow_id"],
         execution_id=row["execution_id"],
         inputs=json.loads(row["inputs"]),
+        runnable_config=json.loads(row["runnable_config"]),
+        tags=json.loads(row["tags"]),
+        callbacks=json.loads(row["callbacks"]),
+        metadata=json.loads(row["metadata"]),
+        run_name=row["run_name"],
         status=row["status"],
         started_at=datetime.fromisoformat(row["started_at"]),
         completed_at=completed_at,
@@ -208,7 +236,8 @@ async def _ensure_trace_columns(conn: aiosqlite.Connection) -> None:
     cursor = await conn.execute("PRAGMA table_info(execution_history)")
     rows = await cursor.fetchall()
     existing = {row["name"] for row in rows}
-    for column, statement in _TRACE_COLUMN_ALTERS.items():
+    alters = {**_TRACE_COLUMN_ALTERS, **_OPTIONAL_COLUMN_ALTERS}
+    for column, statement in alters.items():
         if column not in existing:
             await conn.execute(statement)
 

--- a/apps/backend/src/orcheo_backend/app/history/sqlite_utils.py
+++ b/apps/backend/src/orcheo_backend/app/history/sqlite_utils.py
@@ -42,6 +42,21 @@ CREATE TABLE IF NOT EXISTS execution_history_steps (
 );
 CREATE INDEX IF NOT EXISTS idx_history_steps_execution
     ON execution_history_steps(execution_id, step_index);
+CREATE TABLE IF NOT EXISTS agentensor_checkpoints (
+    id TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    config_version INTEGER NOT NULL,
+    runnable_config TEXT NOT NULL,
+    metrics TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    artifact_url TEXT,
+    is_best INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_workflow
+    ON agentensor_checkpoints(workflow_id, config_version);
+CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_best
+    ON agentensor_checkpoints(workflow_id, is_best);
 """
 
 INSERT_EXECUTION_SQL = """

--- a/apps/backend/src/orcheo_backend/app/history_utils.py
+++ b/apps/backend/src/orcheo_backend/app/history_utils.py
@@ -36,6 +36,11 @@ def history_to_response(
         completed_at=record.completed_at,
         error=record.error,
         inputs=record.inputs,
+        runnable_config=record.runnable_config,
+        tags=record.tags,
+        callbacks=record.callbacks,
+        metadata=record.metadata,
+        run_name=record.run_name,
         steps=steps,
     )
 

--- a/apps/backend/src/orcheo_backend/app/providers.py
+++ b/apps/backend/src/orcheo_backend/app/providers.py
@@ -13,6 +13,10 @@ from orcheo.vault import (
     InMemoryCredentialVault,
 )
 from orcheo.vault.oauth import OAuthCredentialService
+from orcheo_backend.app.agentensor.checkpoint_store import (
+    InMemoryAgentensorCheckpointStore,
+    SqliteAgentensorCheckpointStore,
+)
 from orcheo_backend.app.history import (
     InMemoryRunHistoryStore,
     RunHistoryStore,
@@ -137,6 +141,7 @@ def create_repository(
     settings: Dynaconf,
     credential_service: OAuthCredentialService,
     history_store_ref: dict[str, RunHistoryStore],
+    checkpoint_store_ref: dict[str, object] | None = None,
 ) -> WorkflowRepository:
     """Create the workflow repository using configured backend."""
     backend = cast(
@@ -160,12 +165,16 @@ def create_repository(
             ),
         )
         history_store_ref["store"] = SqliteRunHistoryStore(sqlite_path)
+        if checkpoint_store_ref is not None:
+            checkpoint_store_ref["store"] = SqliteAgentensorCheckpointStore(sqlite_path)
         return SqliteWorkflowRepository(
             sqlite_path,
             credential_service=credential_service,
         )
     if backend == "inmemory":
         history_store_ref["store"] = InMemoryRunHistoryStore()
+        if checkpoint_store_ref is not None:
+            checkpoint_store_ref["store"] = InMemoryAgentensorCheckpointStore()
         return InMemoryWorkflowRepository(credential_service=credential_service)
     msg = "Unsupported repository backend configured."
     raise ValueError(msg)

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/runs.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/runs.py
@@ -22,6 +22,7 @@ class WorkflowRunMixin(InMemoryRepositoryState):
         triggered_by: str,
         input_payload: dict[str, Any],
         actor: str | None = None,
+        runnable_config: dict[str, Any] | None = None,
     ) -> WorkflowRun:
         """Create a workflow run tied to a version."""
         async with self._lock:
@@ -36,6 +37,7 @@ class WorkflowRunMixin(InMemoryRepositoryState):
                 triggered_by=triggered_by,
                 input_payload=input_payload,
                 actor=actor,
+                runnable_config=runnable_config,
             )
             return run.model_copy(deep=True)
 

--- a/apps/backend/src/orcheo_backend/app/repository/protocol.py
+++ b/apps/backend/src/orcheo_backend/app/repository/protocol.py
@@ -108,6 +108,7 @@ class WorkflowRepository(Protocol):
         triggered_by: str,
         input_payload: dict[str, Any],
         actor: str | None = None,
+        runnable_config: dict[str, Any] | None = None,
     ) -> WorkflowRun:
         """Create a workflow run for the specified version."""
 

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
@@ -85,15 +85,47 @@ class SqlitePersistenceMixin(SqliteRepositoryBase):
         triggered_by: str,
         input_payload: Mapping[str, Any],
         actor: str | None,
+        runnable_config: Mapping[str, Any] | None = None,
     ) -> WorkflowRun:
         version = await self._get_version_locked(workflow_version_id)
         if version.workflow_id != workflow_id:
             raise WorkflowVersionNotFoundError(str(workflow_version_id))
 
+        config_payload: dict[str, Any] = {}
+        if runnable_config:
+            if hasattr(runnable_config, "model_dump"):
+                config_payload = runnable_config.model_dump(mode="json")  # type: ignore[arg-type]
+            elif isinstance(runnable_config, Mapping):
+                config_payload = dict(runnable_config)
+        tags = (
+            list(config_payload.get("tags", []))
+            if isinstance(config_payload, dict)
+            else []
+        )
+        callbacks = (
+            list(config_payload.get("callbacks", []))
+            if isinstance(config_payload, dict)
+            else []
+        )
+        metadata = (
+            dict(config_payload.get("metadata", {}))
+            if isinstance(config_payload, Mapping)
+            else {}
+        )
+        run_name = (
+            config_payload.get("run_name")
+            if isinstance(config_payload, Mapping)
+            else None
+        )
         run = WorkflowRun(
             workflow_version_id=workflow_version_id,
             triggered_by=triggered_by,
             input_payload=dict(input_payload),
+            runnable_config=config_payload if isinstance(config_payload, dict) else {},
+            tags=tags,
+            callbacks=callbacks,
+            metadata=metadata,
+            run_name=run_name,
         )
         run.record_event(actor=actor or triggered_by, action="run_created")
 

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_runs.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_runs.py
@@ -19,6 +19,7 @@ class WorkflowRunMixin(SqlitePersistenceMixin):
         triggered_by: str,
         input_payload: dict[str, Any],
         actor: str | None = None,
+        runnable_config: dict[str, Any] | None = None,
     ) -> WorkflowRun:
         await self._ensure_initialized()
         async with self._lock:
@@ -30,6 +31,7 @@ class WorkflowRunMixin(SqlitePersistenceMixin):
                 triggered_by=triggered_by,
                 input_payload=input_payload,
                 actor=actor,
+                runnable_config=runnable_config,
             )
             return run.model_copy(deep=True)
 

--- a/apps/backend/src/orcheo_backend/app/routers/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/routers/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "credential_health",
     "credential_templates",
     "credentials",
+    "agentensor",
     "nodes",
     "runs",
     "triggers",

--- a/apps/backend/src/orcheo_backend/app/routers/agentensor.py
+++ b/apps/backend/src/orcheo_backend/app/routers/agentensor.py
@@ -1,0 +1,48 @@
+"""Agentensor checkpoint APIs."""
+
+from __future__ import annotations
+from uuid import UUID
+from fastapi import APIRouter, Query
+from orcheo.agentensor.checkpoints import AgentensorCheckpointNotFoundError
+from orcheo_backend.app.dependencies import CheckpointStoreDep
+from orcheo_backend.app.errors import raise_not_found
+from orcheo_backend.app.schemas.agentensor import AgentensorCheckpointResponse
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/workflows/{workflow_id}/agentensor/checkpoints",
+    response_model=list[AgentensorCheckpointResponse],
+)
+async def list_agentensor_checkpoints(
+    workflow_id: UUID,
+    store: CheckpointStoreDep,
+    limit: int = Query(20, ge=1, le=200),
+) -> list[AgentensorCheckpointResponse]:
+    """List checkpoints for the specified workflow."""
+    checkpoints = await store.list_checkpoints(str(workflow_id), limit=limit)
+    return [AgentensorCheckpointResponse.from_domain(item) for item in checkpoints]
+
+
+@router.get(
+    "/workflows/{workflow_id}/agentensor/checkpoints/{checkpoint_id}",
+    response_model=AgentensorCheckpointResponse,
+)
+async def get_agentensor_checkpoint(
+    workflow_id: UUID,
+    checkpoint_id: str,
+    store: CheckpointStoreDep,
+) -> AgentensorCheckpointResponse:
+    """Return a single checkpoint for the workflow."""
+    try:
+        checkpoint = await store.get_checkpoint(checkpoint_id)
+    except AgentensorCheckpointNotFoundError as exc:
+        raise_not_found("Checkpoint not found", exc)
+    if checkpoint.workflow_id != str(workflow_id):
+        raise_not_found("Checkpoint not found", AgentensorCheckpointNotFoundError(""))
+    return AgentensorCheckpointResponse.from_domain(checkpoint)
+
+
+__all__ = ["router"]

--- a/apps/backend/src/orcheo_backend/app/routers/runs.py
+++ b/apps/backend/src/orcheo_backend/app/routers/runs.py
@@ -47,11 +47,17 @@ async def create_workflow_run(
 ) -> WorkflowRun:
     """Create a workflow execution run."""
     try:
+        config_payload = (
+            request.runnable_config.model_dump(mode="json")
+            if request.runnable_config is not None
+            else None
+        )
         return await repository.create_run(
             workflow_id,
             workflow_version_id=request.workflow_version_id,
             triggered_by=request.triggered_by,
             input_payload=request.input_payload,
+            runnable_config=config_payload,
         )
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)

--- a/apps/backend/src/orcheo_backend/app/routers/websocket.py
+++ b/apps/backend/src/orcheo_backend/app/routers/websocket.py
@@ -16,7 +16,12 @@ _CANNOT_SEND_AFTER_CLOSE = 'Cannot call "send" once a close message has been sen
 @router.websocket("/ws/workflow/{workflow_id}")
 async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
     """Handle workflow websocket connections by delegating to the executor."""
-    from orcheo_backend.app import authenticate_websocket, execute_workflow
+    from orcheo_backend.app import (
+        authenticate_websocket,
+        execute_workflow,
+        execute_workflow_evaluation,
+        execute_workflow_training,
+    )
 
     try:
         context = await authenticate_websocket(websocket)
@@ -30,7 +35,8 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
         while True:
             data = await websocket.receive_json()
 
-            if data.get("type") == "run_workflow":
+            message_type = data.get("type")
+            if message_type == "run_workflow":
                 execution_id = data.get("execution_id", str(uuid.uuid4()))
                 task = asyncio.create_task(
                     execute_workflow(
@@ -43,6 +49,36 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                     )
                 )
 
+                await task
+                break
+            if message_type == "evaluate_workflow":
+                execution_id = data.get("execution_id", str(uuid.uuid4()))
+                task = asyncio.create_task(
+                    execute_workflow_evaluation(
+                        workflow_id,
+                        data["graph_config"],
+                        data.get("inputs", {}),
+                        execution_id,
+                        websocket,
+                        evaluation=data.get("evaluation"),
+                        runnable_config=data.get("runnable_config"),
+                    )
+                )
+                await task
+                break
+            if message_type == "train_workflow":
+                execution_id = data.get("execution_id", str(uuid.uuid4()))
+                task = asyncio.create_task(
+                    execute_workflow_training(
+                        workflow_id,
+                        data["graph_config"],
+                        data.get("inputs", {}),
+                        execution_id,
+                        websocket,
+                        training=data.get("training"),
+                        runnable_config=data.get("runnable_config"),
+                    )
+                )
                 await task
                 break
 

--- a/apps/backend/src/orcheo_backend/app/routers/websocket.py
+++ b/apps/backend/src/orcheo_backend/app/routers/websocket.py
@@ -39,6 +39,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                         data["inputs"],
                         execution_id,
                         websocket,
+                        runnable_config=data.get("runnable_config"),
                     )
                 )
 

--- a/apps/backend/src/orcheo_backend/app/schemas/agentensor.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/agentensor.py
@@ -1,0 +1,41 @@
+"""Schemas for Agentensor checkpoint APIs."""
+
+from __future__ import annotations
+from datetime import datetime
+from typing import Any
+from pydantic import BaseModel
+from orcheo.agentensor.checkpoints import AgentensorCheckpoint
+
+
+class AgentensorCheckpointResponse(BaseModel):
+    """Response payload for persisted training checkpoints."""
+
+    id: str
+    workflow_id: str
+    config_version: int
+    runnable_config: dict[str, Any]
+    metrics: dict[str, Any]
+    metadata: dict[str, Any]
+    artifact_url: str | None = None
+    created_at: datetime
+    is_best: bool = False
+
+    @classmethod
+    def from_domain(
+        cls, checkpoint: AgentensorCheckpoint
+    ) -> AgentensorCheckpointResponse:
+        """Build a response payload from a checkpoint domain model."""
+        return cls(
+            id=checkpoint.id,
+            workflow_id=checkpoint.workflow_id,
+            config_version=checkpoint.config_version,
+            runnable_config=dict(checkpoint.runnable_config),
+            metrics=dict(checkpoint.metrics),
+            metadata=dict(checkpoint.metadata),
+            artifact_url=checkpoint.artifact_url,
+            created_at=checkpoint.created_at,
+            is_best=checkpoint.is_best,
+        )
+
+
+__all__ = ["AgentensorCheckpointResponse"]

--- a/apps/backend/src/orcheo_backend/app/schemas/runs.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/runs.py
@@ -48,6 +48,11 @@ class RunHistoryResponse(BaseModel):
     completed_at: datetime | None = None
     error: str | None = None
     inputs: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: dict[str, Any] = Field(default_factory=dict)
+    tags: list[Any] = Field(default_factory=list)
+    callbacks: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    run_name: str | None = None
     steps: list[RunHistoryStepResponse] = Field(default_factory=list)
 
 

--- a/apps/backend/src/orcheo_backend/app/schemas/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/workflows.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 from orcheo.models.workflow import Workflow
+from orcheo.runtime.runnable_config import RunnableConfigModel
 
 
 class WorkflowCreateRequest(BaseModel):
@@ -65,6 +66,7 @@ class WorkflowRunCreateRequest(BaseModel):
     workflow_version_id: UUID
     triggered_by: str
     input_payload: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: RunnableConfigModel | None = None
 
 
 class WorkflowVersionDiffResponse(BaseModel):

--- a/apps/backend/src/orcheo_backend/app/workflow_execution.py
+++ b/apps/backend/src/orcheo_backend/app/workflow_execution.py
@@ -10,9 +10,12 @@ from uuid import UUID
 from fastapi import WebSocket, WebSocketDisconnect
 from langchain_core.runnables import RunnableConfig
 from opentelemetry.trace import Span, Tracer
+from orcheo.agentensor.evaluation import EvaluationRequest
+from orcheo.agentensor.training import TrainingRequest
 from orcheo.config import get_settings
 from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
 from orcheo.graph.state import State
+from orcheo.nodes.agentensor import AgentensorNode
 from orcheo.runtime.credentials import CredentialResolver, credential_resolution
 from orcheo.runtime.runnable_config import RunnableConfigModel, parse_runnable_config
 from orcheo.tracing import (
@@ -25,6 +28,7 @@ from orcheo.tracing import (
 )
 from orcheo_backend.app.dependencies import (
     credential_context_from_workflow,
+    get_checkpoint_store,
     get_history_store,
     get_vault,
 )
@@ -375,6 +379,430 @@ async def execute_workflow(
         )
 
 
+async def _run_evaluation_node(
+    *,
+    graph_config: Mapping[str, Any],
+    inputs: dict[str, Any],
+    runtime_config: RunnableConfig,
+    state_config: Mapping[str, Any],
+    evaluation_request: EvaluationRequest,
+    parsed_config: RunnableConfigModel,
+    history_store: RunHistoryStore,
+    websocket: WebSocket,
+    execution_id: str,
+    tracer: Tracer,
+    resolver: CredentialResolver,
+    settings: Any,
+    span: Span,
+) -> None:
+    """Compile the graph and execute evaluation cases."""
+    from orcheo_backend.app import build_graph, create_checkpointer
+
+    async def on_progress(payload: Mapping[str, Any]) -> None:
+        record_workflow_step(tracer, payload)
+        history_step = await history_store.append_step(execution_id, payload)
+        await _safe_send_json(websocket, payload)
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            step=history_step,
+        )
+
+    with credential_resolution(resolver):
+        async with create_checkpointer(settings) as checkpointer:
+            graph = build_graph(graph_config)
+            compiled_graph = graph.compile(checkpointer=checkpointer)
+            node = AgentensorNode(
+                name="agentensor_evaluator",
+                mode="evaluate",
+                prompts=parsed_config.prompts or {},
+                dataset=evaluation_request.dataset,
+                evaluators=evaluation_request.evaluators,
+                max_cases=evaluation_request.max_cases,
+                compiled_graph=compiled_graph,
+                graph_config=graph_config,
+                state_config=state_config,
+                progress_callback=on_progress,
+            )
+            state = _build_initial_state(graph_config, inputs, state_config)
+            _log_sensitive_debug("Initial state: %s", state)
+
+            try:
+                result = await node(state, runtime_config)
+                node_payload = result.get("results", {}).get(
+                    node.name, result.get("results", result)
+                )
+                final_step = await history_store.append_step(
+                    execution_id,
+                    {
+                        "node": node.name,
+                        "event": "evaluation_result",
+                        "payload": node_payload,
+                    },
+                )
+                await _safe_send_json(
+                    websocket,
+                    {
+                        "node": node.name,
+                        "event": "evaluation_result",
+                        "payload": node_payload,
+                    },
+                )
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    step=final_step,
+                )
+            except asyncio.CancelledError as exc:
+                reason = str(exc) or "Evaluation cancelled"
+                record_workflow_cancellation(span, reason=reason)
+                cancellation_payload = {"status": "cancelled", "reason": reason}
+                await history_store.append_step(execution_id, cancellation_payload)
+                await history_store.mark_cancelled(execution_id, reason=reason)
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    include_root=True,
+                    complete=True,
+                )
+                raise
+            except Exception as exc:
+                record_workflow_failure(span, exc)
+                error_message = str(exc)
+                error_payload = {"status": "error", "error": error_message}
+                await _persist_failure_history(
+                    history_store,
+                    execution_id,
+                    error_payload,
+                    error_message,
+                    span,
+                )
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    include_root=True,
+                    complete=True,
+                )
+                raise
+
+
+async def _run_training_node(
+    *,
+    workflow_id: str,
+    graph_config: Mapping[str, Any],
+    inputs: dict[str, Any],
+    runtime_config: RunnableConfig,
+    state_config: Mapping[str, Any],
+    training_request: TrainingRequest,
+    parsed_config: RunnableConfigModel,
+    history_store: RunHistoryStore,
+    websocket: WebSocket,
+    execution_id: str,
+    tracer: Tracer,
+    resolver: CredentialResolver,
+    settings: Any,
+    span: Span,
+    checkpoint_store: Any,
+) -> None:
+    """Compile the graph and execute training with checkpoints."""
+    from orcheo_backend.app import build_graph, create_checkpointer
+
+    async def on_progress(payload: Mapping[str, Any]) -> None:
+        record_workflow_step(tracer, payload)
+        history_step = await history_store.append_step(execution_id, payload)
+        await _safe_send_json(websocket, payload)
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            step=history_step,
+        )
+
+    with credential_resolution(resolver):
+        async with create_checkpointer(settings) as checkpointer:
+            graph = build_graph(graph_config)
+            compiled_graph = graph.compile(checkpointer=checkpointer)
+            node = AgentensorNode(
+                name="agentensor_trainer",
+                mode="train",
+                prompts=parsed_config.prompts or {},
+                dataset=training_request.dataset,
+                evaluators=training_request.evaluators,
+                max_cases=training_request.max_cases,
+                optimizer=training_request.optimizer,
+                compiled_graph=compiled_graph,
+                graph_config=graph_config,
+                state_config=state_config,
+                progress_callback=on_progress,
+                workflow_id=workflow_id,
+                checkpoint_store=checkpoint_store,
+            )
+            state = _build_initial_state(graph_config, inputs, state_config)
+            _log_sensitive_debug("Initial state: %s", state)
+
+            try:
+                result = await node(state, runtime_config)
+                node_payload = result.get("results", {}).get(
+                    node.name, result.get("results", result)
+                )
+                final_step = await history_store.append_step(
+                    execution_id,
+                    {
+                        "node": node.name,
+                        "event": "training_result",
+                        "payload": node_payload,
+                    },
+                )
+                await _safe_send_json(
+                    websocket,
+                    {
+                        "node": node.name,
+                        "event": "training_result",
+                        "payload": node_payload,
+                    },
+                )
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    step=final_step,
+                )
+            except asyncio.CancelledError as exc:
+                reason = str(exc) or "Training cancelled"
+                record_workflow_cancellation(span, reason=reason)
+                cancellation_payload = {"status": "cancelled", "reason": reason}
+                await history_store.append_step(execution_id, cancellation_payload)
+                await history_store.mark_cancelled(execution_id, reason=reason)
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    include_root=True,
+                    complete=True,
+                )
+                raise
+            except Exception as exc:
+                record_workflow_failure(span, exc)
+                error_message = str(exc)
+                error_payload = {"status": "error", "error": error_message}
+                await _persist_failure_history(
+                    history_store,
+                    execution_id,
+                    error_payload,
+                    error_message,
+                    span,
+                )
+                await _emit_trace_update(
+                    history_store,
+                    websocket,
+                    execution_id,
+                    include_root=True,
+                    complete=True,
+                )
+                raise
+
+
+async def execute_workflow_evaluation(
+    workflow_id: str,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+    execution_id: str,
+    websocket: WebSocket,
+    evaluation: Mapping[str, Any] | EvaluationRequest | None,
+    runnable_config: Mapping[str, Any] | RunnableConfigModel | None = None,
+) -> None:  # noqa: PLR0915
+    """Execute workflow evaluation and stream progress via websocket."""
+    logger.info(
+        "Starting evaluation %s with execution_id: %s", workflow_id, execution_id
+    )
+    _log_sensitive_debug("Evaluation inputs: %s", inputs)
+
+    try:
+        evaluation_request = (
+            evaluation
+            if isinstance(evaluation, EvaluationRequest)
+            else EvaluationRequest.model_validate(evaluation or {})
+        )
+    except Exception as exc:
+        error_msg = f"Invalid evaluation payload: {exc}"
+        await _safe_send_json(websocket, {"status": "error", "error": error_msg})
+        return
+
+    settings = get_settings()
+    history_store = get_history_store()
+    vault = get_vault()
+    workflow_uuid: UUID | None = None
+    try:
+        workflow_uuid = UUID(workflow_id)
+    except ValueError:
+        pass
+    credential_context = credential_context_from_workflow(workflow_uuid)
+    resolver = CredentialResolver(vault, context=credential_context)
+    tracer = get_tracer(__name__)
+    parsed_config, runtime_config, state_config, stored_config = (
+        _prepare_runnable_config(execution_id, runnable_config)
+    )
+
+    with workflow_span(
+        tracer,
+        workflow_id=workflow_id,
+        execution_id=execution_id,
+        inputs=inputs,
+        runnable_config=parsed_config,
+    ) as span_context:
+        await history_store.start_run(
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+            inputs=inputs,
+            trace_id=span_context.trace_id,
+            trace_started_at=span_context.started_at,
+            runnable_config=stored_config,
+            tags=parsed_config.tags,
+            callbacks=parsed_config.callbacks,
+            metadata=parsed_config.metadata,
+            run_name=parsed_config.run_name,
+        )
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            include_root=True,
+        )
+
+        await _run_evaluation_node(
+            graph_config=graph_config,
+            inputs=inputs,
+            runtime_config=runtime_config,
+            state_config=state_config,
+            evaluation_request=evaluation_request,
+            parsed_config=parsed_config,
+            history_store=history_store,
+            websocket=websocket,
+            execution_id=execution_id,
+            tracer=tracer,
+            resolver=resolver,
+            settings=settings,
+            span=span_context.span,
+        )
+
+        completion_payload = {"status": "completed"}
+        record_workflow_completion(span_context.span)
+        await history_store.append_step(execution_id, completion_payload)
+        await history_store.mark_completed(execution_id)
+        await _safe_send_json(websocket, completion_payload)  # pragma: no cover
+
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            include_root=True,
+            complete=True,
+        )
+
+
+async def execute_workflow_training(
+    workflow_id: str,
+    graph_config: dict[str, Any],
+    inputs: dict[str, Any],
+    execution_id: str,
+    websocket: WebSocket,
+    training: Mapping[str, Any] | TrainingRequest | None,
+    runnable_config: Mapping[str, Any] | RunnableConfigModel | None = None,
+) -> None:  # noqa: PLR0915
+    """Execute workflow training and stream progress via websocket."""
+    logger.info("Starting training %s with execution_id: %s", workflow_id, execution_id)
+    _log_sensitive_debug("Training inputs: %s", inputs)
+
+    try:
+        training_request = (
+            training
+            if isinstance(training, TrainingRequest)
+            else TrainingRequest.model_validate(training or {})
+        )
+    except Exception as exc:
+        error_msg = f"Invalid training payload: {exc}"
+        await _safe_send_json(websocket, {"status": "error", "error": error_msg})
+        return
+
+    settings = get_settings()
+    history_store = get_history_store()
+    checkpoint_store = get_checkpoint_store()
+    vault = get_vault()
+    workflow_uuid: UUID | None = None
+    try:
+        workflow_uuid = UUID(workflow_id)
+    except ValueError:
+        pass
+    credential_context = credential_context_from_workflow(workflow_uuid)
+    resolver = CredentialResolver(vault, context=credential_context)
+    tracer = get_tracer(__name__)
+    parsed_config, runtime_config, state_config, stored_config = (
+        _prepare_runnable_config(execution_id, runnable_config)
+    )
+
+    with workflow_span(
+        tracer,
+        workflow_id=workflow_id,
+        execution_id=execution_id,
+        inputs=inputs,
+        runnable_config=parsed_config,
+    ) as span_context:
+        await history_store.start_run(
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+            inputs=inputs,
+            trace_id=span_context.trace_id,
+            trace_started_at=span_context.started_at,
+            runnable_config=stored_config,
+            tags=parsed_config.tags,
+            callbacks=parsed_config.callbacks,
+            metadata=parsed_config.metadata,
+            run_name=parsed_config.run_name,
+        )
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            include_root=True,
+        )
+
+        await _run_training_node(
+            workflow_id=workflow_id,
+            graph_config=graph_config,
+            inputs=inputs,
+            runtime_config=runtime_config,
+            state_config=state_config,
+            training_request=training_request,
+            parsed_config=parsed_config,
+            history_store=history_store,
+            websocket=websocket,
+            execution_id=execution_id,
+            tracer=tracer,
+            resolver=resolver,
+            settings=settings,
+            span=span_context.span,
+            checkpoint_store=checkpoint_store,
+        )
+
+        completion_payload = {"status": "completed"}
+        record_workflow_completion(span_context.span)
+        await history_store.append_step(execution_id, completion_payload)
+        await history_store.mark_completed(execution_id)
+        await _safe_send_json(websocket, completion_payload)  # pragma: no cover
+
+        await _emit_trace_update(
+            history_store,
+            websocket,
+            execution_id,
+            include_root=True,
+            complete=True,
+        )
+
+
 async def execute_node(
     node_class: Callable[..., Any],
     node_params: dict[str, Any],
@@ -406,4 +834,6 @@ __all__ = [
     "configure_sensitive_logging",
     "execute_node",
     "execute_workflow",
+    "execute_workflow_evaluation",
+    "execute_workflow_training",
 ]

--- a/docs/agentensor/design.md
+++ b/docs/agentensor/design.md
@@ -112,6 +112,8 @@ The trainer/evaluator mode reuses the existing workflow router and WebSocket str
 | checkpoint | object | `{ id, workflow_id, config_version, runnable_config, metrics, created_at, artifact_url }` |
 | evaluator | object | `{ id, type: "llm" | "deterministic", entrypoint: string, config?: object }`; entrypoints must be importable callables compatible with existing evaluator registry |
 
+**Evaluation payload:** `{ dataset: { id?: string, cases: [{ inputs: object, expected_output?: any, metadata?: object }] }, evaluators: [{ id, entrypoint, config?: object }], max_cases?: int }`. Entrypoints resolve to callables/classes that accept `(EvaluationContext)` and return a `value`/`reason` pair; results stream via the existing WebSocket channel as `evaluation_progress` and `evaluation_summary` events.
+
 Example `RunnableConfig` payload:
 
 ```json

--- a/docs/agentensor/plan.md
+++ b/docs/agentensor/plan.md
@@ -44,13 +44,13 @@ Deliver runtime support for `langchain_core.runnables.RunnableConfig` on workflo
 
 #### Task Checklist
 
-- [ ] Task 1.1: Extend run API/SDK schema to accept `RunnableConfig`, with validation and backward compatibility
+- [x] Task 1.1: Extend run API/SDK schema to accept `RunnableConfig`, with validation and backward compatibility
   - Dependencies: Requirements sign-off
-- [ ] Task 1.2: Propagate merged config into LangGraph runtime and node execution context (including resolving node -> config prompt references for trainable `TextTensor` prompts); enforce safe limits
+- [x] Task 1.2: Propagate merged config into LangGraph runtime and node execution context (including resolving node -> config prompt references for trainable `TextTensor` prompts); enforce safe limits
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Register AgentensorNode in `src/orcheo/nodes/registry.py` as a `TaskNode` subclass and validate `{{path.to.value}}` interpolation for prompts
+- [x] Task 1.3: Register AgentensorNode in `src/orcheo/nodes/registry.py` as a `TaskNode` subclass and validate `{{path.to.value}}` interpolation for prompts
   - Dependencies: Task 1.2
-- [ ] Task 1.4: Persist run metadata (config, tags, callbacks) and emit observability signals
+- [x] Task 1.4: Persist run metadata (config, tags, callbacks) and emit observability signals
   - Dependencies: Task 1.2
 
 ---

--- a/docs/agentensor/plan.md
+++ b/docs/agentensor/plan.md
@@ -61,11 +61,11 @@ Deliver runtime support for `langchain_core.runnables.RunnableConfig` on workflo
 
 #### Task Checklist
 
-- [ ] Task 2.1: Implement AgentensorNode evaluation flow with dataset/evaluator wiring
+- [x] Task 2.1: Implement AgentensorNode evaluation flow with dataset/evaluator wiring
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Add API/CLI entry to trigger evaluation runs and stream progress via existing workflow router/WebSocket channel
+- [x] Task 2.2: Add API/CLI entry to trigger evaluation runs and stream progress via existing workflow router/WebSocket channel
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Aggregate metrics, persist results, and document evaluator schema
+- [x] Task 2.3: Aggregate metrics, persist results, and document evaluator schema
   - Dependencies: Task 2.1
 
 ---
@@ -76,13 +76,13 @@ Deliver runtime support for `langchain_core.runnables.RunnableConfig` on workflo
 
 #### Task Checklist
 
-- [ ] Task 3.1: Integrate optimizer loop for trainable prompts (referenced by nodes via config paths) and runnable-config updates; emit checkpoints
+- [x] Task 3.1: Integrate optimizer loop for trainable prompts (referenced by nodes via config paths) and runnable-config updates; emit checkpoints
   - Dependencies: Milestone 2
-- [ ] Task 3.2: Persist checkpoints and best-performing configs in a dedicated DB table keyed by `workflow_id` with versioned records; expose download/reuse endpoints and ship SQLite/PostgreSQL migrations
+- [x] Task 3.2: Persist checkpoints and best-performing configs in a dedicated DB table keyed by `workflow_id` with versioned records; expose download/reuse endpoints and ship SQLite/PostgreSQL migrations
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Add safeguards (concurrency limits, timeout caps) and end-to-end tests for training mode (including compatibility with existing nodes)
+- [x] Task 3.3: Add safeguards (concurrency limits, timeout caps) and end-to-end tests for training mode (including compatibility with existing nodes)
   - Dependencies: Task 3.1
-- [ ] Task 3.4: Conduct performance and migration testing (concurrency, rollback/restore) and document operational runbooks
+- [x] Task 3.4: Conduct performance and migration testing (concurrency, rollback/restore) and document operational runbooks
   - Dependencies: Task 3.2
 
 ---

--- a/docs/agentensor/runbook.md
+++ b/docs/agentensor/runbook.md
@@ -1,0 +1,69 @@
+# Agentensor Training Runbook
+
+## Overview
+- Training runs are dispatched over the existing workflow websocket (`type: "train_workflow"`). Payload mirrors evaluation but accepts a `training` block with dataset/evaluators plus optimizer settings (`epochs`, `checkpoint_interval`, `case_timeout_seconds`, `max_concurrency`).
+- AgentensorNode enforces guardrails: concurrency is capped at 8 (or the requested `max_concurrency`, whichever is lower) and case timeouts default to 30s (max 300s).
+- Checkpoints are emitted at `checkpoint_interval` boundaries and whenever a new best score is observed. Each checkpoint captures the runnable config (including prompts), metrics, and metadata (`epoch`, summary).
+
+## Storage & Migrations
+- **SQLite**: `agentensor_checkpoints` table is auto-created alongside execution history.
+  ```
+  CREATE TABLE IF NOT EXISTS agentensor_checkpoints (
+      id TEXT PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      config_version INTEGER NOT NULL,
+      runnable_config TEXT NOT NULL,
+      metrics TEXT NOT NULL,
+      metadata TEXT NOT NULL DEFAULT '{}',
+      artifact_url TEXT,
+      is_best INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_workflow
+      ON agentensor_checkpoints(workflow_id, config_version);
+  CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_best
+      ON agentensor_checkpoints(workflow_id, is_best);
+  ```
+- **PostgreSQL**: apply the equivalent DDL before deploying:
+  ```
+  CREATE TABLE IF NOT EXISTS agentensor_checkpoints (
+      id TEXT PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      config_version INTEGER NOT NULL,
+      runnable_config JSONB NOT NULL,
+      metrics JSONB NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      artifact_url TEXT NULL,
+      is_best BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_workflow
+      ON agentensor_checkpoints (workflow_id, config_version);
+  CREATE INDEX IF NOT EXISTS idx_agentensor_checkpoints_best
+      ON agentensor_checkpoints (workflow_id, is_best);
+  ```
+- **Rollback/restore**: checkpoints are append-only. To roll back a regression, fetch the previous best via `GET /api/workflows/{workflow_id}/agentensor/checkpoints?limit=5`, select the desired `config_version`, and reuse its `runnable_config` in a new run.
+
+## Operations
+- Start a training run by streaming:
+  ```json
+  {
+    "type": "train_workflow",
+    "graph_config": {...},
+    "inputs": {...},
+    "training": {
+      "dataset": {"cases": [...]},
+      "evaluators": [{"id": "quality", "entrypoint": "module:evaluator"}],
+      "optimizer": {"epochs": 3, "checkpoint_interval": 1}
+    }
+  }
+  ```
+- Monitor progress events:
+  - `training_progress`: per-case output/evaluations
+  - `training_checkpoint`: persisted checkpoint payload
+  - `training_epoch_complete`: summary per epoch
+- Download/reuse: `GET /api/workflows/{workflow_id}/agentensor/checkpoints/{checkpoint_id}` returns the stored config and metrics for reuse.
+
+## Performance & Concurrency Checks
+- The training node caps `max_concurrency` to 8 and applies wait-for timeouts per case. Increase `checkpoint_interval` to reduce write amplification in long runs.
+- For load testing, run concurrent websocket training sessions against SQLite and Postgres backends; verify checkpoint ordering and `is_best` flag consistency. On Postgres, wrap the DDL above in migrations to validate apply/rollback.

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
@@ -17,7 +17,7 @@ from .app import (
 )
 from .commands.listing import list_workflows
 from .commands.managing import delete_workflow, download_workflow, upload_workflow
-from .commands.running import run_workflow
+from .commands.running import evaluate_workflow, run_workflow
 from .commands.showing import show_workflow
 from .formatting import _format_workflow_as_json, _format_workflow_as_python
 from .ingest import (
@@ -52,6 +52,7 @@ from .streaming import (
     _prepare_streaming_graph,
     _process_stream_messages,
     _render_node_output,
+    _stream_workflow_evaluation,
     _stream_workflow_run,
 )
 
@@ -71,6 +72,7 @@ __all__ = [
     "_normalize_workflow_name",
     "_upload_langgraph_script",
     "_stream_workflow_run",
+    "_stream_workflow_evaluation",
     "_process_stream_messages",
     "_handle_status_update",
     "_handle_node_event",
@@ -100,6 +102,7 @@ __all__ = [
     "list_workflows",
     "show_workflow",
     "run_workflow",
+    "evaluate_workflow",
     "delete_workflow",
     "upload_workflow",
     "download_workflow",

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
@@ -32,6 +32,20 @@ RunnableConfigFileOption = Annotated[
     str | None,
     typer.Option("--config-file", help="Path to JSON file with runnable config."),
 ]
+EvaluationOption = Annotated[
+    str | None,
+    typer.Option(
+        "--evaluation",
+        help="JSON payload describing evaluation dataset/evaluators.",
+    ),
+]
+EvaluationFileOption = Annotated[
+    str | None,
+    typer.Option(
+        "--evaluation-file",
+        help="Path to JSON file with evaluation payload.",
+    ),
+]
 ForceOption = Annotated[
     bool,
     typer.Option("--force", help="Skip confirmation prompt."),
@@ -85,6 +99,8 @@ __all__ = [
     "InputsFileOption",
     "RunnableConfigOption",
     "RunnableConfigFileOption",
+    "EvaluationOption",
+    "EvaluationFileOption",
     "ForceOption",
     "FilePathArgument",
     "WorkflowIdOption",

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
@@ -24,6 +24,14 @@ InputsFileOption = Annotated[
     str | None,
     typer.Option("--inputs-file", help="Path to JSON file with inputs."),
 ]
+RunnableConfigOption = Annotated[
+    str | None,
+    typer.Option("--config", help="JSON LangChain runnable config payload."),
+]
+RunnableConfigFileOption = Annotated[
+    str | None,
+    typer.Option("--config-file", help="Path to JSON file with runnable config."),
+]
 ForceOption = Annotated[
     bool,
     typer.Option("--force", help="Skip confirmation prompt."),
@@ -75,6 +83,8 @@ __all__ = [
     "ActorOption",
     "InputsOption",
     "InputsFileOption",
+    "RunnableConfigOption",
+    "RunnableConfigFileOption",
     "ForceOption",
     "FilePathArgument",
     "WorkflowIdOption",

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
@@ -9,11 +9,16 @@ from orcheo_sdk.cli.workflow.app import (
     ActorOption,
     InputsFileOption,
     InputsOption,
+    RunnableConfigFileOption,
+    RunnableConfigOption,
     WorkflowIdArgument,
     _state,
     workflow_app,
 )
-from orcheo_sdk.cli.workflow.inputs import _resolve_run_inputs
+from orcheo_sdk.cli.workflow.inputs import (
+    _resolve_run_inputs,
+    _resolve_runnable_config,
+)
 from orcheo_sdk.services import run_workflow_data
 
 
@@ -24,6 +29,8 @@ def run_workflow(
     triggered_by: ActorOption = "cli",
     inputs: InputsOption = None,
     inputs_file: InputsFileOption = None,
+    config: RunnableConfigOption = None,
+    config_file: RunnableConfigFileOption = None,
     stream: bool = typer.Option(
         True,
         "--stream/--no-stream",
@@ -35,6 +42,7 @@ def run_workflow(
     if state.settings.offline:
         raise CLIError("Workflow executions require network connectivity.")
     input_payload = _resolve_run_inputs(inputs, inputs_file)
+    runnable_config = _resolve_runnable_config(config, config_file)
     from orcheo_sdk.cli import workflow as workflow_module
 
     graph_config = (
@@ -49,6 +57,7 @@ def run_workflow(
                 graph_config,
                 input_payload,
                 triggered_by=triggered_by,
+                runnable_config=runnable_config,
             )
         )
         if final_status in {"error", "cancelled", "connection_error", "timeout"}:
@@ -61,6 +70,7 @@ def run_workflow(
         state.settings.service_token,
         inputs=input_payload,
         triggered_by=triggered_by,
+        runnable_config=runnable_config,
     )
     render_json(state.console, result, title="Run created")
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
@@ -7,6 +7,8 @@ from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.output import render_json
 from orcheo_sdk.cli.workflow.app import (
     ActorOption,
+    EvaluationFileOption,
+    EvaluationOption,
     InputsFileOption,
     InputsOption,
     RunnableConfigFileOption,
@@ -16,6 +18,7 @@ from orcheo_sdk.cli.workflow.app import (
     workflow_app,
 )
 from orcheo_sdk.cli.workflow.inputs import (
+    _resolve_evaluation_payload,
     _resolve_run_inputs,
     _resolve_runnable_config,
 )
@@ -73,6 +76,55 @@ def run_workflow(
         runnable_config=runnable_config,
     )
     render_json(state.console, result, title="Run created")
+
+
+@workflow_app.command("evaluate")
+def evaluate_workflow(
+    ctx: typer.Context,
+    workflow_id: WorkflowIdArgument,
+    triggered_by: ActorOption = "cli",
+    inputs: InputsOption = None,
+    inputs_file: InputsFileOption = None,
+    config: RunnableConfigOption = None,
+    config_file: RunnableConfigFileOption = None,
+    evaluation: EvaluationOption = None,
+    evaluation_file: EvaluationFileOption = None,
+    stream: bool = typer.Option(
+        True,
+        "--stream/--no-stream",
+        help="Stream evaluation progress in real-time (default: True).",
+    ),
+) -> None:
+    """Trigger an evaluation run using Agentensor evaluation mode."""
+    state = _state(ctx)
+    if state.settings.offline:
+        raise CLIError("Workflow evaluations require network connectivity.")
+    input_payload = _resolve_run_inputs(inputs, inputs_file)
+    runnable_config = _resolve_runnable_config(config, config_file)
+    evaluation_payload = _resolve_evaluation_payload(evaluation, evaluation_file)
+    from orcheo_sdk.cli import workflow as workflow_module
+
+    graph_config = (
+        workflow_module._prepare_streaming_graph(state, workflow_id) if stream else None
+    )
+    if graph_config is None:
+        raise CLIError(
+            "Evaluation requires streaming mode; unable to load workflow graph."
+        )
+
+    final_status = asyncio.run(
+        workflow_module._stream_workflow_evaluation(
+            state,
+            workflow_id,
+            graph_config,
+            input_payload,
+            evaluation_payload,
+            triggered_by=triggered_by,
+            runnable_config=runnable_config,
+        )
+    )
+    if final_status in {"error", "cancelled", "connection_error", "timeout"}:
+        raise CLIError(f"Workflow evaluation failed with status: {final_status}")
 
 
 __all__ = ["run_workflow"]

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
@@ -114,6 +114,23 @@ def _resolve_runnable_config(
     return None
 
 
+def _resolve_evaluation_payload(
+    evaluation: str | None,
+    evaluation_file: str | None,
+) -> dict[str, Any]:
+    """Resolve an evaluation payload from inline JSON or file."""
+    if not evaluation and not evaluation_file:
+        raise CLIError("Provide --evaluation or --evaluation-file for evaluation runs.")
+    if evaluation and evaluation_file:
+        raise CLIError("Provide either --evaluation or --evaluation-file, not both.")
+    if evaluation:
+        payload = _load_inputs_from_string(evaluation)
+    else:
+        assert evaluation_file is not None
+        payload = _load_inputs_from_path(evaluation_file)
+    return dict(payload)
+
+
 def _cache_notice(state: CLIState, subject: str, stale: bool) -> None:
     """Display cache usage notice in the console."""
     note = "[yellow]Using cached data[/yellow]"
@@ -128,5 +145,6 @@ __all__ = [
     "_validate_local_path",
     "_load_inputs_from_path",
     "_resolve_runnable_config",
+    "_resolve_evaluation_payload",
     "_cache_notice",
 ]

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
@@ -87,6 +87,33 @@ def _load_inputs_from_path(path: str) -> Mapping[str, Any]:
     return data
 
 
+def _resolve_runnable_config(
+    config: str | None,
+    config_file: str | None,
+) -> dict[str, Any] | None:
+    """Resolve a runnable config from inline JSON or file."""
+    if not config and not config_file:
+        return None
+    if config and config_file:
+        raise CLIError("Provide either --config or --config-file, not both.")
+    if config:
+        try:
+            payload = json.loads(config)
+        except json.JSONDecodeError as exc:  # pragma: no cover - converted to CLIError
+            raise CLIError(f"Invalid JSON payload: {exc}") from exc
+        if not isinstance(payload, Mapping):
+            msg = "Runnable config payload must be a JSON object."
+            raise CLIError(msg)
+        return dict(payload)
+    if config_file:
+        path_obj = _validate_local_path(config_file, description="config")
+        data = json.loads(path_obj.read_text(encoding="utf-8"))
+        if not isinstance(data, Mapping):
+            raise CLIError("Runnable config payload must be a JSON object.")
+        return dict(data)
+    return None
+
+
 def _cache_notice(state: CLIState, subject: str, stale: bool) -> None:
     """Display cache usage notice in the console."""
     note = "[yellow]Using cached data[/yellow]"
@@ -100,5 +127,6 @@ __all__ = [
     "_load_inputs_from_string",
     "_validate_local_path",
     "_load_inputs_from_path",
+    "_resolve_runnable_config",
     "_cache_notice",
 ]

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/streaming.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/streaming.py
@@ -15,6 +15,7 @@ async def _stream_workflow_run(
     inputs: Mapping[str, Any],
     *,
     triggered_by: str | None = None,
+    runnable_config: Mapping[str, Any] | None = None,
 ) -> str:
     """Stream workflow execution via WebSocket and display node outputs."""
     import json
@@ -36,6 +37,8 @@ async def _stream_workflow_run(
     }
     if triggered_by is not None:
         payload["triggered_by"] = triggered_by
+    if runnable_config is not None:
+        payload["runnable_config"] = runnable_config
 
     state.console.print("[cyan]Starting workflow execution...[/cyan]")
     state.console.print(f"[dim]Execution ID: {execution_id}[/dim]\n")

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/streaming.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/streaming.py
@@ -78,6 +78,78 @@ async def _stream_workflow_run(
         return "websocket_error"
 
 
+async def _stream_workflow_evaluation(
+    state: CLIState,
+    workflow_id: str,
+    graph_config: dict[str, Any],
+    inputs: Mapping[str, Any],
+    evaluation: Mapping[str, Any],
+    *,
+    triggered_by: str | None = None,
+    runnable_config: Mapping[str, Any] | None = None,
+) -> str:
+    """Stream workflow evaluation via WebSocket."""
+    import json
+    import uuid
+    import websockets
+    from websockets import exceptions as ws_exceptions
+    from orcheo_sdk.cli import workflow as workflow_module
+
+    ws_base = state.client.base_url.replace("http://", "ws://").replace(
+        "https://", "wss://"
+    )
+    websocket_url = f"{ws_base}/ws/workflow/{workflow_id}"
+    execution_id = str(uuid.uuid4())
+    payload: dict[str, Any] = {
+        "type": "evaluate_workflow",
+        "graph_config": graph_config,
+        "inputs": dict(inputs),
+        "execution_id": execution_id,
+        "evaluation": evaluation,
+    }
+    if triggered_by is not None:
+        payload["triggered_by"] = triggered_by
+    if runnable_config is not None:
+        payload["runnable_config"] = runnable_config
+
+    state.console.print("[cyan]Starting workflow evaluation...[/cyan]")
+    state.console.print(f"[dim]Execution ID: {execution_id}[/dim]\n")
+
+    try:
+        async with websockets.connect(
+            websocket_url, open_timeout=5, close_timeout=5
+        ) as websocket:
+            await websocket.send(json.dumps(payload))
+            process_messages = getattr(
+                workflow_module,
+                "_process_stream_messages",
+                _process_stream_messages,
+            )
+            return await process_messages(state, websocket)
+    except (ConnectionRefusedError, OSError) as exc:
+        state.console.print(
+            "[red]Failed to connect to server.[/red]\n"
+            "[dim]Ensure the backend is running.[/dim]"
+        )
+        state.console.print(f"[dim]Error: {exc}[/dim]")
+        return "connection_error"
+    except getattr(workflow_module, "TimeoutError", TimeoutError):
+        state.console.print(
+            "[red]Timed out while connecting.[/red]\n"
+            "[dim]Retry once the server is reachable.[/dim]"
+        )
+        return "timeout"
+    except ws_exceptions.InvalidStatusCode as exc:  # type: ignore[attr-defined]
+        state.console.print(
+            f"[red]Server rejected connection (HTTP {exc.status_code}).[/red]\n"
+            "[dim]Verify the workflow ID and backend availability.[/dim]"
+        )
+        return f"http_{exc.status_code}"
+    except ws_exceptions.WebSocketException as exc:
+        state.console.print(f"[red]WebSocket error: {exc}[/red]")
+        return "websocket_error"
+
+
 async def _process_stream_messages(state: CLIState, websocket: Any) -> str:
     """Process streaming messages from WebSocket."""
     import json

--- a/packages/sdk/src/orcheo_sdk/client/executor.py
+++ b/packages/sdk/src/orcheo_sdk/client/executor.py
@@ -48,6 +48,7 @@ class HttpWorkflowExecutor:
         triggered_by: str,
         inputs: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
+        runnable_config: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create a workflow run and return the backend payload."""
         url = self.client.workflow_trigger_url(workflow_id)
@@ -57,6 +58,8 @@ class HttpWorkflowExecutor:
             "triggered_by": triggered_by,
             "input_payload": dict(inputs or {}),
         }
+        if runnable_config is not None:
+            payload["runnable_config"] = runnable_config
 
         attempt = 0
         delay = self.backoff_factor

--- a/packages/sdk/src/orcheo_sdk/mcp_server/tools/workflow.py
+++ b/packages/sdk/src/orcheo_sdk/mcp_server/tools/workflow.py
@@ -37,6 +37,7 @@ def run_workflow(
     workflow_id: str,
     inputs: dict[str, Any] | None = None,
     triggered_by: str = "mcp",
+    runnable_config: dict[str, Any] | None = None,
     profile: str | None = None,
 ) -> dict[str, Any]:
     """Trigger a workflow execution using the latest version."""
@@ -47,6 +48,7 @@ def run_workflow(
         settings.service_token,
         inputs=inputs,
         triggered_by=triggered_by,
+        runnable_config=runnable_config,
     )
 
 

--- a/packages/sdk/src/orcheo_sdk/services/workflows/execution.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/execution.py
@@ -13,6 +13,7 @@ def run_workflow_data(
     service_token: str | None,
     inputs: dict[str, Any] | None = None,
     triggered_by: str = "api",
+    runnable_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Trigger workflow execution using the latest version."""
     from orcheo_sdk.client import HttpWorkflowExecutor, OrcheoClient
@@ -35,4 +36,5 @@ def run_workflow_data(
         workflow_version_id=version_id,
         triggered_by=triggered_by,
         inputs=inputs or {},
+        runnable_config=runnable_config,
     )

--- a/src/orcheo/agentensor/__init__.py
+++ b/src/orcheo/agentensor/__init__.py
@@ -1,10 +1,25 @@
 """Integration helpers for the vendored agentensor package."""
 
+from orcheo.agentensor.checkpoints import (
+    AgentensorCheckpoint,
+    AgentensorCheckpointNotFoundError,
+    AgentensorCheckpointStore,
+)
 from orcheo.agentensor.prompts import (
     TrainablePrompt,
     TrainablePrompts,
     build_text_tensors,
 )
+from orcheo.agentensor.training import OptimizerConfig, TrainingRequest
 
 
-__all__ = ["TrainablePrompt", "TrainablePrompts", "build_text_tensors"]
+__all__ = [
+    "AgentensorCheckpoint",
+    "AgentensorCheckpointNotFoundError",
+    "AgentensorCheckpointStore",
+    "OptimizerConfig",
+    "TrainablePrompt",
+    "TrainablePrompts",
+    "TrainingRequest",
+    "build_text_tensors",
+]

--- a/src/orcheo/agentensor/checkpoints.py
+++ b/src/orcheo/agentensor/checkpoints.py
@@ -1,0 +1,82 @@
+"""Checkpoint models shared across Agentensor training flows."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+from uuid import uuid4
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+    return datetime.now(tz=UTC)
+
+
+class AgentensorCheckpoint(BaseModel):
+    """Concrete checkpoint record persisted by the trainer.
+
+    The optional ``artifact_url`` can reference external artifacts (e.g., files in
+    object storage) produced during training; it remains unset in Milestone 3 while
+    metrics/config snapshots are persisted inline.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    workflow_id: str = Field(max_length=128, min_length=1)
+    config_version: int = Field(ge=1)
+    runnable_config: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    artifact_url: str | None = Field(
+        default=None, description="Optional link to external checkpoint artifacts."
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    is_best: bool = False
+
+
+@runtime_checkable
+class AgentensorCheckpointStore(Protocol):
+    """Persistence interface for trainer checkpoints."""
+
+    async def record_checkpoint(
+        self,
+        *,
+        workflow_id: str,
+        runnable_config: Mapping[str, Any],
+        metrics: Mapping[str, Any],
+        metadata: Mapping[str, Any] | None = None,
+        artifact_url: str | None = None,
+        is_best: bool = False,
+        config_version: int | None = None,
+    ) -> AgentensorCheckpoint:
+        """Persist a checkpoint with an auto-incremented config version."""
+
+    async def list_checkpoints(
+        self,
+        workflow_id: str,
+        *,
+        limit: int | None = None,
+    ) -> list[AgentensorCheckpoint]:
+        """Return checkpoints associated with a workflow ordered by version."""
+
+    async def get_checkpoint(self, checkpoint_id: str) -> AgentensorCheckpoint:
+        """Return a checkpoint by identifier or raise if missing."""
+
+    async def latest_checkpoint(
+        self,
+        workflow_id: str,
+    ) -> AgentensorCheckpoint | None:
+        """Return the most recent checkpoint for the workflow if present."""
+
+
+class AgentensorCheckpointNotFoundError(RuntimeError):
+    """Raised when the requested checkpoint does not exist."""
+
+
+__all__ = [
+    "AgentensorCheckpoint",
+    "AgentensorCheckpointNotFoundError",
+    "AgentensorCheckpointStore",
+]

--- a/src/orcheo/agentensor/evaluation.py
+++ b/src/orcheo/agentensor/evaluation.py
@@ -1,0 +1,95 @@
+"""Evaluation schemas and helpers for Agentensor."""
+
+from __future__ import annotations
+import importlib
+import inspect
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+@dataclass
+class EvaluationContext:
+    """Context passed to evaluator callables."""
+
+    inputs: dict[str, Any]
+    output: Any
+    expected_output: Any
+    metadata: dict[str, Any]
+    duration_ms: float
+
+
+class EvaluationCase(BaseModel):
+    """Single evaluation case containing inputs and optional expectations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    expected_output: Any = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvaluationDataset(BaseModel):
+    """Dataset wrapper for evaluation cases."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | None = None
+    cases: list[EvaluationCase] = Field(default_factory=list)
+
+    @field_validator("cases")
+    @classmethod
+    def _ensure_cases(cls, value: list[EvaluationCase]) -> list[EvaluationCase]:
+        if not value:
+            msg = "At least one evaluation case is required."
+            raise ValueError(msg)
+        return value
+
+
+class EvaluatorDefinition(BaseModel):
+    """Reference to an evaluator callable or class."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    entrypoint: str
+    config: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("entrypoint")
+    @classmethod
+    def _validate_entrypoint(cls, value: str) -> str:
+        if ":" not in value:
+            msg = "Entrypoint must be in the form 'module:attribute'."
+            raise ValueError(msg)
+        return value
+
+    def load(self) -> Any:
+        """Materialize the evaluator from the entrypoint string."""
+        module_path, attr = self.entrypoint.split(":", 1)
+        module = importlib.import_module(module_path)
+        target = getattr(module, attr)
+        if inspect.isclass(target):
+            return target(**self.config) if self.config else target()
+        if self.config:
+            return partial(target, **self.config)
+        return target
+
+
+class EvaluationRequest(BaseModel):
+    """Top-level request payload for an evaluation run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset: EvaluationDataset
+    evaluators: list[EvaluatorDefinition] = Field(default_factory=list)
+    max_cases: int | None = Field(default=None, gt=0)
+
+
+__all__ = [
+    "EvaluationCase",
+    "EvaluationContext",
+    "EvaluationDataset",
+    "EvaluationRequest",
+    "EvaluatorDefinition",
+]

--- a/src/orcheo/agentensor/training.py
+++ b/src/orcheo/agentensor/training.py
@@ -1,0 +1,36 @@
+"""Training payload schemas for AgentensorNode."""
+
+from __future__ import annotations
+from pydantic import BaseModel, ConfigDict, Field
+from orcheo.agentensor.evaluation import EvaluationDataset, EvaluatorDefinition
+
+
+_MAX_EPOCHS = 50
+_MAX_CHECKPOINT_INTERVAL = 100
+_MAX_CASE_TIMEOUT = 300
+_MAX_TRAIN_CONCURRENCY = 16
+
+
+class OptimizerConfig(BaseModel):
+    """Configuration for the training optimizer loop."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    epochs: int = Field(default=3, ge=1, le=_MAX_EPOCHS)
+    checkpoint_interval: int = Field(default=1, ge=1, le=_MAX_CHECKPOINT_INTERVAL)
+    case_timeout_seconds: int = Field(default=30, ge=1, le=_MAX_CASE_TIMEOUT)
+    max_concurrency: int = Field(default=4, ge=1, le=_MAX_TRAIN_CONCURRENCY)
+
+
+class TrainingRequest(BaseModel):
+    """Top-level request payload for a training run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset: EvaluationDataset
+    evaluators: list[EvaluatorDefinition] = Field(default_factory=list)
+    optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
+    max_cases: int | None = Field(default=None, gt=0)
+
+
+__all__ = ["OptimizerConfig", "TrainingRequest"]

--- a/src/orcheo/edges/base.py
+++ b/src/orcheo/edges/base.py
@@ -17,7 +17,7 @@ class BaseEdge(BaseRunnable):
 
     async def __call__(self, state: State, config: RunnableConfig) -> str | list[Send]:
         """Execute the edge and return the routing decision."""
-        self.decode_variables(state)
+        self.decode_variables(state, config=config)
         result = await self.run(state, config)
         return result
 

--- a/src/orcheo/graph/state.py
+++ b/src/orcheo/graph/state.py
@@ -11,6 +11,7 @@ class State(MessagesState):
     inputs: dict[str, Any]
     results: Annotated[dict[str, Any], dict_reducer]
     structured_response: Any
+    config: dict[str, Any] | None
 
 
 def dict_reducer(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:

--- a/src/orcheo/models/workflow_entities.py
+++ b/src/orcheo/models/workflow_entities.py
@@ -194,6 +194,11 @@ class WorkflowRun(TimestampedAuditModel):
     status: WorkflowRunStatus = Field(default=WorkflowRunStatus.PENDING)
     triggered_by: str
     input_payload: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    callbacks: list[Any] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    run_name: str | None = None
     output_payload: dict[str, Any] | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -1,5 +1,6 @@
 """Node registry and metadata definitions for Orcheo."""
 
+from orcheo.nodes.agentensor import AgentensorNode
 from orcheo.nodes.ai import AgentNode
 from orcheo.nodes.code import PythonCode
 from orcheo.nodes.communication import DiscordWebhookNode, EmailNode
@@ -44,6 +45,7 @@ __all__ = [
     "NodeRegistry",
     "registry",
     "AgentNode",
+    "AgentensorNode",
     "PythonCode",
     "HttpRequestNode",
     "JsonProcessingNode",

--- a/src/orcheo/nodes/agentensor.py
+++ b/src/orcheo/nodes/agentensor.py
@@ -1,0 +1,50 @@
+"""Agentensor evaluation/training node placeholder."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
+from pydantic import Field
+from orcheo.agentensor.prompts import TrainablePrompts
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.registry import NodeMetadata, registry
+
+
+@registry.register(
+    NodeMetadata(
+        name="AgentensorNode",
+        description=(
+            "Evaluate or train agent prompts using Agentensor datasets and evaluators."
+        ),
+        category="agentensor",
+    )
+)
+class AgentensorNode(TaskNode):
+    """Node shell for Agentensor evaluation and training flows."""
+
+    mode: Literal["evaluate", "train"] = "evaluate"
+    prompts: TrainablePrompts = Field(
+        default_factory=dict,
+        description="Trainable prompt definitions resolved from runnable configs.",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return resolved prompts and selected mode as a placeholder result."""
+        resolved_prompts = {
+            name: prompt.model_dump(mode="json")
+            for name, prompt in self.prompts.items()
+        }
+        tag_payload: list[str] | None = None
+        if isinstance(config, Mapping):
+            tags = config.get("tags")
+            if isinstance(tags, list):
+                tag_payload = [str(tag) for tag in tags]
+        return {
+            "mode": self.mode,
+            "prompts": resolved_prompts,
+            "tags": tag_payload or [],
+        }
+
+
+__all__ = ["AgentensorNode"]

--- a/src/orcheo/nodes/agentensor.py
+++ b/src/orcheo/nodes/agentensor.py
@@ -1,14 +1,33 @@
-"""Agentensor evaluation/training node placeholder."""
+"""Agentensor evaluation/training node."""
 
 from __future__ import annotations
-from collections.abc import Mapping
-from typing import Any, Literal
+import asyncio
+import inspect
+import logging
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, Literal, cast
 from langchain_core.runnables import RunnableConfig
-from pydantic import Field
-from orcheo.agentensor.prompts import TrainablePrompts
+from pydantic import ConfigDict, Field
+from orcheo.agentensor.checkpoints import (
+    AgentensorCheckpoint,
+    AgentensorCheckpointStore,
+)
+from orcheo.agentensor.evaluation import (
+    EvaluationCase,
+    EvaluationContext,
+    EvaluationDataset,
+    EvaluatorDefinition,
+)
+from orcheo.agentensor.prompts import TrainablePrompts, build_text_tensors
+from orcheo.agentensor.training import OptimizerConfig
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
+
+
+logger = logging.getLogger(__name__)
 
 
 @registry.register(
@@ -23,28 +42,616 @@ from orcheo.nodes.registry import NodeMetadata, registry
 class AgentensorNode(TaskNode):
     """Node shell for Agentensor evaluation and training flows."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     mode: Literal["evaluate", "train"] = "evaluate"
     prompts: TrainablePrompts = Field(
         default_factory=dict,
         description="Trainable prompt definitions resolved from runnable configs.",
     )
+    dataset: EvaluationDataset | None = Field(
+        default=None,
+        description="Dataset of cases to evaluate (optional for prompt-only runs).",
+    )
+    evaluators: list[EvaluatorDefinition] = Field(
+        default_factory=list,
+        description="Evaluators applied to each case output.",
+    )
+    max_cases: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional cap on the number of cases to run.",
+    )
+    compiled_graph: Any | None = Field(
+        default=None,
+        exclude=True,
+        description="Compiled LangGraph used for evaluation.",
+    )
+    graph_config: Mapping[str, Any] | None = Field(
+        default=None,
+        exclude=True,
+        description="Graph config to shape evaluation state.",
+    )
+    state_config: Mapping[str, Any] | None = Field(
+        default=None,
+        exclude=True,
+        description="Runnable config injected into evaluation state.",
+    )
+    progress_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = Field(
+        default=None,
+        exclude=True,
+        description="Optional hook for streaming evaluation progress.",
+    )
+    optimizer: OptimizerConfig = Field(
+        default_factory=OptimizerConfig,
+        description="Training optimizer configuration when mode='train'.",
+    )
+    checkpoint_store: AgentensorCheckpointStore | None = Field(
+        default=None,
+        exclude=True,
+        description="Optional persistence layer for training checkpoints.",
+    )
+    workflow_id: str | None = Field(
+        default=None,
+        description="Workflow identifier used to persist checkpoints.",
+    )
+
+    _max_concurrency_cap = 8
 
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
-        """Return resolved prompts and selected mode as a placeholder result."""
+        """Execute the configured evaluation or return prompt metadata."""
         resolved_prompts = {
             name: prompt.model_dump(mode="json")
             for name, prompt in self.prompts.items()
         }
+        if self.state_config is None and isinstance(state, Mapping):
+            maybe_config = state.get("config")
+            if isinstance(maybe_config, Mapping):
+                self.state_config = maybe_config
         tag_payload: list[str] | None = None
         if isinstance(config, Mapping):
             tags = config.get("tags")
             if isinstance(tags, list):
                 tag_payload = [str(tag) for tag in tags]
-        return {
+        result_base = {
             "mode": self.mode,
             "prompts": resolved_prompts,
             "tags": tag_payload or [],
         }
+        if self.mode == "train":
+            return await self._run_training(state, config, result_base)
+        if self.mode != "evaluate":
+            return result_base
+        if self.dataset is None or not self.dataset.cases:
+            return result_base | {"summary": {}, "results": []}
+
+        compiled_graph = self._require_compiled_graph()
+        evaluators = self._resolve_evaluators()
+        cases = list(self.dataset.cases)
+        if self.max_cases is not None:
+            cases = cases[: self.max_cases]
+        aggregated: dict[str, list[float]] = {
+            definition.id: [] for definition, _ in evaluators
+        }
+        case_results: list[dict[str, Any]] = []
+        for index, case in enumerate(cases):
+            case_inputs = self._merge_inputs(state, case)
+            start = time.perf_counter()
+            output_state = await compiled_graph.ainvoke(
+                self._build_case_state(case_inputs),
+                config=config,
+            )
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            output_payload = self._extract_output(output_state)
+            context = EvaluationContext(
+                inputs=case_inputs,
+                output=output_payload,
+                expected_output=case.expected_output,
+                metadata=case.metadata,
+                duration_ms=duration_ms,
+            )
+            evaluations = await self._evaluate_case(
+                evaluators, context, aggregated=aggregated
+            )
+            case_result = {
+                "case_index": index,
+                "inputs": case_inputs,
+                "output": output_payload,
+                "evaluations": evaluations,
+                "metadata": case.metadata,
+                "duration_ms": duration_ms,
+            }
+            case_results.append(case_result)
+            await self._emit_progress(
+                {
+                    "node": self.name,
+                    "event": "evaluation_progress",
+                    "payload": case_result,
+                }
+            )
+
+        summary = self._summarize_metrics(aggregated)
+        summary_payload = {
+            "node": self.name,
+            "event": "evaluation_summary",
+            "payload": {
+                "dataset_id": self.dataset.id,
+                "summary": summary,
+                "cases_ran": len(case_results),
+            },
+        }
+        await self._emit_progress(summary_payload)
+
+        return result_base | {
+            "dataset_id": self.dataset.id,
+            "summary": summary,
+            "results": case_results,
+        }
+
+    async def _run_training(
+        self,
+        state: State,
+        config: RunnableConfig,
+        result_base: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self.dataset is None or not self.dataset.cases:
+            return result_base | {
+                "summary": {},
+                "results": [],
+                "checkpoints": [],
+            }
+
+        trainable_prompts = [
+            name
+            for name, prompt in self.prompts.items()
+            if getattr(prompt, "requires_grad", False)
+        ]
+        if not trainable_prompts:
+            msg = (
+                "AgentensorNode training requires at least one prompt with "
+                "requires_grad=True."
+            )
+            raise ValueError(msg)
+
+        compiled_graph = self._require_compiled_graph()
+        evaluators = self._resolve_evaluators()
+        cases = list(self.dataset.cases)
+        if self.max_cases is not None:
+            cases = cases[: self.max_cases]
+
+        capped_config = self._enforce_training_limits(config)
+        checkpoints: list[dict[str, Any]] = []
+        best_checkpoint: AgentensorCheckpoint | None = None
+        best_score: float = -1.0
+        all_results: list[dict[str, Any]] = []
+
+        for epoch in range(1, self.optimizer.epochs + 1):
+            runtime_prompts = build_text_tensors(self.prompts)
+            self._refresh_state_prompts(runtime_prompts)
+
+            aggregated: dict[str, list[float]] = {
+                definition.id: [] for definition, _ in evaluators
+            }
+            case_results = await self._run_training_cases(
+                cases,
+                compiled_graph,
+                capped_config,
+                runtime_prompts,
+                evaluators,
+                aggregated=aggregated,
+                epoch=epoch,
+                state=state,
+            )
+            all_results.extend(case_results)
+            summary = self._summarize_metrics(aggregated)
+            self._apply_optimizer(runtime_prompts)
+            score = self._score_summary(summary)
+            should_checkpoint = (
+                epoch % max(1, self.optimizer.checkpoint_interval) == 0
+                or epoch == self.optimizer.epochs
+            )
+            checkpoint_obj: AgentensorCheckpoint | None = None
+            if should_checkpoint:
+                checkpoint_obj = await self._emit_checkpoint(
+                    summary,
+                    capped_config,
+                    epoch=epoch,
+                    is_best=score >= best_score,
+                )
+                checkpoints.append(checkpoint_obj.model_dump(mode="json"))
+                await self._emit_progress(
+                    {
+                        "node": self.name,
+                        "event": "training_checkpoint",
+                        "payload": checkpoint_obj.model_dump(mode="json"),
+                    }
+                )
+
+            if score >= best_score:
+                best_score = score
+                if checkpoint_obj is None:
+                    checkpoint_obj = await self._emit_checkpoint(
+                        summary,
+                        capped_config,
+                        epoch=epoch,
+                        is_best=True,
+                    )
+                    checkpoints.append(checkpoint_obj.model_dump(mode="json"))
+                best_checkpoint = checkpoint_obj
+
+            await self._emit_progress(
+                {
+                    "node": self.name,
+                    "event": "training_epoch_complete",
+                    "payload": {
+                        "epoch": epoch,
+                        "summary": summary,
+                    },
+                }
+            )
+
+        best_payload = (
+            best_checkpoint.model_dump(mode="json") if best_checkpoint else None
+        )
+        trained_prompts = {
+            name: prompt.model_dump(mode="json")
+            for name, prompt in self.prompts.items()
+        }
+        return result_base | {
+            "dataset_id": self.dataset.id,
+            "summary": best_payload["metrics"] if best_payload else {},
+            "results": all_results,
+            "checkpoints": checkpoints,
+            "best_checkpoint": best_payload,
+            "prompts": trained_prompts,
+        }
+
+    async def _evaluate_case(
+        self,
+        evaluators: Sequence[tuple[EvaluatorDefinition, Any]],
+        context: EvaluationContext,
+        *,
+        aggregated: dict[str, list[float]],
+    ) -> dict[str, dict[str, Any]]:
+        evaluations: dict[str, dict[str, Any]] = {}
+        for definition, evaluator in evaluators:
+            outcome = await self._run_evaluator(definition, evaluator, context)
+            evaluations[definition.id] = outcome
+            aggregated.setdefault(definition.id, []).append(outcome["score"])
+        return evaluations
+
+    async def _run_evaluator(
+        self,
+        definition: EvaluatorDefinition,
+        evaluator: Any,
+        context: EvaluationContext,
+    ) -> dict[str, Any]:
+        try:
+            if hasattr(evaluator, "evaluate"):
+                candidate = evaluator.evaluate(context)
+            else:
+                candidate = evaluator(context)
+            result = await candidate if inspect.iscoroutine(candidate) else candidate
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Evaluator %s failed while scoring case.", definition.id, exc_info=exc
+            )
+            return {"score": 0.0, "passed": False, "reason": str(exc)}
+
+        return self._normalise_evaluation_result(result)
+
+    @staticmethod
+    def _normalise_evaluation_result(result: Any) -> dict[str, Any]:
+        score: float | None = None
+        reason: str | None = None
+        value: Any = result
+
+        if hasattr(result, "value"):
+            value = result.value  # type: ignore[attr-defined]
+            reason = result.reason if hasattr(result, "reason") else None
+        elif isinstance(result, Mapping):
+            if "value" in result:
+                value = result["value"]
+            reason = result.get("reason")
+
+        if isinstance(value, bool):
+            score = 1.0 if value else 0.0
+            passed = value
+        elif isinstance(value, int | float):
+            score = float(value)
+            passed = score >= 0.5
+        else:
+            passed = False if value is None else bool(value)
+
+        if score is None:
+            score = 1.0 if passed else 0.0
+        return {"score": score, "passed": passed, "reason": reason}
+
+    def _summarize_metrics(
+        self, aggregated: Mapping[str, list[float]]
+    ) -> dict[str, float]:
+        summary: dict[str, float] = {}
+        for evaluator_id, scores in aggregated.items():
+            if scores:
+                summary[evaluator_id] = sum(scores) / len(scores)
+            else:
+                summary[evaluator_id] = 0.0
+        return summary
+
+    async def _emit_progress(self, payload: dict[str, Any]) -> None:
+        if self.progress_callback is None:
+            return
+        await self.progress_callback(payload)
+
+    def _merge_inputs(self, state: State, case: EvaluationCase) -> dict[str, Any]:
+        base_inputs: Mapping[str, Any] | None = None
+        if isinstance(state, Mapping):
+            if "inputs" in state and isinstance(state["inputs"], Mapping):
+                base_inputs = state["inputs"]
+            else:
+                base_inputs = state
+        merged: dict[str, Any] = {}
+        if isinstance(base_inputs, Mapping):
+            merged.update(base_inputs)
+        merged.update(case.inputs)
+        return merged
+
+    def _build_case_state(self, inputs: Mapping[str, Any]) -> dict[str, Any]:
+        runtime_config: Mapping[str, Any] = (
+            dict(self.state_config) if isinstance(self.state_config, Mapping) else {}
+        )
+        if (
+            self.graph_config
+            and isinstance(self.graph_config, Mapping)
+            and self.graph_config.get("format") == LANGGRAPH_SCRIPT_FORMAT
+        ):
+            state = dict(inputs)
+            state["config"] = runtime_config
+            return state
+        return {
+            "messages": [],
+            "results": {},
+            "inputs": dict(inputs),
+            "structured_response": None,
+            "config": runtime_config,
+        }
+
+    @staticmethod
+    def _extract_output(output_state: Any) -> Any:
+        if isinstance(output_state, Mapping):
+            if "results" in output_state:
+                return output_state["results"]
+            if "output" in output_state:
+                return output_state["output"]
+        return output_state
+
+    def _require_compiled_graph(self) -> Any:
+        if self.compiled_graph is None:
+            msg = "AgentensorNode evaluation requires a compiled graph."
+            raise ValueError(msg)
+        return self.compiled_graph
+
+    def _enforce_training_limits(self, config: RunnableConfig) -> RunnableConfig:
+        if not isinstance(config, Mapping):
+            return config
+        updated = dict(config)
+        allowed_concurrency = min(
+            self.optimizer.max_concurrency, self._max_concurrency_cap
+        )
+        max_concurrency = updated.get("max_concurrency")
+        if not isinstance(max_concurrency, int) or (
+            max_concurrency > allowed_concurrency
+        ):
+            updated["max_concurrency"] = allowed_concurrency
+        recursion_limit = updated.get("recursion_limit")
+        if not isinstance(recursion_limit, int):
+            updated["recursion_limit"] = 50
+        return cast(RunnableConfig, updated)
+
+    def _resolve_evaluators(self) -> list[tuple[EvaluatorDefinition, Any]]:
+        resolved: list[tuple[EvaluatorDefinition, Any]] = []
+        for definition in self.evaluators:
+            evaluator = definition.load()
+            resolved.append((definition, evaluator))
+        return resolved
+
+    def _refresh_state_prompts(self, prompts: Mapping[str, Any]) -> None:
+        if not prompts:
+            return
+        base_config = (
+            dict(self.state_config) if isinstance(self.state_config, Mapping) else {}
+        )
+        base_config["prompts"] = prompts
+        self.state_config = base_config
+
+    async def _run_training_cases(
+        self,
+        cases: Sequence[EvaluationCase],
+        compiled_graph: Any,
+        config: RunnableConfig,
+        runtime_prompts: Mapping[str, Any],
+        evaluators: Sequence[tuple[EvaluatorDefinition, Any]],
+        *,
+        aggregated: dict[str, list[float]],
+        epoch: int,
+        state: State,
+    ) -> list[dict[str, Any]]:
+        case_results: list[dict[str, Any]] = []
+        for index, case in enumerate(cases):
+            case_inputs = self._merge_inputs(state, case)
+            start = time.perf_counter()
+            try:
+                output_state = await asyncio.wait_for(
+                    compiled_graph.ainvoke(
+                        self._build_case_state(case_inputs),
+                        config=config,
+                    ),
+                    timeout=self.optimizer.case_timeout_seconds,
+                )
+            except TimeoutError:
+                duration_ms = (time.perf_counter() - start) * 1000.0
+                case_result = {
+                    "case_index": index,
+                    "epoch": epoch,
+                    "error": "timeout",
+                    "duration_ms": duration_ms,
+                    "evaluations": {},
+                }
+                case_results.append(case_result)
+                await self._emit_progress(
+                    {
+                        "node": self.name,
+                        "event": "training_progress",
+                        "payload": case_result,
+                    }
+                )
+                continue
+            except Exception as exc:  # pragma: no cover - defensive
+                duration_ms = (time.perf_counter() - start) * 1000.0
+                failure_reason = str(exc)
+                evaluations = {
+                    definition.id: {
+                        "score": 0.0,
+                        "passed": False,
+                        "reason": failure_reason,
+                    }
+                    for definition, _ in evaluators
+                }
+                for definition in evaluations:
+                    aggregated.setdefault(definition, []).append(0.0)
+                case_result = {
+                    "case_index": index,
+                    "epoch": epoch,
+                    "error": failure_reason,
+                    "duration_ms": duration_ms,
+                    "evaluations": evaluations,
+                }
+                case_results.append(case_result)
+                await self._emit_progress(
+                    {
+                        "node": self.name,
+                        "event": "training_progress",
+                        "payload": case_result,
+                    }
+                )
+                continue
+
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            output_payload = self._extract_output(output_state)
+            context = EvaluationContext(
+                inputs=case_inputs,
+                output=output_payload,
+                expected_output=case.expected_output,
+                metadata=case.metadata,
+                duration_ms=duration_ms,
+            )
+            evaluations = await self._evaluate_case(
+                evaluators, context, aggregated=aggregated
+            )
+            self._apply_gradients(runtime_prompts, evaluations)
+            case_result = {
+                "case_index": index,
+                "epoch": epoch,
+                "inputs": case_inputs,
+                "output": output_payload,
+                "evaluations": evaluations,
+                "metadata": case.metadata,
+                "duration_ms": duration_ms,
+            }
+            case_results.append(case_result)
+            await self._emit_progress(
+                {
+                    "node": self.name,
+                    "event": "training_progress",
+                    "payload": case_result,
+                }
+            )
+        return case_results
+
+    def _apply_gradients(
+        self, prompts: Mapping[str, Any], evaluations: Mapping[str, Mapping[str, Any]]
+    ) -> None:
+        feedback: list[str] = []
+        for evaluation in evaluations.values():
+            if evaluation.get("passed") is True:
+                continue
+            reason = evaluation.get("reason")
+            if reason:
+                feedback.append(str(reason))
+        if not feedback:
+            return
+        gradient = " ".join(feedback)
+        for prompt in prompts.values():
+            backward = getattr(prompt, "backward", None)
+            if backward is None:
+                continue
+            backward(gradient)
+
+    def _apply_optimizer(self, prompts: Mapping[str, Any]) -> None:
+        for name, prompt in prompts.items():
+            grad = getattr(prompt, "text_grad", "")
+            requires_grad = getattr(prompt, "requires_grad", False)
+            if not requires_grad or not grad:
+                continue
+            base_prompt = self.prompts.get(name)
+            if base_prompt is None:
+                continue
+            updated_text = self._rewrite_prompt(base_prompt.text, grad)
+            base_prompt.text = updated_text
+            reset = getattr(prompt, "zero_grad", None)
+            if reset is not None:
+                reset()
+
+    @staticmethod
+    def _rewrite_prompt(text: str, grad: str) -> str:
+        cleaned_grad = " ".join(str(grad).split())
+        if not cleaned_grad:
+            return text
+        if cleaned_grad in text:
+            return text
+        return f"{text.strip()}\n\n[feedback] {cleaned_grad}".strip()
+
+    def _score_summary(self, summary: Mapping[str, float]) -> float:
+        if not summary:
+            return 0.0
+        return sum(summary.values()) / len(summary)
+
+    async def _emit_checkpoint(
+        self,
+        summary: Mapping[str, float],
+        config: RunnableConfig,
+        *,
+        epoch: int,
+        is_best: bool,
+    ) -> AgentensorCheckpoint:
+        checkpoint_config = self._checkpoint_config(config)
+        metadata = {"epoch": epoch, "summary": dict(summary)}
+        if self.checkpoint_store is not None and self.workflow_id is not None:
+            return await self.checkpoint_store.record_checkpoint(
+                workflow_id=self.workflow_id,
+                runnable_config=checkpoint_config,
+                metrics=summary,
+                metadata=metadata,
+                is_best=is_best,
+            )
+
+        return AgentensorCheckpoint(
+            workflow_id=self.workflow_id or "unknown",
+            config_version=epoch,
+            runnable_config=checkpoint_config,
+            metrics=dict(summary),
+            metadata=metadata,
+            is_best=is_best,
+        )
+
+    def _checkpoint_config(self, config: RunnableConfig) -> dict[str, Any]:
+        base_config = dict(config) if isinstance(config, Mapping) else {}
+        if self.prompts:
+            base_config["prompts"] = {
+                name: prompt.model_dump(mode="json")
+                for name, prompt in self.prompts.items()
+            }
+        return base_config
 
 
 __all__ = ["AgentensorNode"]

--- a/src/orcheo/nodes/sub_workflow.py
+++ b/src/orcheo/nodes/sub_workflow.py
@@ -50,6 +50,7 @@ class SubWorkflowNode(TaskNode):
                 "results": copy.deepcopy(state.get("results", {})),
                 "messages": list(state.get("messages", [])),
                 "structured_response": state.get("structured_response"),
+                "config": state.get("config"),
             }
         )
 

--- a/src/orcheo/runtime/runnable_config.py
+++ b/src/orcheo/runtime/runnable_config.py
@@ -1,0 +1,179 @@
+"""Utilities for validating and merging ``RunnableConfig`` payloads."""
+
+from __future__ import annotations
+import json
+from collections.abc import Mapping
+from typing import Any, cast
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from orcheo.agentensor.prompts import TrainablePrompt, TrainablePrompts
+
+
+# Conservative limits to guard against runaway graphs.
+_MAX_RECURSION_LIMIT = 100
+_MAX_CONCURRENCY = 32
+
+
+def _ensure_json_serialisable(value: Any, *, field_name: str) -> Any:
+    """Raise a validation error when the value cannot be JSON-serialised."""
+    try:
+        json.dumps(value)
+    except TypeError as exc:
+        msg = f"{field_name} must be JSON serialisable"
+        raise ValueError(msg) from exc
+    return value
+
+
+class RunnableConfigModel(BaseModel):
+    """Validated representation of a user-supplied ``RunnableConfig``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    configurable: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    callbacks: list[Any] = Field(default_factory=list)
+    run_name: str | None = None
+    recursion_limit: int | None = Field(
+        default=None,
+        ge=1,
+        le=_MAX_RECURSION_LIMIT,
+        description="Maximum recursion depth allowed for the graph.",
+    )
+    max_concurrency: int | None = Field(
+        default=None,
+        ge=1,
+        le=_MAX_CONCURRENCY,
+        description="Maximum concurrent tasks allowed for the graph.",
+    )
+    prompts: TrainablePrompts | None = None
+
+    @field_validator("configurable", "metadata")
+    @classmethod
+    def _validate_serialisable_mapping(
+        cls, value: dict[str, Any], info: ValidationInfo
+    ) -> dict[str, Any]:
+        field_name = info.field_name or "field"
+        _ensure_json_serialisable(value, field_name=field_name)
+        return value
+
+    @field_validator("callbacks")
+    @classmethod
+    def _validate_callbacks(cls, value: list[Any]) -> list[Any]:
+        _ensure_json_serialisable(value, field_name="callbacks")
+        return value
+
+    @field_validator("tags", mode="after")
+    @classmethod
+    def _normalise_tags(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for tag in value:
+            normalized = tag.strip()
+            if not normalized:
+                continue
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(normalized)
+        return deduped
+
+    @field_validator("run_name")
+    @classmethod
+    def _normalise_run_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        candidate = value.strip()
+        return candidate or None
+
+    @field_validator("prompts", mode="after")
+    @classmethod
+    def _validate_prompts(
+        cls, prompts: TrainablePrompts | None
+    ) -> TrainablePrompts | None:
+        if prompts is None:
+            return None
+        for name, prompt in prompts.items():
+            if not isinstance(prompt, TrainablePrompt):
+                msg = f"Prompt '{name}' must be a TrainablePrompt."
+                raise ValueError(msg)
+        return prompts
+
+    def to_runnable_config(self, execution_id: str) -> RunnableConfig:
+        """Return a LangChain-compatible config merged with runtime defaults."""
+        configurable = dict(self.configurable)
+        configurable["thread_id"] = execution_id
+
+        config: dict[str, Any] = {"configurable": configurable}
+        if self.tags:
+            config["tags"] = list(self.tags)
+        if self.metadata:
+            config["metadata"] = dict(self.metadata)
+        if self.callbacks:
+            config["callbacks"] = list(self.callbacks)
+        if self.run_name is not None:
+            config["run_name"] = self.run_name
+        if self.recursion_limit is not None:
+            config["recursion_limit"] = self.recursion_limit
+        if self.max_concurrency is not None:
+            config["max_concurrency"] = self.max_concurrency
+        if self.prompts:
+            config["prompts"] = {
+                name: prompt.model_dump(mode="json")
+                for name, prompt in self.prompts.items()
+            }
+        return cast(RunnableConfig, config)
+
+    def to_state_config(self, execution_id: str) -> dict[str, Any]:
+        """Return a dict suitable for injecting into runtime state."""
+        configurable = dict(self.configurable)
+        configurable["thread_id"] = execution_id
+        state_config: dict[str, Any] = {
+            "configurable": configurable,
+            "tags": list(self.tags),
+            "metadata": dict(self.metadata),
+            "callbacks": list(self.callbacks),
+            "run_name": self.run_name,
+        }
+        if self.recursion_limit is not None:
+            state_config["recursion_limit"] = self.recursion_limit
+        if self.max_concurrency is not None:
+            state_config["max_concurrency"] = self.max_concurrency
+        if self.prompts:
+            state_config["prompts"] = {
+                name: prompt.model_copy(deep=True)
+                for name, prompt in self.prompts.items()
+            }
+        return state_config
+
+    def to_json_config(self, execution_id: str) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot of the merged config."""
+        state_config = self.to_state_config(execution_id)
+        serialized = {}
+        for key, value in state_config.items():
+            if key == "prompts" and isinstance(value, Mapping):
+                serialized[key] = {
+                    name: prompt.model_dump(mode="json")
+                    for name, prompt in value.items()
+                }
+            else:
+                serialized[key] = value
+        return serialized
+
+
+def parse_runnable_config(
+    value: Mapping[str, Any] | RunnableConfigModel | None,
+) -> RunnableConfigModel:
+    """Parse and validate a runnable config value."""
+    if value is None:
+        return RunnableConfigModel()
+    if isinstance(value, RunnableConfigModel):
+        return value
+    return RunnableConfigModel.model_validate(value)
+
+
+__all__ = [
+    "RunnableConfigModel",
+    "parse_runnable_config",
+]

--- a/tests/agentensor/test_agentensor_node.py
+++ b/tests/agentensor/test_agentensor_node.py
@@ -1,0 +1,55 @@
+"""Tests for AgentensorNode registration and prompt interpolation."""
+
+from __future__ import annotations
+from typing import Any, cast
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.agentensor.prompts import TrainablePrompt
+from orcheo.graph.state import State
+from orcheo.nodes.agentensor import AgentensorNode
+from orcheo.nodes.registry import registry
+from orcheo.runtime.runnable_config import RunnableConfigModel
+
+
+def _build_state_and_config() -> tuple[State, RunnableConfig]:
+    base_config = RunnableConfigModel(
+        prompts={"seed": TrainablePrompt(text="Hello world")},
+        tags=["experiment"],
+        run_name="agentensor-eval",
+    )
+    runtime_config = base_config.to_runnable_config("exec-agentensor")
+    state_config = base_config.to_state_config("exec-agentensor")
+    state = cast(
+        State,
+        {
+            "inputs": {"lang": "en"},
+            "results": {},
+            "structured_response": {},
+            "config": state_config,
+        },
+    )
+    return state, runtime_config
+
+
+@pytest.mark.asyncio
+async def test_agentensor_node_resolves_prompts_from_config() -> None:
+    state, runtime_config = _build_state_and_config()
+    node = AgentensorNode(
+        name="agentensor",
+        prompts={
+            "candidate": TrainablePrompt(
+                text="{{config.prompts.seed.text}}",
+                metadata={"lang": "{{inputs.lang}}"},
+                requires_grad=True,
+            )
+        },
+    )
+
+    result = await node(state, runtime_config)
+
+    payload: dict[str, Any] = result["results"]["agentensor"]
+    candidate = payload["prompts"]["candidate"]
+    assert candidate["text"] == "Hello world"
+    assert candidate["metadata"]["lang"] == "en"
+    assert payload["tags"] == ["experiment"]
+    assert registry.get_node("AgentensorNode") is AgentensorNode

--- a/tests/agentensor/test_agentensor_node.py
+++ b/tests/agentensor/test_agentensor_node.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 from typing import Any, cast
 import pytest
 from langchain_core.runnables import RunnableConfig
+from orcheo.agentensor.evaluation import (
+    EvaluationCase,
+    EvaluationContext,
+    EvaluationDataset,
+    EvaluatorDefinition,
+)
 from orcheo.agentensor.prompts import TrainablePrompt
+from orcheo.agentensor.training import OptimizerConfig
 from orcheo.graph.state import State
 from orcheo.nodes.agentensor import AgentensorNode
 from orcheo.nodes.registry import registry
@@ -31,6 +38,21 @@ def _build_state_and_config() -> tuple[State, RunnableConfig]:
     return state, runtime_config
 
 
+def evaluation_echo(ctx: EvaluationContext) -> dict[str, Any]:
+    """Simple evaluator that checks output mirroring."""
+    output = ctx.output if isinstance(ctx.output, dict) else {}
+    value = output.get("echo") == ctx.inputs.get("prompt")
+    return {"value": value, "reason": "echo match" if value else "mismatch"}
+
+
+def training_evaluator(ctx: EvaluationContext) -> dict[str, Any]:
+    """Evaluator used to drive prompt updates in training mode."""
+    output = ctx.output if isinstance(ctx.output, dict) else {}
+    candidate = output.get("echo", "")
+    passed = "feedback" in str(candidate)
+    return {"value": passed, "reason": "needs feedback"}
+
+
 @pytest.mark.asyncio
 async def test_agentensor_node_resolves_prompts_from_config() -> None:
     state, runtime_config = _build_state_and_config()
@@ -53,3 +75,180 @@ async def test_agentensor_node_resolves_prompts_from_config() -> None:
     assert candidate["metadata"]["lang"] == "en"
     assert payload["tags"] == ["experiment"]
     assert registry.get_node("AgentensorNode") is AgentensorNode
+
+
+@pytest.mark.asyncio
+async def test_agentensor_node_runs_evaluation_with_progress() -> None:
+    class DummyGraph:
+        async def ainvoke(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+            return {"results": {"echo": state["inputs"]["prompt"]}}
+
+    progress_events: list[dict[str, Any]] = []
+
+    async def progress(payload: dict[str, Any]) -> None:
+        progress_events.append(payload)
+
+    state, runtime_config = _build_state_and_config()
+    node = AgentensorNode(
+        name="agentensor",
+        mode="evaluate",
+        dataset=EvaluationDataset(
+            cases=[EvaluationCase(inputs={"prompt": "ping"}, metadata={"idx": 0})]
+        ),
+        evaluators=[
+            EvaluatorDefinition(
+                id="echo-check",
+                entrypoint="tests.agentensor.test_agentensor_node:evaluation_echo",
+            )
+        ],
+        compiled_graph=DummyGraph(),
+        graph_config={},
+        state_config=state["config"],
+        progress_callback=progress,
+    )
+
+    result = await node(state, runtime_config)
+
+    payload: dict[str, Any] = result["results"]["agentensor"]
+    assert payload["summary"] == {"echo-check": 1.0}
+    assert payload["results"][0]["evaluations"]["echo-check"]["passed"] is True
+    assert progress_events[0]["event"] == "evaluation_progress"
+    assert progress_events[-1]["event"] == "evaluation_summary"
+
+
+@pytest.mark.asyncio
+async def test_agentensor_training_emits_checkpoints_and_best_config() -> None:
+    class TrainingGraph:
+        async def ainvoke(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+            prompt_obj = state["config"]["prompts"]["candidate"]
+            prompt_text = (
+                prompt_obj.text if hasattr(prompt_obj, "text") else prompt_obj["text"]
+            )
+            return {"results": {"echo": prompt_text}}
+
+    progress_events: list[dict[str, Any]] = []
+
+    async def progress(payload: dict[str, Any]) -> None:
+        progress_events.append(payload)
+
+    state, runtime_config = _build_state_and_config()
+    node = AgentensorNode(
+        name="agentensor_trainer",
+        mode="train",
+        dataset=EvaluationDataset(
+            cases=[EvaluationCase(inputs={"prompt": "ping"}, metadata={"idx": 0})]
+        ),
+        evaluators=[
+            EvaluatorDefinition(
+                id="echo-pass",
+                entrypoint="tests.agentensor.test_agentensor_node:training_evaluator",
+            )
+        ],
+        compiled_graph=TrainingGraph(),
+        graph_config={},
+        state_config=state["config"],
+        progress_callback=progress,
+        optimizer=OptimizerConfig(epochs=2, checkpoint_interval=1, max_concurrency=2),
+        workflow_id="wf-training",
+        prompts={
+            "candidate": TrainablePrompt(
+                text="{{config.prompts.seed.text}}",
+                requires_grad=True,
+            )
+        },
+    )
+
+    result = await node(state, runtime_config)
+
+    payload: dict[str, Any] = result["results"]["agentensor_trainer"]
+    assert payload["summary"]["echo-pass"] == 1.0
+    assert payload["best_checkpoint"]["workflow_id"] == "wf-training"
+    assert len(payload["checkpoints"]) == 2
+    assert "feedback" in payload["prompts"]["candidate"]["text"]
+    assert any(event["event"] == "training_checkpoint" for event in progress_events)
+
+
+@pytest.mark.asyncio
+async def test_agentensor_training_requires_trainable_prompts() -> None:
+    class TrainingGraph:
+        async def ainvoke(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+            prompt_obj = state["config"]["prompts"]["candidate"]
+            prompt_text = (
+                prompt_obj.text if hasattr(prompt_obj, "text") else prompt_obj["text"]
+            )
+            return {"results": {"echo": prompt_text}}
+
+    state, runtime_config = _build_state_and_config()
+    node = AgentensorNode(
+        name="agentensor_trainer",
+        mode="train",
+        dataset=EvaluationDataset(
+            cases=[EvaluationCase(inputs={"prompt": "ping"}, metadata={"idx": 0})]
+        ),
+        evaluators=[
+            EvaluatorDefinition(
+                id="echo-pass",
+                entrypoint="tests.agentensor.test_agentensor_node:training_evaluator",
+            )
+        ],
+        compiled_graph=TrainingGraph(),
+        graph_config={},
+        state_config=state["config"],
+        optimizer=OptimizerConfig(epochs=1),
+        workflow_id="wf-training",
+        prompts={
+            "candidate": TrainablePrompt(
+                text="{{config.prompts.seed.text}}",
+                requires_grad=False,
+            )
+        },
+    )
+
+    with pytest.raises(ValueError, match="requires_grad=True"):
+        await node(state, runtime_config)
+
+
+@pytest.mark.asyncio
+async def test_agentensor_training_adds_best_checkpoint_when_unscheduled() -> None:
+    class TrainingGraph:
+        async def ainvoke(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+            prompt_obj = state["config"]["prompts"]["candidate"]
+            prompt_text = (
+                prompt_obj.text if hasattr(prompt_obj, "text") else prompt_obj["text"]
+            )
+            return {"results": {"echo": prompt_text}}
+
+    state, runtime_config = _build_state_and_config()
+    node = AgentensorNode(
+        name="agentensor_trainer",
+        mode="train",
+        dataset=EvaluationDataset(
+            cases=[EvaluationCase(inputs={"prompt": "ping"}, metadata={"idx": 0})]
+        ),
+        evaluators=[
+            EvaluatorDefinition(
+                id="echo-pass",
+                entrypoint="tests.agentensor.test_agentensor_node:training_evaluator",
+            )
+        ],
+        compiled_graph=TrainingGraph(),
+        graph_config={},
+        state_config=state["config"],
+        optimizer=OptimizerConfig(epochs=3, checkpoint_interval=5),
+        workflow_id="wf-training",
+        prompts={
+            "candidate": TrainablePrompt(
+                text="{{config.prompts.seed.text}}",
+                requires_grad=True,
+            )
+        },
+    )
+
+    result = await node(state, runtime_config)
+
+    payload: dict[str, Any] = result["results"]["agentensor_trainer"]
+    epochs_recorded = {cp["metadata"]["epoch"] for cp in payload["checkpoints"]}
+    assert 1 in epochs_recorded
+    assert 2 in epochs_recorded
+    assert 3 in epochs_recorded
+    assert payload["best_checkpoint"]["metadata"]["epoch"] in {2, 3}

--- a/tests/backend/api/test_backend_dependencies.py
+++ b/tests/backend/api/test_backend_dependencies.py
@@ -75,8 +75,14 @@ def test_create_repository_uses_explicit_settings(
         settings: object,
         credential_service: object,
         history_store_ref: object,
+        checkpoint_store_ref: object,
     ) -> object:
-        captured["args"] = (settings, credential_service, history_store_ref)
+        captured["args"] = (
+            settings,
+            credential_service,
+            history_store_ref,
+            checkpoint_store_ref,
+        )
         return sentinel_repository
 
     monkeypatch.setattr(
@@ -92,6 +98,7 @@ def test_create_repository_uses_explicit_settings(
         sentinel_settings,
         sentinel_service,
         dependencies._history_store_ref,
+        dependencies._checkpoint_store_ref,
     )
     assert dependencies._repository_ref["repository"] is sentinel_repository
 

--- a/tests/backend/test_agentensor_checkpoints.py
+++ b/tests/backend/test_agentensor_checkpoints.py
@@ -1,0 +1,136 @@
+"""Tests for Agentensor checkpoint persistence backends."""
+
+from __future__ import annotations
+import asyncio
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+from orcheo.agentensor.checkpoints import (
+    AgentensorCheckpoint,
+    AgentensorCheckpointNotFoundError,
+)
+from orcheo_backend.app.agentensor.checkpoint_store import (
+    InMemoryAgentensorCheckpointStore,
+    SqliteAgentensorCheckpointStore,
+)
+
+
+@pytest.mark.asyncio
+async def test_inmemory_checkpoint_store_increments_versions() -> None:
+    store = InMemoryAgentensorCheckpointStore()
+
+    first = await store.record_checkpoint(
+        workflow_id="wf-1",
+        runnable_config={"a": 1},
+        metrics={"score": 0.1},
+        is_best=False,
+    )
+    second = await store.record_checkpoint(
+        workflow_id="wf-1",
+        runnable_config={"a": 2},
+        metrics={"score": 0.9},
+        is_best=True,
+    )
+
+    assert {first.config_version, second.config_version} == {1, 2}
+    assert second.is_best is True
+    assert first.is_best is False
+    latest = await store.latest_checkpoint("wf-1")
+    assert latest is second
+    listed = await store.list_checkpoints("wf-1")
+    assert listed[0] is second
+    assert listed[1] is first
+
+
+def test_checkpoint_model_validates_fields() -> None:
+    with pytest.raises(ValidationError):
+        AgentensorCheckpoint(
+            workflow_id="",
+            config_version=0,
+            runnable_config={},
+            metrics={},
+            metadata={},
+        )
+
+    checkpoint = AgentensorCheckpoint(
+        workflow_id="wf-valid",
+        config_version=1,
+        runnable_config={},
+        metrics={},
+        metadata={},
+    )
+
+    assert checkpoint.workflow_id == "wf-valid"
+
+
+@pytest.mark.asyncio
+async def test_inmemory_checkpoint_store_handles_concurrent_writes() -> None:
+    store = InMemoryAgentensorCheckpointStore()
+
+    cp1, cp2 = await asyncio.gather(
+        store.record_checkpoint(
+            workflow_id="wf-cc",
+            runnable_config={},
+            metrics={},
+        ),
+        store.record_checkpoint(
+            workflow_id="wf-cc",
+            runnable_config={},
+            metrics={},
+        ),
+    )
+
+    assert {cp1.config_version, cp2.config_version} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_sqlite_checkpoint_store_persists_and_retrieves(
+    tmp_path: Path,
+) -> None:
+    store_path = tmp_path / "agentensor.sqlite"
+    store = SqliteAgentensorCheckpointStore(store_path)
+
+    first = await store.record_checkpoint(
+        workflow_id="wf-2",
+        runnable_config={"p": "v1"},
+        metrics={"score": 0.3},
+    )
+    best = await store.record_checkpoint(
+        workflow_id="wf-2",
+        runnable_config={"p": "v2"},
+        metrics={"score": 0.8},
+        is_best=True,
+    )
+
+    assert best.is_best is True
+    assert best.config_version == first.config_version + 1
+    listed = await store.list_checkpoints("wf-2")
+    assert listed[0].id == best.id
+    fetched = await store.get_checkpoint(first.id)
+    assert fetched.runnable_config == {"p": "v1"}
+    with pytest.raises(AgentensorCheckpointNotFoundError):
+        await store.get_checkpoint("missing")
+
+
+@pytest.mark.asyncio
+async def test_sqlite_checkpoint_store_resets_previous_best(tmp_path: Path) -> None:
+    store_path = tmp_path / "agentensor.sqlite"
+    store = SqliteAgentensorCheckpointStore(store_path)
+
+    first = await store.record_checkpoint(
+        workflow_id="wf-3",
+        runnable_config={"p": "v1"},
+        metrics={"score": 0.4},
+        is_best=True,
+    )
+    second = await store.record_checkpoint(
+        workflow_id="wf-3",
+        runnable_config={"p": "v2"},
+        metrics={"score": 0.9},
+        is_best=True,
+    )
+
+    listed = await store.list_checkpoints("wf-3")
+    assert second.id == listed[0].id
+    assert sum(1 for cp in listed if cp.is_best) == 1
+    assert all(cp.is_best is (cp.id == second.id) for cp in listed)

--- a/tests/backend/test_history_inmemory_store.py
+++ b/tests/backend/test_history_inmemory_store.py
@@ -39,6 +39,32 @@ async def test_start_run_duplicate_execution_id_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_run_persists_runnable_config() -> None:
+    store = InMemoryRunHistoryStore()
+    runnable_config = {
+        "configurable": {"thread_id": "exec"},
+        "metadata": {"foo": "bar"},
+    }
+
+    await store.start_run(
+        workflow_id="wf",
+        execution_id="exec",
+        inputs={"foo": "bar"},
+        runnable_config=runnable_config,
+        tags=["alpha"],
+        callbacks=[{"name": "cb"}],
+        metadata={"foo": "bar"},
+        run_name="demo",
+    )
+
+    history = await store.get_history("exec")
+    assert history.runnable_config["metadata"] == {"foo": "bar"}
+    assert history.tags == ["alpha"]
+    assert history.callbacks == [{"name": "cb"}]
+    assert history.run_name == "demo"
+
+
+@pytest.mark.asyncio
 async def test_mark_failed_returns_copy_and_persists() -> None:
     store = InMemoryRunHistoryStore()
     await store.start_run(workflow_id="wf", execution_id="exec")

--- a/tests/backend/test_history_sqlite_store_core.py
+++ b/tests/backend/test_history_sqlite_store_core.py
@@ -62,6 +62,28 @@ async def test_sqlite_store_records_trace_metadata(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_sqlite_store_persists_runnable_config(tmp_path: Path) -> None:
+    db_path = tmp_path / "history-config.sqlite"
+    store = SqliteRunHistoryStore(str(db_path))
+    await store.start_run(
+        workflow_id="wf",
+        execution_id="exec",
+        runnable_config={"metadata": {"foo": "bar"}},
+        tags=["alpha"],
+        callbacks=[{"name": "cb"}],
+        metadata={"foo": "bar"},
+        run_name="demo",
+    )
+
+    history = await store.get_history("exec")
+    assert history.runnable_config["metadata"] == {"foo": "bar"}
+    assert history.tags == ["alpha"]
+    assert history.callbacks == [{"name": "cb"}]
+    assert history.metadata == {"foo": "bar"}
+    assert history.run_name == "demo"
+
+
+@pytest.mark.asyncio
 async def test_sqlite_store_duplicate_execution_id_raises(
     tmp_path: Path,
 ) -> None:

--- a/tests/backend/test_providers.py
+++ b/tests/backend/test_providers.py
@@ -98,6 +98,7 @@ def test_create_repository_sqlite_backend_sets_history_store(
     )
     credential_service = object()
     history_store_ref: dict[str, object] = {}
+    checkpoint_store_ref: dict[str, object] = {}
 
     class FakeStore:
         def __init__(self, path: str) -> None:
@@ -109,12 +110,14 @@ def test_create_repository_sqlite_backend_sets_history_store(
             self.credential_service = credential_service
 
     monkeypatch.setattr(providers, "SqliteRunHistoryStore", FakeStore)
+    monkeypatch.setattr(providers, "SqliteAgentensorCheckpointStore", FakeStore)
     monkeypatch.setattr(providers, "SqliteWorkflowRepository", FakeRepository)
 
     repository = providers.create_repository(
         settings,
         credential_service=credential_service,
         history_store_ref=history_store_ref,
+        checkpoint_store_ref=checkpoint_store_ref,
     )
 
     assert isinstance(repository, FakeRepository)
@@ -122,3 +125,5 @@ def test_create_repository_sqlite_backend_sets_history_store(
     assert repository.credential_service is credential_service
     assert isinstance(history_store_ref["store"], FakeStore)
     assert history_store_ref["store"].path == "/tmp/workflows.sqlite"
+    assert isinstance(checkpoint_store_ref["store"], FakeStore)
+    assert checkpoint_store_ref["store"].path == "/tmp/workflows.sqlite"

--- a/tests/nodes/test_base_task_node.py
+++ b/tests/nodes/test_base_task_node.py
@@ -45,6 +45,25 @@ def test_decode_variables_with_results_prefix() -> None:
     assert node.input_var == "test_from_results"
 
 
+def test_decode_variables_reads_config_state() -> None:
+    state = State({"results": {}, "config": {"threshold": 0.75}})
+    node = MockTaskNode(name="test", input_var="{{config.threshold}}")
+
+    node.decode_variables(state)
+
+    assert node.input_var == 0.75
+
+
+def test_decode_variables_injects_config_argument() -> None:
+    state = State({"results": {}})
+    node = MockTaskNode(name="test", input_var="{{config.limit}}")
+
+    node.decode_variables(state, config={"limit": 5})
+
+    assert node.input_var == 5
+    assert state["config"]["limit"] == 5
+
+
 def test_decode_variables_non_dict_traversal(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/runtime/test_runnable_config.py
+++ b/tests/runtime/test_runnable_config.py
@@ -1,0 +1,48 @@
+"""Tests for runnable config validation and merging."""
+
+from __future__ import annotations
+import pytest
+from orcheo.agentensor.prompts import TrainablePrompt
+from orcheo.runtime.runnable_config import RunnableConfigModel, parse_runnable_config
+
+
+def test_parse_runnable_config_builds_runtime_payload() -> None:
+    model = parse_runnable_config(
+        {
+            "tags": ["A", "a "],
+            "metadata": {"foo": "bar"},
+            "recursion_limit": 10,
+            "prompts": {"welcome": {"text": "hi", "type": "TextTensor"}},
+        }
+    )
+
+    runtime_config = model.to_runnable_config("exec-1")
+    assert runtime_config["configurable"]["thread_id"] == "exec-1"
+    assert runtime_config["tags"] == ["A"]
+    assert runtime_config["metadata"] == {"foo": "bar"}
+    assert runtime_config["recursion_limit"] == 10
+    assert runtime_config["prompts"]["welcome"]["text"] == "hi"
+
+
+def test_state_config_keeps_prompt_models() -> None:
+    prompt = TrainablePrompt(text="Hello there", requires_grad=True)
+    model = RunnableConfigModel(prompts={"seed": prompt})
+
+    state_config = model.to_state_config("thread-123")
+
+    seed_prompt = state_config["prompts"]["seed"]
+    assert isinstance(seed_prompt, TrainablePrompt)
+    assert seed_prompt.requires_grad is True
+    assert state_config["configurable"]["thread_id"] == "thread-123"
+
+
+def test_parse_runnable_config_rejects_non_serialisable_metadata() -> None:
+    with pytest.raises(ValueError):
+        parse_runnable_config({"metadata": {"ts": object()}})
+
+
+def test_parse_runnable_config_enforces_limits() -> None:
+    with pytest.raises(ValueError):
+        parse_runnable_config({"recursion_limit": 1000})
+    with pytest.raises(ValueError):
+        parse_runnable_config({"max_concurrency": 10_000})

--- a/tests/sdk/test_workflow_cli_run.py
+++ b/tests/sdk/test_workflow_cli_run.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 import pytest
 from orcheo_sdk.cli.errors import CLIError
-from orcheo_sdk.cli.workflow import run_workflow
+from orcheo_sdk.cli.workflow import evaluate_workflow, run_workflow
 from tests.sdk.workflow_cli_test_utils import DummyCtx, make_state
 
 
@@ -25,12 +25,14 @@ def test_run_workflow_raises_on_failed_stream(
         graph_config: dict[str, Any],
         inputs: Any,
         triggered_by: str | None = None,
+        runnable_config: Any | None = None,
     ) -> str:
         assert state_arg is state
         assert workflow_id == "wf-1"
         assert graph_config == {"nodes": []}
         assert inputs == {}
         assert triggered_by == "cli"
+        assert runnable_config is None
         return "error"
 
     monkeypatch.setattr("orcheo_sdk.cli.workflow._stream_workflow_run", fake_stream)
@@ -57,14 +59,58 @@ def test_run_workflow_allows_successful_stream(
         graph_config: dict[str, Any],
         inputs: Any,
         triggered_by: str | None = None,
+        runnable_config: Any | None = None,
     ) -> str:
         assert state_arg is state
         assert workflow_id == "wf-1"
         assert graph_config == {"nodes": []}
         assert inputs == {}
         assert triggered_by == "cli"
+        assert runnable_config is None
         return "completed"
 
     monkeypatch.setattr("orcheo_sdk.cli.workflow._stream_workflow_run", fake_stream)
 
     run_workflow(DummyCtx(state), "wf-1")
+
+
+def test_evaluate_workflow_streams_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = make_state()
+
+    state.client.responses = {
+        "/api/workflows/wf-2/versions": [
+            {"id": "ver-1", "version": 1, "graph": {"nodes": []}}
+        ]
+    }
+
+    async def fake_stream(
+        state_arg: Any,
+        workflow_id: str,
+        graph_config: dict[str, Any],
+        inputs: Any,
+        evaluation: Any,
+        triggered_by: str | None = None,
+        runnable_config: Any | None = None,
+    ) -> str:
+        assert state_arg is state
+        assert workflow_id == "wf-2"
+        assert graph_config == {"nodes": []}
+        assert inputs == {}
+        assert evaluation == {"dataset": {"cases": [{"inputs": {"a": 1}}]}}
+        assert triggered_by == "cli"
+        assert runnable_config is None
+        return "completed"
+
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.workflow._stream_workflow_evaluation", fake_stream
+    )
+
+    evaluate_payload = '{"dataset": {"cases": [{"inputs": {"a": 1}}]}}'
+    evaluate_workflow(
+        DummyCtx(state),
+        "wf-2",
+        evaluation=evaluate_payload,
+        stream=True,
+    )

--- a/tests/test_app_workflow_websocket.py
+++ b/tests/test_app_workflow_websocket.py
@@ -37,5 +37,74 @@ async def test_workflow_websocket_routes_requests() -> None:
         {"input": "test"},
         "test-execution",
         mock_websocket,
+        runnable_config=None,
     )
     mock_websocket.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_workflow_websocket_routes_evaluation_requests() -> None:
+    """Incoming evaluation messages route to execute_workflow_evaluation."""
+
+    mock_websocket = AsyncMock(spec=WebSocket)
+    mock_websocket.receive_json.return_value = {
+        "type": "evaluate_workflow",
+        "graph_config": {"nodes": []},
+        "inputs": {"input": "test"},
+        "execution_id": "eval-execution",
+        "evaluation": {"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+    }
+
+    with (
+        patch("orcheo_backend.app.execute_workflow_evaluation") as mock_execute,
+        patch(
+            "orcheo_backend.app._history_store_ref",
+            {"store": InMemoryRunHistoryStore()},
+        ),
+    ):
+        mock_execute.return_value = None
+        await workflow_websocket(mock_websocket, "workflow-abc")
+
+    mock_execute.assert_called_once_with(
+        "workflow-abc",
+        {"nodes": []},
+        {"input": "test"},
+        "eval-execution",
+        mock_websocket,
+        evaluation={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+        runnable_config=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_websocket_routes_training_requests() -> None:
+    """Incoming training messages route to execute_workflow_training."""
+
+    mock_websocket = AsyncMock(spec=WebSocket)
+    mock_websocket.receive_json.return_value = {
+        "type": "train_workflow",
+        "graph_config": {"nodes": []},
+        "inputs": {"input": "test"},
+        "execution_id": "train-execution",
+        "training": {"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+    }
+
+    with (
+        patch("orcheo_backend.app.execute_workflow_training") as mock_execute,
+        patch(
+            "orcheo_backend.app._history_store_ref",
+            {"store": InMemoryRunHistoryStore()},
+        ),
+    ):
+        mock_execute.return_value = None
+        await workflow_websocket(mock_websocket, "workflow-train")
+
+    mock_execute.assert_called_once_with(
+        "workflow-train",
+        {"nodes": []},
+        {"input": "test"},
+        "train-execution",
+        mock_websocket,
+        training={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
+        runnable_config=None,
+    )


### PR DESCRIPTION
Updates in this PR:

1. Added validated runnable config parsing/merging with safe limits and state injection (src/orcheo/runtime/runnable_config.py, src/orcheo/graph/state.py), and improved template decoding to walk BaseModel attributes for config-backed prompts (src/orcheo/nodes/base.py).
2. Propagated runnable configs through execution: run API accepts configs, repositories persist them, runtime builds merged configs with thread IDs, and run history/traces now store tags/metadata/callbacks (apps/backend/src/orcheo_backend/app/workflow_execution.py, apps/backend/src/orcheo_backend/app/routers/runs.py, history store/trace utils updates).
3. Added AgentensorNode registration and prompt interpolation coverage (src/orcheo/nodes/agentensor.py, new tests), and ensured sub-workflow state carries configs.
4. SDK/CLI now accept --config/--config-file, pass configs over WebSocket/HTTP, and plan checklist marks Milestone 1 tasks complete (packages/sdk/src/orcheo_sdk/cli/workflow/*, docs/agentensor/plan.md).
