### PR TITLE
Add documents for uploading workflows with runnable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ After installation, restart your shell or source your shell configuration file.
 | `orcheo workflow list [--include-archived]` | List workflows with owner, last run, and status. |
 | `orcheo workflow show <workflow>` | Print workflow summary, publish status/details, Mermaid graph, and latest runs. |
 | `orcheo workflow run <workflow> [--inputs <json> \| --inputs-file <path>] [--config <json> \| --config-file <path>]` | Trigger a workflow execution and stream status to the console. |
-| `orcheo workflow upload <file> [--name <name>]` | Upload a workflow from Python or JSON file. |
+| `orcheo workflow upload <file> [--name <name>] [--config <json> \| --config-file <path>]` | Upload a workflow from Python or JSON file. |
 | `orcheo workflow download <workflow> [-o <file>]` | Download workflow definition as Python or JSON. |
 | `orcheo workflow delete <workflow> [--force]` | Delete a workflow with confirmation safeguards. |
 | `orcheo workflow publish <workflow> [--require-login] [--chatkit-public-base-url <url>]` | Publish a workflow for public ChatKit access, optionally requiring OAuth login and overriding the share-link origin for that run. |
@@ -144,6 +144,8 @@ After installation, restart your shell or source your shell configuration file.
 Published workflows remain accessible until you run `orcheo workflow unpublish <workflow>` or toggle the `--require-login` flag to gate public chats behind OAuth.
 
 Pass workflow inputs inline with `--inputs` or from disk via `--inputs-file`. Use `--config` or `--config-file` to provide LangChain runnable configuration for the execution (each pair is mutually exclusive).
+
+Upload-time defaults can be stored on a workflow version with `orcheo workflow upload ... --config` or `--config-file`. Stored config is merged with per-run overrides (run config wins). Avoid putting secrets in runnable config; use environment variables or credential vaults instead.
 
 #### Offline Mode
 

--- a/apps/backend/src/orcheo_backend/app/chatkit/workflow_executor.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/workflow_executor.py
@@ -14,6 +14,7 @@ from orcheo.graph.builder import build_graph
 from orcheo.models import CredentialAccessContext
 from orcheo.persistence import create_checkpointer
 from orcheo.runtime.credentials import CredentialResolver, credential_resolution
+from orcheo.runtime.runnable_config import merge_runnable_configs
 from orcheo.vault import BaseCredentialVault
 from orcheo_backend.app.chatkit.message_utils import (
     build_initial_state,
@@ -70,9 +71,9 @@ class WorkflowExecutor:
             compiled = graph.compile(checkpointer=checkpointer)
             initial_state = build_initial_state(graph_config, inputs)
             payload: Any = initial_state
-            config: RunnableConfig = {
-                "configurable": {"thread_id": str(uuid4())},
-            }
+            execution_id = str(uuid4())
+            merged_config = merge_runnable_configs(version.runnable_config, None)
+            config: RunnableConfig = merged_config.to_runnable_config(execution_id)
             with credential_resolution(credential_resolver):
                 final_state = await compiled.ainvoke(payload, config=config)
 

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/versions.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/versions.py
@@ -23,6 +23,7 @@ class WorkflowVersionMixin(InMemoryRepositoryState):
         *,
         graph: dict[str, Any],
         metadata: dict[str, Any],
+        runnable_config: dict[str, Any] | None = None,
         notes: str | None,
         created_by: str,
     ) -> WorkflowVersion:
@@ -39,6 +40,7 @@ class WorkflowVersionMixin(InMemoryRepositoryState):
                 version=next_version_number,
                 graph=json.loads(json.dumps(graph)),
                 metadata=dict(metadata),
+                runnable_config=dict(runnable_config) if runnable_config else None,
                 created_by=created_by,
                 notes=notes,
             )

--- a/apps/backend/src/orcheo_backend/app/repository/protocol.py
+++ b/apps/backend/src/orcheo_backend/app/repository/protocol.py
@@ -76,6 +76,7 @@ class WorkflowRepository(Protocol):
         *,
         graph: dict[str, Any],
         metadata: dict[str, Any],
+        runnable_config: dict[str, Any] | None = None,
         notes: str | None,
         created_by: str,
     ) -> WorkflowVersion:

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
+from orcheo.runtime.runnable_config import merge_runnable_configs
 from orcheo_backend.app.repository import (
     WorkflowNotFoundError,
     WorkflowRunNotFoundError,
@@ -91,12 +92,18 @@ class SqlitePersistenceMixin(SqliteRepositoryBase):
         if version.workflow_id != workflow_id:
             raise WorkflowVersionNotFoundError(str(workflow_version_id))
 
-        config_payload: dict[str, Any] = {}
+        config_payload: dict[str, Any] | None = None
         if runnable_config:
             if hasattr(runnable_config, "model_dump"):
                 config_payload = runnable_config.model_dump(mode="json")  # type: ignore[arg-type]
             elif isinstance(runnable_config, Mapping):  # pragma: no branch
                 config_payload = dict(runnable_config)
+        merged_config = merge_runnable_configs(version.runnable_config, config_payload)
+        config_payload = merged_config.model_dump(
+            mode="json",
+            exclude_defaults=True,
+            exclude_none=True,
+        )
         tags = (
             list(config_payload.get("tags", []))
             if isinstance(config_payload, dict)

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_versions.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_versions.py
@@ -22,6 +22,7 @@ class WorkflowVersionMixin(SqlitePersistenceMixin):
         *,
         graph: dict[str, Any],
         metadata: dict[str, Any],
+        runnable_config: dict[str, Any] | None = None,
         notes: str | None,
         created_by: str,
     ) -> WorkflowVersion:
@@ -46,6 +47,7 @@ class WorkflowVersionMixin(SqlitePersistenceMixin):
                     version=next_version_number,
                     graph=json.loads(json.dumps(graph)),
                     metadata=dict(metadata),
+                    runnable_config=dict(runnable_config) if runnable_config else None,
                     created_by=created_by,
                     notes=notes,
                 )

--- a/apps/backend/src/orcheo_backend/app/routers/websocket.py
+++ b/apps/backend/src/orcheo_backend/app/routers/websocket.py
@@ -46,6 +46,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                         execution_id,
                         websocket,
                         runnable_config=data.get("runnable_config"),
