### PR TITLE
Enhancement/authentication

### DIFF
--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -86,6 +86,10 @@ def _build_api_router() -> APIRouter:
 
     router.include_router(chatkit_router.router)
     router.include_router(auth.router)
+    # Public webhook invocation routes - external services (Slack, GitHub, etc.)
+    # cannot provide Orcheo auth tokens. Security is enforced via webhook-level
+    # validation (HMAC signatures, shared secrets) configured per workflow.
+    router.include_router(triggers.public_webhook_router)
     router.include_router(protected_router)
     return router
 

--- a/apps/backend/src/orcheo_backend/app/routers/triggers.py
+++ b/apps/backend/src/orcheo_backend/app/routers/triggers.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Public router for webhook invocation endpoints that external services (Slack, etc.)
+# call directly. These routes are NOT protected by authentication because external
+# services cannot provide Orcheo auth tokens. Security is enforced via webhook-level
+# validation (HMAC signatures, shared secrets, etc.) configured per workflow.
+public_webhook_router = APIRouter()
+
 
 def _parse_webhook_body(
     raw_body: bytes, *, preserve_raw_body: bool
@@ -95,7 +101,7 @@ async def get_webhook_trigger_config(
         raise_not_found("Workflow not found", exc)
 
 
-@router.api_route(
+@public_webhook_router.api_route(
     "/workflows/{workflow_id}/triggers/webhook",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     response_model=WorkflowRun,
@@ -244,4 +250,4 @@ async def dispatch_manual_runs(
         ) from exc
 
 
-__all__ = ["router"]
+__all__ = ["router", "public_webhook_router"]

--- a/apps/backend/src/orcheo_backend/app/service_token_repository/postgres_repository.py
+++ b/apps/backend/src/orcheo_backend/app/service_token_repository/postgres_repository.py
@@ -132,7 +132,8 @@ class PostgresServiceTokenRepository(ServiceTokenRepository):
         self._pool_max_idle = pool_max_idle
         self._pool: Any | None = None
         self._lock = asyncio.Lock()
-        self._init_lock = asyncio.Lock()
+        self._pool_lock = asyncio.Lock()
+        self._schema_lock = asyncio.Lock()
         self._initialized = False
 
     async def _get_pool(self) -> Any:
@@ -140,7 +141,7 @@ class PostgresServiceTokenRepository(ServiceTokenRepository):
         if self._pool is not None:
             return self._pool
 
-        async with self._init_lock:
+        async with self._pool_lock:
             if self._pool is not None:
                 return self._pool
 
@@ -177,7 +178,7 @@ class PostgresServiceTokenRepository(ServiceTokenRepository):
         if self._initialized:
             return
 
-        async with self._init_lock:
+        async with self._schema_lock:
             if self._initialized:
                 return
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
+      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system
       - ORCHEO_MCP_STDIO_LOG=/dev/stderr
@@ -76,6 +78,8 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
+      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system
       - ORCHEO_MCP_STDIO_LOG=/dev/stderr
@@ -103,6 +107,8 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
+      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system
       - ORCHEO_MCP_STDIO_LOG=/dev/stderr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
-      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_MODE=required
       - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system
@@ -78,7 +78,7 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
-      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_MODE=required
       - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system
@@ -107,7 +107,7 @@ services:
       - ORCHEO_VAULT_BACKEND=postgres
       - ORCHEO_VAULT_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - ORCHEO_AUTH_SERVICE_TOKEN_BACKEND=postgres
-      - ORCHEO_AUTH_ENABLED=true
+      - ORCHEO_AUTH_MODE=required
       - ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       # Use system Python from base image instead of downloading
       - UV_PYTHON_PREFERENCE=system


### PR DESCRIPTION
1. Added public_webhook_router and mounted it in the API router so external services can hit webhook routes without Orcheo auth while still validating at the webhook leve
1. Enabled authentication by default for backend, worker, and trigger containers via Docker env vars so deployments default to authenticated mode
1. Split the service-token repository init lock into separate pool/schema locks to avoid deadlocks and updated the related race-condition tests to cover the new behaviors