+                        stored_runnable_config=data.get("stored_runnable_config"),
                     )
                 )
 
@@ -62,6 +63,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                         websocket,
                         evaluation=data.get("evaluation"),
                         runnable_config=data.get("runnable_config"),
+                        stored_runnable_config=data.get("stored_runnable_config"),
                     )
                 )
                 await task
@@ -77,6 +79,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                         websocket,
                         training=data.get("training"),
                         runnable_config=data.get("runnable_config"),
+                        stored_runnable_config=data.get("stored_runnable_config"),
                     )
                 )
                 await task

--- a/apps/backend/src/orcheo_backend/app/schemas/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/workflows.py
@@ -34,6 +34,7 @@ class WorkflowVersionCreateRequest(BaseModel):
 
     graph: dict[str, Any]
     metadata: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: RunnableConfigModel | None = None
     notes: str | None = None
     created_by: str
 
@@ -44,6 +45,7 @@ class WorkflowVersionIngestRequest(BaseModel):
     script: str
     entrypoint: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: RunnableConfigModel | None = None
     notes: str | None = None
     created_by: str
 

--- a/docs/workflow_upload_config/1_requirements.md
+++ b/docs/workflow_upload_config/1_requirements.md
@@ -43,7 +43,7 @@ Goals: provide upload-time config inputs equivalent to run-time inputs; persist 
   - Add `--config` and `--config-file` to `orcheo workflow upload` with the same JSON parsing and mutual-exclusion rules as `workflow run`.
   - Accept config for both JSON workflow uploads and LangGraph script ingestion.
 - **P0: Persisted runnable config**
-  - Store the provided runnable config in the workflow version record within the configured repository backend (SQLite by default; in-memory only for tests/dev).
+  - Store the provided runnable config in the workflow version record within the configured repository backend (SQLite by default). In tests/dev, the in-memory repository stores it only for the lifetime of the process.
   - Include the stored config in workflow version responses and workflow show output.
 - **P1: Runtime merge behavior**
   - When executing a run, merge stored runnable config with per-run config so overrides win while preserving stored values.
@@ -51,7 +51,7 @@ Goals: provide upload-time config inputs equivalent to run-time inputs; persist 
   - Update README and workflow upload documentation to show examples of `--config` and `--config-file`.
 
 ### Designs (if applicable)
-See docs/workflow_upload_config/2_design.md for architecture and API details.
+See docs/workflow_upload_config/2_design.md for architecture and API details, including [API Contracts](2_design.md#api-contracts), [Data Models / Schemas](2_design.md#data-models--schemas), [Error Scenarios](2_design.md#error-scenarios), and [Rollback Plan](2_design.md#rollback-plan).
 
 ## TECHNICAL CONSIDERATIONS
 ### Architecture Overview
@@ -59,7 +59,7 @@ The CLI resolves config input and forwards it to the SDK upload flow. The backen
 
 ### Technical Requirements
 - Reuse `RunnableConfigModel` validation and JSON parsing rules for upload-time config.
-- Store config in the workflow version payload within the workflow versions table in the configured repository backend (SQLite by default; in-memory only for tests/dev).
+- Store config in the workflow_versions.payload.runnable_config field in the configured repository backend (SQLite by default). In tests/dev, the in-memory repository stores it only for the lifetime of the process.
 - Maintain backward compatibility for uploads without config and for older version payloads without stored runnable config.
 - Provide deterministic merge precedence: run config overrides stored runnable config on conflicts.
 

--- a/docs/workflow_upload_config/1_requirements.md
+++ b/docs/workflow_upload_config/1_requirements.md
@@ -1,0 +1,94 @@
+# Requirements Document
+
+## METADATA
+- **Authors:** Codex
+- **Project/Feature Name:** Workflow Upload Runnable Config
+- **Type:** Enhancement
+- **Summary:** Allow workflow uploads to accept runnable configs via `--config` or `--config-file` and persist them per workflow version in the configured repository (SQLite by default).
+- **Owner (if different than authors):** Shaojie Jiang
+- **Date Started:** 2025-12-21
+
+## RELEVANT LINKS & STAKEHOLDERS
+
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| CLI Reference | README.md | Shaojie Jiang | CLI commands and `workflow run` config options |
+| Design Review | docs/workflow_upload_config/2_design.md | Shaojie Jiang | Workflow upload config design |
+| Eng Requirement Doc | docs/workflow_upload_config/1_requirements.md | Shaojie Jiang | Workflow upload config requirements |
+| Project Plan | docs/workflow_upload_config/3_plan.md | Shaojie Jiang | Workflow upload config plan |
+
+## PROBLEM DEFINITION
+### Objectives
+Enable `orcheo workflow upload` to accept `--config` and `--config-file` with the same semantics as `orcheo workflow run`. Persist the provided runnable config in the workflow version storage (configured repository backend, SQLite by default) so uploads can carry default configuration without hard-coding it in scripts.
+
+### Target users
+Workflow authors and operators who want stable defaults for runtime config (tags, metadata, concurrency, prompts) and repeatable uploads.
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+| Workflow author | Upload a workflow with `--config` or `--config-file` | I can set default runtime configuration without editing code | P0 | Upload validates JSON object input, stores config with the new workflow version, and reports success |
+| Operator | View stored config in workflow show output | I can audit and reproduce runs | P0 | Workflow show output includes the stored runnable config from the latest version |
+| Workflow author | Override defaults on run | I can use per-run overrides when needed | P1 | Run config merges with stored runnable config, with explicit run config taking precedence |
+
+### Context, Problems, Opportunities
+`orcheo workflow run` supports `--config` and `--config-file`, but `orcheo workflow upload` does not. Authors must either bake defaults into Python scripts or pass config on every run, which leads to duplicated settings and drift. Allowing uploads to include runnable config improves repeatability, keeps code cleaner, and ensures the config is preserved alongside the workflow version in storage.
+
+### Product goals and Non-goals
+Goals: provide upload-time config inputs equivalent to run-time inputs; persist runnable config in the workflow version store; expose it via version APIs and workflow show output for audit and reuse; keep backward compatibility for uploads without config. Non-goals: redesigning workflow execution UI, adding new config schema fields beyond existing `RunnableConfig`, or migrating historical scripts to strip embedded config.
+
+## PRODUCT DEFINITION
+### Requirements
+- **P0: Upload-time config inputs**
+  - Add `--config` and `--config-file` to `orcheo workflow upload` with the same JSON parsing and mutual-exclusion rules as `workflow run`.
+  - Accept config for both JSON workflow uploads and LangGraph script ingestion.
+- **P0: Persisted runnable config**
+  - Store the provided runnable config in the workflow version record within the configured repository backend (SQLite by default; in-memory only for tests/dev).
+  - Include the stored config in workflow version responses and workflow show output.
+- **P1: Runtime merge behavior**
+  - When executing a run, merge stored runnable config with per-run config so overrides win while preserving stored values.
+- **P1: Documentation**
+  - Update README and workflow upload documentation to show examples of `--config` and `--config-file`.
+
+### Designs (if applicable)
+See docs/workflow_upload_config/2_design.md for architecture and API details.
+
+## TECHNICAL CONSIDERATIONS
+### Architecture Overview
+The CLI resolves config input and forwards it to the SDK upload flow. The backend validates the payload using the existing runnable config model and persists the config with the workflow version in the configured repository backend (SQLite by default). Workflow runs can read and merge the stored runnable config with per-run overrides.
+
+### Technical Requirements
+- Reuse `RunnableConfigModel` validation and JSON parsing rules for upload-time config.
+- Store config in the workflow version payload within the workflow versions table in the configured repository backend (SQLite by default; in-memory only for tests/dev).
+- Maintain backward compatibility for uploads without config and for older version payloads without stored runnable config.
+- Provide deterministic merge precedence: run config overrides stored runnable config on conflicts.
+
+## MARKET DEFINITION
+Internal feature; no external market analysis required.
+
+## LAUNCH/ROLLOUT PLAN
+
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| Primary: Uploads with config succeed | >=99% success rate on CLI uploads using config |
+| Secondary: Stored config visibility | 100% of uploaded configs appear in version payloads |
+| Guardrail: Runtime behavior | No regression in runs without config and no config merge errors |
+
+### Rollout Strategy
+Ship the CLI and API changes together behind a minor release; validate in staging with a few internal workflows before enabling for general use.
+
+### Experiment Plan (if applicable)
+Not applicable.
+
+### Estimated Launch Phases (if applicable)
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | Internal workflows | Enable upload config in staging; verify persistence and merge behavior |
+| **Phase 2** | All environments | Release to users with updated docs and examples |
+
+## HYPOTHESIS & RISKS
+Adding runnable config to workflow uploads will reduce script churn and improve reproducibility. Risks include storing sensitive values in configs and confusing precedence between stored configs and per-run overrides. Mitigation: validation via `RunnableConfigModel`, clear CLI messaging about precedence, and documentation warning against embedding secrets.
+
+## APPENDIX
+None.

--- a/docs/workflow_upload_config/2_design.md
+++ b/docs/workflow_upload_config/2_design.md
@@ -1,0 +1,144 @@
+# Design Document
+
+## For Workflow Upload Runnable Config
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2025-12-21
+- **Status:** Draft
+
+---
+
+## Overview
+
+This feature adds upload-time runnable configuration so workflow authors can set default runtime settings without baking them into scripts. The CLI gains `--config` and `--config-file` options that behave the same as `orcheo workflow run`, including JSON validation and mutual exclusion. Uploads can now carry tags, metadata, concurrency limits, and other `RunnableConfig` fields as part of the workflow version record.
+
+The runnable config is persisted alongside the workflow version in the configured repository backend (SQLite by default; in-memory only for tests/dev). Workflow runs can merge stored config with per-run overrides, ensuring stored values apply unless explicitly overridden.
+
+The design is intentionally narrow: it reuses the same runnable config parsing/validation as workflow runs and only expands upload payloads and storage, avoiding new config schemas or runtime behavior changes beyond merge precedence. The config is stored with workflow versions (the workflow versions table payload), separate from Agentensor checkpoint tables.
+
+## Components
+
+- **CLI Upload Command (packages/sdk)**
+  - Adds `--config` and `--config-file` flags to `orcheo workflow upload`.
+  - Reuses the existing runnable config JSON parser (`_resolve_runnable_config`) to enforce object payloads consistently with `workflow run`.
+- **SDK Upload Service (packages/sdk)**
+  - Accepts the parsed config and forwards it to the appropriate upload API.
+  - Supports both JSON workflow uploads and LangGraph script ingestion.
+- **Workflow API (apps/backend)**
+  - Extends workflow version creation and ingestion requests to accept a runnable config payload.
+  - Validates with `RunnableConfigModel` and returns the stored config in responses and workflow show output.
+- **Repository Storage (apps/backend)**
+  - Persists the runnable config in the workflow versions table (payload JSON) so it is available per version in the configured repository backend (SQLite by default).
+- **Execution Layer (apps/backend)**
+  - Merges stored config with run-supplied config; run config wins on conflict.
+
+## Request Flows
+
+### Flow 1: JSON Workflow Upload with Config
+
+1. User runs `orcheo workflow upload workflow.json --config '{...}'`.
+2. CLI parses the JSON config using the same rules as `workflow run`.
+3. SDK upload sends the workflow payload and runnable config to `/api/workflows` (or `/api/workflows/{id}` for updates).
+4. Backend validates the config, persists it on the workflow version record, and returns the new version.
+
+### Flow 2: LangGraph Script Upload with Config
+
+1. User runs `orcheo workflow upload workflow.py --config-file config.json`.
+2. CLI validates the config file and passes it to the SDK ingestion request.
+3. Backend ingests the script at `/api/workflows/{id}/versions/ingest`, attaching the runnable config to the version.
+4. The version payload stores the runnable config for that version.
+
+### Flow 3: Workflow Run with Stored Config
+
+1. User triggers a run with optional per-run config.
+2. Backend loads the workflow version runnable config from storage.
+3. Runtime merges stored config with run config, applying run config precedence.
+4. Execution proceeds with the merged config and is stored with the run record.
+
+## API Contracts
+
+```
+POST /api/workflows
+Body:
+  name: string
+  graph: object
+  metadata: object (optional)
+  runnable_config: object (optional)
+
+Response:
+  201 Created -> WorkflowVersion payload including runnable_config
+  400 -> validation errors for config or payload
+```
+
+```
+POST /api/workflows/{workflow_id}/versions/ingest
+Body:
+  script: string
+  entrypoint: string (optional)
+  metadata: object (optional)
+  notes: string (optional)
+  created_by: string
+  runnable_config: object (optional)
+
+Response:
+  201 Created -> WorkflowVersion payload including runnable_config
+  400 -> validation errors for config or payload
+```
+
+The CLI flags are mutually exclusive: `--config` and `--config-file` cannot be provided together. Config payloads must be JSON objects compatible with `RunnableConfigModel`.
+
+## Data Models / Schemas
+
+| Field | Type | Description |
+|-------|------|-------------|
+| runnable_config | object | Stored `RunnableConfig` for the workflow version; saved with version payload |
+
+Example payload snippet:
+
+```json
+{
+  "name": "SupportBot",
+  "graph": {"nodes": [], "edges": []},
+  "runnable_config": {
+    "tags": ["support", "v1"],
+    "metadata": {"owner": "cx"},
+    "max_concurrency": 4,
+    "recursion_limit": 25
+  }
+}
+```
+
+## Security Considerations
+
+- Validate configs with `RunnableConfigModel` and reject non-object JSON.
+- Document that secrets should not be stored in runnable configs.
+- Ensure stored config is scoped to the workflow version and respects existing auth controls.
+
+## Performance Considerations
+
+- Minimal overhead: config validation is small and stored alongside existing payloads.
+- Merge logic should be deterministic and avoid deep-copying large configs unnecessarily.
+
+## Testing Strategy
+
+- **Unit tests**: config parsing and mutual exclusion at the CLI layer.
+- **Integration tests**: upload endpoints accept and return runnable config for both JSON and script ingestion.
+- **Repository tests**: persisted runnable config in the configured repository backend (SQLite default).
+- **Regression tests**: workflow runs without config remain unchanged; run config overrides defaults correctly.
+
+## Rollout Plan
+
+1. Phase 1: Ship API and repository changes in staging; validate persistence and retrieval.
+2. Phase 2: Enable CLI flags and update docs; test with internal workflows.
+3. Phase 3: Release to all users.
+
+Include backward compatibility for older versions without stored runnable config.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2025-12-21 | Codex | Initial draft |

--- a/docs/workflow_upload_config/3_plan.md
+++ b/docs/workflow_upload_config/3_plan.md
@@ -17,6 +17,8 @@ Add upload-time runnable config support so workflows can ship with initial confi
 - Requirements: docs/workflow_upload_config/1_requirements.md
 - Design: docs/workflow_upload_config/2_design.md
 
+**Priority Mapping:** P0 work is covered in Milestones 1 and 2. P1 work is covered in Milestone 3 (runtime merge, documentation, and regression coverage).
+
 ---
 
 ## Milestones
@@ -44,10 +46,11 @@ Add upload-time runnable config support so workflows can ship with initial confi
 
 - [ ] Task 2.1: Extend workflow version create/ingest schemas to accept `runnable_config` and validate with `RunnableConfigModel`
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Persist runnable config in workflow version payloads in the configured repository backend (SQLite by default; in-memory only for tests/dev)
+- [ ] Task 2.2: Persist runnable config in workflow version payloads in the configured repository backend (SQLite by default; in-memory for tests/dev and only retained for the process lifetime)
   - Dependencies: Task 2.1
 - [ ] Task 2.3: Add migrations if a new column is introduced; otherwise verify payload compatibility across existing records
   - Dependencies: Task 2.2
+  - Notes: If adding a column, make it nullable with a default of null; existing versions without runnable_config must continue to behave as empty.
 
 ---
 
@@ -73,3 +76,10 @@ Add upload-time runnable config support so workflows can ship with initial confi
 | Date | Author | Changes |
 |------|--------|---------|
 | 2025-12-21 | Codex | Initial draft |
+
+---
+
+## Rollback / Contingency
+
+- Disable or hide the CLI flags and ignore runnable_config in upload handlers if needed.
+- Keep stored runnable_config in payloads; no data rollback required.

--- a/docs/workflow_upload_config/3_plan.md
+++ b/docs/workflow_upload_config/3_plan.md
@@ -29,11 +29,11 @@ Add upload-time runnable config support so workflows can ship with initial confi
 
 #### Task Checklist
 
-- [ ] Task 1.1: Add `--config` and `--config-file` options to `orcheo workflow upload` with mutual exclusion and JSON validation
+- [x] Task 1.1: Add `--config` and `--config-file` options to `orcheo workflow upload` with mutual exclusion and JSON validation
   - Dependencies: None
-- [ ] Task 1.2: Reuse `_resolve_runnable_config` and thread parsed config through `upload_workflow_data` and LangGraph ingestion helpers
+- [x] Task 1.2: Reuse `_resolve_runnable_config` and thread parsed config through `upload_workflow_data` and LangGraph ingestion helpers
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Update CLI tests for JSON and script uploads to cover config inputs and invalid JSON cases
+- [x] Task 1.3: Update CLI tests for JSON and script uploads to cover config inputs and invalid JSON cases
   - Dependencies: Task 1.2
 
 ---
@@ -44,11 +44,11 @@ Add upload-time runnable config support so workflows can ship with initial confi
 
 #### Task Checklist
 
-- [ ] Task 2.1: Extend workflow version create/ingest schemas to accept `runnable_config` and validate with `RunnableConfigModel`
+- [x] Task 2.1: Extend workflow version create/ingest schemas to accept `runnable_config` and validate with `RunnableConfigModel`
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Persist runnable config in workflow version payloads in the configured repository backend (SQLite by default; in-memory for tests/dev and only retained for the process lifetime)
+- [x] Task 2.2: Persist runnable config in workflow version payloads in the configured repository backend (SQLite by default; in-memory for tests/dev and only retained for the process lifetime)
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Add migrations if a new column is introduced; otherwise verify payload compatibility across existing records
+- [x] Task 2.3: Add migrations if a new column is introduced; otherwise verify payload compatibility across existing records
   - Dependencies: Task 2.2
   - Notes: If adding a column, make it nullable with a default of null; existing versions without runnable_config must continue to behave as empty.
 
@@ -60,13 +60,13 @@ Add upload-time runnable config support so workflows can ship with initial confi
 
 #### Task Checklist
 
-- [ ] Task 3.1: Merge stored config with per-run config in workflow execution (run config precedence)
+- [x] Task 3.1: Merge stored config with per-run config in workflow execution (run config precedence)
   - Dependencies: Milestone 2
-- [ ] Task 3.2: Expose stored config in workflow version responses and `workflow show` output
+- [x] Task 3.2: Expose stored config in workflow version responses and `workflow show` output
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Update README and workflow upload docs with examples and warnings about secrets
+- [x] Task 3.3: Update README and workflow upload docs with examples and warnings about secrets
   - Dependencies: Task 3.2
-- [ ] Task 3.4: Add regression tests for runs without stored config and with overrides
+- [x] Task 3.4: Add regression tests for runs without stored config and with overrides
   - Dependencies: Task 3.1
 
 ---

--- a/docs/workflow_upload_config/3_plan.md
+++ b/docs/workflow_upload_config/3_plan.md
@@ -1,0 +1,75 @@
+# Project Plan
+
+## For Workflow Upload Runnable Config
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2025-12-21
+- **Status:** Draft
+
+---
+
+## Overview
+
+Add upload-time runnable config support so workflows can ship with initial configuration using `--config` or `--config-file`, and persist that config on workflow versions in the configured repository backend (SQLite by default). This plan coordinates CLI, API, repository, and runtime merge behavior.
+
+**Related Documents:**
+- Requirements: docs/workflow_upload_config/1_requirements.md
+- Design: docs/workflow_upload_config/2_design.md
+
+---
+
+## Milestones
+
+### Milestone 1: CLI and SDK Support
+
+**Description:** Expose `--config` and `--config-file` on workflow upload and forward validated config to upload services.
+
+#### Task Checklist
+
+- [ ] Task 1.1: Add `--config` and `--config-file` options to `orcheo workflow upload` with mutual exclusion and JSON validation
+  - Dependencies: None
+- [ ] Task 1.2: Reuse `_resolve_runnable_config` and thread parsed config through `upload_workflow_data` and LangGraph ingestion helpers
+  - Dependencies: Task 1.1
+- [ ] Task 1.3: Update CLI tests for JSON and script uploads to cover config inputs and invalid JSON cases
+  - Dependencies: Task 1.2
+
+---
+
+### Milestone 2: Backend API and Persistence
+
+**Description:** Accept and persist runnable config on workflow versions.
+
+#### Task Checklist
+
+- [ ] Task 2.1: Extend workflow version create/ingest schemas to accept `runnable_config` and validate with `RunnableConfigModel`
+  - Dependencies: Milestone 1
+- [ ] Task 2.2: Persist runnable config in workflow version payloads in the configured repository backend (SQLite by default; in-memory only for tests/dev)
+  - Dependencies: Task 2.1
+- [ ] Task 2.3: Add migrations if a new column is introduced; otherwise verify payload compatibility across existing records
+  - Dependencies: Task 2.2
+
+---
+
+### Milestone 3: Runtime Merge and Documentation
+
+**Description:** Use stored config during execution and document the new workflow upload behavior.
+
+#### Task Checklist
+
+- [ ] Task 3.1: Merge stored config with per-run config in workflow execution (run config precedence)
+  - Dependencies: Milestone 2
+- [ ] Task 3.2: Expose stored config in workflow version responses and `workflow show` output
+  - Dependencies: Task 3.1
+- [ ] Task 3.3: Update README and workflow upload docs with examples and warnings about secrets
+  - Dependencies: Task 3.2
+- [ ] Task 3.4: Add regression tests for runs without stored config and with overrides
+  - Dependencies: Task 3.1
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2025-12-21 | Codex | Initial draft |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -121,7 +121,7 @@ Available on all commands:
 | `orcheo workflow show <id>` | Display workflow details, versions, and runs | - |
 | `orcheo workflow run <id>` | Trigger a workflow execution | `--actor` - Actor name (default: "cli")<br>`--inputs` - JSON inputs payload<br>`--inputs-file` - Path to JSON inputs file |
 | `orcheo workflow delete <id>` | Delete a workflow | `--force` - Skip confirmation prompt |
-| `orcheo workflow upload <file>` | Upload workflow from Python or JSON file | `--id` - Workflow ID (for updates) |
+| `orcheo workflow upload <file>` | Upload workflow from Python or JSON file | `--id` - Workflow ID (for updates)<br>`--config` - JSON runnable config payload<br>`--config-file` - JSON runnable config file |
 | `orcheo workflow download <id>` | Download workflow configuration | `-o, --output` - Output file path<br>`-f, --format` - Format: json or python (default: json) |
 
 **Examples:**
@@ -143,6 +143,9 @@ orcheo workflow upload workflow.py
 # Update existing workflow
 orcheo workflow upload workflow.py --id my-workflow-id
 
+# Upload with runnable config defaults (stored per version)
+orcheo workflow upload workflow.py --config '{"tags": ["support"], "max_concurrency": 4}'
+
 # Download workflow as JSON
 orcheo workflow download my-workflow-id -o workflow.json
 
@@ -152,6 +155,8 @@ orcheo workflow download my-workflow-id -o workflow.py -f python
 # Delete a workflow
 orcheo workflow delete my-workflow-id --force
 ```
+
+Avoid putting secrets in runnable configs; use environment variables or credential vaults instead.
 
 ##### Node Management
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
@@ -11,13 +11,19 @@ from orcheo_sdk.cli.workflow.app import (
     ForceOption,
     FormatOption,
     OutputPathOption,
+    RunnableConfigFileOption,
+    RunnableConfigOption,
     WorkflowIdArgument,
     WorkflowIdOption,
     WorkflowNameOption,
     _state,
     workflow_app,
 )
-from orcheo_sdk.cli.workflow.inputs import _cache_notice, _validate_local_path
+from orcheo_sdk.cli.workflow.inputs import (
+    _cache_notice,
+    _resolve_runnable_config,
+    _validate_local_path,
+)
 from orcheo_sdk.services import (
     delete_workflow_data,
     download_workflow_data,
@@ -58,18 +64,22 @@ def upload_workflow(
     workflow_id: WorkflowIdOption = None,
     entrypoint: EntrypointOption = None,
     workflow_name: WorkflowNameOption = None,
+    config: RunnableConfigOption = None,
+    config_file: RunnableConfigFileOption = None,
 ) -> None:
     """Upload a workflow from a Python or JSON file."""
     state = _state(ctx)
     if state.settings.offline:
         raise CLIError("Uploading workflows requires network connectivity.")
 
+    runnable_config = _resolve_runnable_config(config, config_file)
     result = upload_workflow_data(
         state.client,
         file_path,
         workflow_id=workflow_id,
         workflow_name=workflow_name,
         entrypoint=entrypoint,
+        runnable_config=runnable_config,
         console=state.console,
     )
     identifier = workflow_id or result.get("id") or "workflow"

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
@@ -48,11 +48,12 @@ def run_workflow(
     runnable_config = _resolve_runnable_config(config, config_file)
     from orcheo_sdk.cli import workflow as workflow_module
 
-    graph_config = (
+    graph_payload = (
         workflow_module._prepare_streaming_graph(state, workflow_id) if stream else None
     )
 
-    if graph_config is not None:
+    if graph_payload is not None:
+        graph_config, stored_runnable_config = graph_payload
         final_status = asyncio.run(
             workflow_module._stream_workflow_run(
                 state,
@@ -61,6 +62,7 @@ def run_workflow(
                 input_payload,
                 triggered_by=triggered_by,
                 runnable_config=runnable_config,
+                stored_runnable_config=stored_runnable_config,
             )
         )
         if final_status in {"error", "cancelled", "connection_error", "timeout"}:
@@ -104,13 +106,14 @@ def evaluate_workflow(
     evaluation_payload = _resolve_evaluation_payload(evaluation, evaluation_file)
     from orcheo_sdk.cli import workflow as workflow_module
 
-    graph_config = (
+    graph_payload = (
         workflow_module._prepare_streaming_graph(state, workflow_id) if stream else None
     )
-    if graph_config is None:
+    if graph_payload is None:
         raise CLIError(
             "Evaluation requires streaming mode; unable to load workflow graph."
         )
+    graph_config, stored_runnable_config = graph_payload
 
     final_status = asyncio.run(
         workflow_module._stream_workflow_evaluation(
@@ -121,6 +124,7 @@ def evaluate_workflow(
             evaluation_payload,
             triggered_by=triggered_by,
             runnable_config=runnable_config,
+            stored_runnable_config=stored_runnable_config,
         )
     )
     if final_status in {"error", "cancelled", "connection_error", "timeout"}:

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
@@ -85,6 +85,9 @@ def _upload_langgraph_script(
         "notes": f"Uploaded from {path.name} via CLI",
         "created_by": "cli",
     }
+    runnable_config = workflow_config.get("runnable_config")
+    if runnable_config is not None:
+        ingest_payload["runnable_config"] = runnable_config
 
     try:
         version = state.client.post(

--- a/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
@@ -76,6 +76,7 @@ def upload_workflow_data(
     workflow_id: str | None = None,
     workflow_name: str | None = None,
     entrypoint: str | None = None,
+    runnable_config: dict[str, Any] | None = None,
     console: Any | None = None,
 ) -> dict[str, Any]:
     """Upload workflow definition from a local file."""
@@ -109,6 +110,8 @@ def upload_workflow_data(
     if workflow_config.get("_type") == "langgraph_script":
         if entrypoint:
             workflow_config["entrypoint"] = entrypoint
+        if runnable_config is not None:
+            workflow_config["runnable_config"] = runnable_config
         result = _upload_langgraph_workflow(
             state,  # type: ignore[arg-type]
             workflow_config,
@@ -120,6 +123,8 @@ def upload_workflow_data(
     else:
         if requested_name:
             workflow_config["name"] = requested_name
+        if runnable_config is not None:
+            workflow_config["runnable_config"] = runnable_config
         result = _submit_workflow_configuration(
             client,
             workflow_config,

--- a/src/orcheo/models/workflow_entities.py
+++ b/src/orcheo/models/workflow_entities.py
@@ -159,6 +159,7 @@ class WorkflowVersion(TimestampedAuditModel):
     version: int = Field(gt=0)
     graph: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    runnable_config: dict[str, Any] | None = None
     created_by: str
     notes: str | None = None
 

--- a/src/orcheo/runtime/runnable_config.py
+++ b/src/orcheo/runtime/runnable_config.py
@@ -173,7 +173,77 @@ def parse_runnable_config(
     return RunnableConfigModel.model_validate(value)
 
 
+def merge_runnable_configs(
+    stored: Mapping[str, Any] | RunnableConfigModel | None,
+    override: Mapping[str, Any] | RunnableConfigModel | None,
+) -> RunnableConfigModel:
+    """Merge stored and override configs, letting override fields win."""
+    base = parse_runnable_config(stored)
+    if override is None:
+        return base
+    override_model = (
+        override
+        if isinstance(override, RunnableConfigModel)
+        else RunnableConfigModel.model_validate(override)
+    )
+    if not override_model.model_fields_set:
+        return base  # pragma: no cover
+
+    merged = base.model_dump(mode="python")
+    fields_set = override_model.model_fields_set
+
+    if "configurable" in fields_set:
+        _merge_mapping_field(merged, base, override_model, "configurable")
+    if "metadata" in fields_set:
+        _merge_mapping_field(merged, base, override_model, "metadata")
+    if "prompts" in fields_set:
+        _merge_prompts_field(merged, base, override_model)
+
+    for field in (
+        "tags",
+        "callbacks",
+        "run_name",
+        "recursion_limit",
+        "max_concurrency",
+    ):
+        if field in fields_set:
+            value = getattr(override_model, field)
+            merged[field] = list(value) if isinstance(value, list) else value
+
+    return RunnableConfigModel.model_validate(merged)
+
+
+def _merge_mapping_field(
+    merged: dict[str, Any],
+    base: RunnableConfigModel,
+    override: RunnableConfigModel,
+    field_name: str,
+) -> None:
+    override_value = dict(getattr(override, field_name))
+    if override_value:
+        base_value = dict(getattr(base, field_name))
+        merged[field_name] = {**base_value, **override_value}
+    else:
+        merged[field_name] = {}
+
+
+def _merge_prompts_field(
+    merged: dict[str, Any],
+    base: RunnableConfigModel,
+    override: RunnableConfigModel,
+) -> None:
+    override_prompts = override.prompts
+    if override_prompts is None:
+        merged["prompts"] = None
+        return
+    base_prompts = base.prompts or {}
+    merged_prompts = dict(base_prompts)
+    merged_prompts.update(override_prompts)
+    merged["prompts"] = merged_prompts
+
+
 __all__ = [
     "RunnableConfigModel",
+    "merge_runnable_configs",
     "parse_runnable_config",
 ]

--- a/tests/backend/test_app_workflow_versions_create.py
+++ b/tests/backend/test_app_workflow_versions_create.py
@@ -20,9 +20,20 @@ async def test_create_workflow_version_success() -> None:
 
     workflow_id = uuid4()
     version_id = uuid4()
+    captured_config: dict[str, object] | None = None
 
     class Repository:
-        async def create_version(self, wf_id, graph, metadata, notes, created_by):
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
+            nonlocal captured_config
+            captured_config = runnable_config
             return WorkflowVersion(
                 id=version_id,
                 workflow_id=wf_id,
@@ -37,6 +48,7 @@ async def test_create_workflow_version_success() -> None:
     request = WorkflowVersionCreateRequest(
         graph={"nodes": []},
         metadata={"test": "data"},
+        runnable_config={"tags": ["v1"]},
         notes="Test version",
         created_by="admin",
     )
@@ -46,6 +58,7 @@ async def test_create_workflow_version_success() -> None:
     assert result.id == version_id
     assert result.workflow_id == workflow_id
     assert result.version == 1
+    assert captured_config == {"tags": ["v1"]}
 
 
 @pytest.mark.asyncio()
@@ -55,7 +68,15 @@ async def test_create_workflow_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
-        async def create_version(self, wf_id, graph, metadata, notes, created_by):
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
             raise WorkflowNotFoundError("not found")
 
     request = WorkflowVersionCreateRequest(
@@ -75,9 +96,20 @@ async def test_ingest_workflow_version_success() -> None:
 
     workflow_id = uuid4()
     version_id = uuid4()
+    captured_config: dict[str, object] | None = None
 
     class Repository:
-        async def create_version(self, wf_id, graph, metadata, notes, created_by):
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
+            nonlocal captured_config
+            captured_config = runnable_config
             return WorkflowVersion(
                 id=version_id,
                 workflow_id=wf_id,
@@ -96,12 +128,14 @@ async def test_ingest_workflow_version_success() -> None:
     request = WorkflowVersionIngestRequest(
         script=script_code,
         entrypoint="graph",
+        runnable_config={"tags": ["ingest"]},
         created_by="admin",
     )
 
     result = await ingest_workflow_version(workflow_id, request, Repository())
 
     assert result.id == version_id
+    assert captured_config == {"tags": ["ingest"]}
 
 
 @pytest.mark.asyncio()
@@ -111,7 +145,15 @@ async def test_ingest_workflow_version_script_error() -> None:
     workflow_id = uuid4()
 
     class Repository:
-        async def create_version(self, wf_id, graph, metadata, notes, created_by):
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
             return WorkflowVersion(
                 id=uuid4(),
                 workflow_id=wf_id,
@@ -141,7 +183,15 @@ async def test_ingest_workflow_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
-        async def create_version(self, wf_id, graph, metadata, notes, created_by):
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
             raise WorkflowNotFoundError("not found")
 
     script_code = (

--- a/tests/backend/test_chatkit_workflow_executor.py
+++ b/tests/backend/test_chatkit_workflow_executor.py
@@ -87,7 +87,11 @@ class DummyGraph:
 async def test_run_inserts_raw_messages_and_records_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    version = Mock(id="version", graph={"format": "standard"})
+    version = Mock(
+        id="version",
+        graph={"format": "standard"},
+        runnable_config=None,
+    )
     repository = AsyncMock()
     repository.get_latest_version.return_value = version
     run_record = Mock(id="run-id")

--- a/tests/sdk/test_cli_workflow_upload_json.py
+++ b/tests/sdk/test_cli_workflow_upload_json.py
@@ -55,3 +55,35 @@ def test_workflow_upload_json_file_update_existing(
         )
     assert result.exit_code == 0
     assert "updated successfully" in result.stdout
+
+
+def test_workflow_upload_json_file_with_runnable_config(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Test workflow upload forwards runnable config for JSON payloads."""
+    json_file = tmp_path / "workflow.json"
+    json_file.write_text(
+        json.dumps({"name": "TestWorkflow", "graph": {"nodes": [], "edges": []}}),
+        encoding="utf-8",
+    )
+
+    created = {"id": "wf-new", "name": "TestWorkflow"}
+    with respx.mock(assert_all_called=True) as router:
+        create_route = router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "upload",
+                str(json_file),
+                "--config",
+                '{"tags": ["alpha"], "max_concurrency": 3}',
+            ],
+            env=env,
+        )
+    assert result.exit_code == 0
+    body = json.loads(create_route.calls[0].request.content)
+    assert body["runnable_config"]["tags"] == ["alpha"]
+    assert body["runnable_config"]["max_concurrency"] == 3

--- a/tests/sdk/test_cli_workflow_upload_validation.py
+++ b/tests/sdk/test_cli_workflow_upload_validation.py
@@ -65,3 +65,23 @@ def test_workflow_upload_unsupported_file_type(
     assert result.exit_code != 0
     assert isinstance(result.exception, CLIError)
     assert "Unsupported file type" in str(result.exception)
+
+
+def test_workflow_upload_invalid_runnable_config(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Test workflow upload rejects invalid JSON config payloads."""
+    json_file = tmp_path / "workflow.json"
+    json_file.write_text(
+        '{"name": "TestWorkflow", "graph": {"nodes": [], "edges": []}}',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["workflow", "upload", str(json_file), "--config", "{not-json"],
+        env=env,
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, CLIError)
+    assert "Invalid JSON payload" in str(result.exception)

--- a/tests/sdk/test_workflow_cli_run.py
+++ b/tests/sdk/test_workflow_cli_run.py
@@ -26,6 +26,7 @@ def test_run_workflow_raises_on_failed_stream(
         inputs: Any,
         triggered_by: str | None = None,
         runnable_config: Any | None = None,
+        stored_runnable_config: Any | None = None,
     ) -> str:
         assert state_arg is state
         assert workflow_id == "wf-1"
@@ -33,6 +34,7 @@ def test_run_workflow_raises_on_failed_stream(
         assert inputs == {}
         assert triggered_by == "cli"
         assert runnable_config is None
+        assert stored_runnable_config is None
         return "error"
 
     monkeypatch.setattr("orcheo_sdk.cli.workflow._stream_workflow_run", fake_stream)
@@ -60,6 +62,7 @@ def test_run_workflow_allows_successful_stream(
         inputs: Any,
         triggered_by: str | None = None,
         runnable_config: Any | None = None,
+        stored_runnable_config: Any | None = None,
     ) -> str:
         assert state_arg is state
         assert workflow_id == "wf-1"
@@ -67,6 +70,7 @@ def test_run_workflow_allows_successful_stream(
         assert inputs == {}
         assert triggered_by == "cli"
         assert runnable_config is None
+        assert stored_runnable_config is None
         return "completed"
 
     monkeypatch.setattr("orcheo_sdk.cli.workflow._stream_workflow_run", fake_stream)
@@ -93,6 +97,7 @@ def test_evaluate_workflow_streams_progress(
         evaluation: Any,
         triggered_by: str | None = None,
         runnable_config: Any | None = None,
+        stored_runnable_config: Any | None = None,
     ) -> str:
         assert state_arg is state
         assert workflow_id == "wf-2"
@@ -101,6 +106,7 @@ def test_evaluate_workflow_streams_progress(
         assert evaluation == {"dataset": {"cases": [{"inputs": {"a": 1}}]}}
         assert triggered_by == "cli"
         assert runnable_config is None
+        assert stored_runnable_config is None
         return "completed"
 
     monkeypatch.setattr(
@@ -148,7 +154,7 @@ def test_evaluate_workflow_raises_on_failed_stream(
     payload = '{"dataset": {"cases": [{"inputs": {"value": 1}}]}}'
     monkeypatch.setattr(
         "orcheo_sdk.cli.workflow._prepare_streaming_graph",
-        lambda *_: {"nodes": []},
+        lambda *_: ({"nodes": []}, None),
     )
 
     async def fake_stream(
@@ -160,6 +166,7 @@ def test_evaluate_workflow_raises_on_failed_stream(
         *,
         triggered_by: str | None = None,
         runnable_config: Any | None = None,
+        stored_runnable_config: Any | None = None,
     ) -> str:
         return "error"
 

--- a/tests/sdk/test_workflow_cli_streaming.py
+++ b/tests/sdk/test_workflow_cli_streaming.py
@@ -80,6 +80,7 @@ async def test_stream_workflow_run_succeeds(
         {"input": "value"},
         triggered_by="cli-actor",
         runnable_config={"priority": "high"},
+        stored_runnable_config={"tags": ["stored"]},
     )
     assert result == "completed"
     assert connection.sent, "payload was not sent"
@@ -88,6 +89,7 @@ async def test_stream_workflow_run_succeeds(
     assert payload["inputs"] == {"input": "value"}
     assert payload["triggered_by"] == "cli-actor"
     assert payload["runnable_config"] == {"priority": "high"}
+    assert payload["stored_runnable_config"] == {"tags": ["stored"]}
 
 
 @pytest.mark.asyncio()
@@ -237,6 +239,7 @@ async def test_stream_workflow_evaluation_succeeds(
         {"name": "agent"},
         triggered_by="cli-actor",
         runnable_config={"priority": "high"},
+        stored_runnable_config={"tags": ["stored"]},
     )
     assert result == "completed"
     assert connection.sent, "payload was not sent"
@@ -244,6 +247,7 @@ async def test_stream_workflow_evaluation_succeeds(
     assert payload["type"] == "evaluate_workflow"
     assert payload["evaluation"] == {"name": "agent"}
     assert payload["runnable_config"] == {"priority": "high"}
+    assert payload["stored_runnable_config"] == {"tags": ["stored"]}
 
 
 @pytest.mark.asyncio()

--- a/tests/test_app_ingest_workflow_version.py
+++ b/tests/test_app_ingest_workflow_version.py
@@ -156,6 +156,7 @@ async def test_ingest_workflow_version_raises_not_found_error() -> None:
             *,
             graph: dict[str, object],
             metadata: dict[str, object],
+            runnable_config: dict[str, object] | None = None,
             notes: str | None,
             created_by: str,
         ):

--- a/tests/test_app_workflow_websocket.py
+++ b/tests/test_app_workflow_websocket.py
@@ -38,6 +38,7 @@ async def test_workflow_websocket_routes_requests() -> None:
         "test-execution",
         mock_websocket,
         runnable_config=None,
+        stored_runnable_config=None,
     )
     mock_websocket.close.assert_called_once()
 
@@ -73,6 +74,7 @@ async def test_workflow_websocket_routes_evaluation_requests() -> None:
         mock_websocket,
         evaluation={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
         runnable_config=None,
+        stored_runnable_config=None,
     )
 
 
@@ -107,4 +109,5 @@ async def test_workflow_websocket_routes_training_requests() -> None:
         mock_websocket,
         training={"dataset": {"cases": [{"inputs": {"foo": "bar"}}]}},
         runnable_config=None,
+        stored_runnable_config=None,
     )


### PR DESCRIPTION
1. Updated workflow upload config requirements/design/plan to store runnable_config with workflow versions in the configured repository backend (SQLite by default).
1. Standardized API/CLI naming on runnable_config, removed “default” naming, and clarified merge precedence with per-run config.
1. Documented reuse of workflow run config parsing/validation and added workflow show output expectations.
1. Clarified storage separation from Agentensor checkpoints and updated rollout/testing notes accordingly.