### PR TITLE
Backend hardening

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,8 +10,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     npm \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv
+# Install uv (+ uvx shim)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
+    && chmod +x /usr/local/bin/uvx
 
 # Copy dependency files first for better caching
 COPY pyproject.toml uv.lock README.md ./

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ docker-up:
 docker-down:
 	docker compose down
 
+docker-restart:
+	docker compose restart
+
 docker-build:
 	docker compose build
 

--- a/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/base.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit_store_postgres/base.py
@@ -48,14 +48,15 @@ class BasePostgresStore(Store[ChatKitRequestContext]):
         self._pool_max_idle = pool_max_idle
         self._pool: Any | None = None
         self._lock = asyncio.Lock()
-        self._init_lock = asyncio.Lock()
+        self._pool_lock = asyncio.Lock()
+        self._schema_lock = asyncio.Lock()
         self._initialized = False
 
     async def _get_pool(self) -> Any:
         if self._pool is not None:
             return self._pool
 
-        async with self._init_lock:
+        async with self._pool_lock:
             if self._pool is not None:
                 return self._pool
 
@@ -92,7 +93,7 @@ class BasePostgresStore(Store[ChatKitRequestContext]):
         if self._initialized:
             return
 
-        async with self._init_lock:
+        async with self._schema_lock:
             if self._initialized:
                 return
 

--- a/apps/backend/src/orcheo_backend/app/factory.py
+++ b/apps/backend/src/orcheo_backend/app/factory.py
@@ -84,6 +84,7 @@ def _build_api_router() -> APIRouter:
     protected_router.include_router(nodes.router)
     protected_router.include_router(agentensor.router)
 
+    router.include_router(workflows.public_router)
     router.include_router(chatkit_router.router)
     router.include_router(auth.router)
     # Public webhook invocation routes - external services (Slack, GitHub, etc.)

--- a/apps/backend/src/orcheo_backend/app/schemas/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/workflows.py
@@ -97,3 +97,15 @@ class WorkflowPublishResponse(BaseModel):
 
     workflow: Workflow
     message: str | None = None
+    share_url: str | None = None
+
+
+class PublicWorkflow(BaseModel):
+    """Public workflow metadata returned without authentication."""
+
+    id: UUID
+    name: str
+    description: str | None = None
+    is_public: bool
+    require_login: bool
+    share_url: str | None = None

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-api.ts
@@ -3,10 +3,12 @@ import { buildBackendHttpUrl } from "@/lib/config";
 import type {
   ApiWorkflow,
   ApiWorkflowVersion,
+  PublicWorkflowMetadata,
   RequestOptions,
 } from "./workflow-storage.types";
 
 export const API_BASE = "/api/workflows";
+export const PUBLIC_WORKFLOW_PATH = "/api/workflows";
 
 const JSON_HEADERS = {
   Accept: "application/json",
@@ -64,6 +66,24 @@ export const fetchWorkflow = async (
 ): Promise<ApiWorkflow | undefined> => {
   try {
     return await request<ApiWorkflow>(`${API_BASE}/${workflowId}`);
+  } catch (error) {
+    if (
+      error instanceof ApiRequestError &&
+      (error.status === 404 || error.status === 410)
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+export const fetchPublicWorkflow = async (
+  workflowId: string,
+): Promise<PublicWorkflowMetadata | undefined> => {
+  try {
+    return await request<PublicWorkflowMetadata>(
+      `${PUBLIC_WORKFLOW_PATH}/${workflowId}/public`,
+    );
   } catch (error) {
     if (
       error instanceof ApiRequestError &&

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
@@ -20,6 +20,15 @@ export interface ApiWorkflow {
   updated_at: string;
 }
 
+export interface PublicWorkflowMetadata {
+  id: string;
+  name: string;
+  description: string | null;
+  is_public: boolean;
+  require_login: boolean;
+  share_url: string | null;
+}
+
 export interface ApiWorkflowVersion {
   id: string;
   workflow_id: string;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       - ./apps/canvas:/app
       - canvas_node_modules:/app/node_modules
     environment:
-      - VITE_ORCHEO_BACKEND_URL=http://localhost:8000
+      - VITE_ORCHEO_BACKEND_URL=https://orcheo.ai-colleagues.com
       - VITE_ORCHEO_AUTH_ISSUER=${VITE_ORCHEO_AUTH_ISSUER:-}
       - VITE_ORCHEO_AUTH_CLIENT_ID=${VITE_ORCHEO_AUTH_CLIENT_ID:-}
       - VITE_ORCHEO_AUTH_REDIRECT_URI=${VITE_ORCHEO_AUTH_REDIRECT_URI:-}
@@ -153,6 +153,7 @@ services:
       - VITE_ORCHEO_AUTH_PROVIDER_PARAM=${VITE_ORCHEO_AUTH_PROVIDER_PARAM:-}
       - VITE_ORCHEO_AUTH_PROVIDER_GOOGLE=${VITE_ORCHEO_AUTH_PROVIDER_GOOGLE:-}
       - VITE_ORCHEO_AUTH_PROVIDER_GITHUB=${VITE_ORCHEO_AUTH_PROVIDER_GITHUB:-}
+      - VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_6954ef8b091c8190b0734f266b51edd00094f73ed7d04989
     depends_on:
       - backend
     command: npm run dev -- --host 0.0.0.0

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -29,7 +29,7 @@ services read configuration via Dynaconf with the `ORCHEO_` prefix.
 | `ORCHEO_TRACING_INSECURE` | `false` | Boolean (`1/0`, `true/false`, etc.) | Allows insecure OTLP connections when set to true ([tracing/provider.py](../src/orcheo/tracing/provider.py)). |
 | `ORCHEO_TRACING_HIGH_TOKEN_THRESHOLD` | `1000` | Positive integer | Token usage threshold that emits `token.chunk` events ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
 | `ORCHEO_TRACING_PREVIEW_MAX_LENGTH` | `512` | Positive integer ≥ 16 | Maximum characters retained for prompt/response previews ([tracing/workflow.py](../src/orcheo/tracing/workflow.py)). |
-| `ORCHEO_CHATKIT_PUBLIC_BASE_URL` | _none_ | HTTP(S) URL | Optional frontend origin used when generating ChatKit share links in the CLI/MCP; defaults to `ORCHEO_API_URL` with any `/api` suffix removed when unset ([publish.py](../packages/sdk/src/orcheo_sdk/services/workflows/publish.py)). One-off overrides can be supplied via `orcheo workflow publish --chatkit-public-base-url`. |
+| `ORCHEO_CHATKIT_PUBLIC_BASE_URL` | _none_ | HTTP(S) URL | Optional frontend origin used when generating ChatKit share links in the backend API responses and the CLI/MCP; defaults to `ORCHEO_API_URL` with any `/api` suffix removed when unset in the CLI/MCP ([publish.py](../packages/sdk/src/orcheo_sdk/services/workflows/publish.py)). One-off overrides can be supplied via `orcheo workflow publish --chatkit-public-base-url`. |
 
 Note: `ORCHEO_REPOSITORY_BACKEND=inmemory` stores runs in-process only and does not enqueue webhook/cron/manual triggers for execution. These runs remain `PENDING` unless you execute them manually (for example, via the websocket runner).
 

--- a/examples/chatkit_agent/workflow.py
+++ b/examples/chatkit_agent/workflow.py
@@ -1,0 +1,30 @@
+"""ChatKit agent workflow.
+
+This workflow exposes a single AgentNode suitable for ChatKit's public UI.
+ChatKit sends message/history payloads; the AgentNode normalizes them into
+LangChain messages and generates a reply.
+"""
+
+from langgraph.graph import END, START, StateGraph
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode
+
+
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+
+
+def build_graph() -> StateGraph:
+    """Build the ChatKit agent workflow."""
+    graph = StateGraph(State)
+
+    agent_node = AgentNode(
+        name="agent",
+        ai_model=DEFAULT_MODEL,
+        model_kwargs={"api_key": "[[openai_api_key]]"},
+        system_prompt="{{config.configurable.system_prompt}}",
+    )
+
+    graph.add_node("agent", agent_node)
+    graph.add_edge(START, "agent")
+    graph.add_edge("agent", END)
+    return graph

--- a/examples/chatkit_widgets/chatkit_widgets.py
+++ b/examples/chatkit_widgets/chatkit_widgets.py
@@ -10,7 +10,7 @@ from orcheo.runtime.credentials import CredentialResolver, credential_resolution
 
 
 DEFAULT_MODEL = "openai:gpt-4o-mini"
-DEFAULT_WIDGETS_DIR = "path/to/widgets"
+DEFAULT_WIDGETS_DIR = "/app/examples/chatkit_widgets/widgets"
 DEFAULT_MESSAGE = "Generate a shopping list with the following items: apples, bananas, bread, milk, eggs, cheese, butter, and tomato."  # noqa: E501
 
 

--- a/examples/wecom_bot_responder/workflow.py
+++ b/examples/wecom_bot_responder/workflow.py
@@ -19,9 +19,12 @@ Orcheo vault secrets required:
 - wecom_encoding_aes_key: AES key for callback decryption
 """
 
+from collections.abc import Mapping
+from typing import Any
 from langgraph.graph import END, StateGraph
 from orcheo.edges import Condition, IfElse
 from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode
 from orcheo.nodes.wecom import (
     WeComAccessTokenNode,
     WeComCustomerServiceSendNode,
@@ -29,6 +32,79 @@ from orcheo.nodes.wecom import (
     WeComEventsParserNode,
     WeComSendMessageNode,
 )
+
+
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+
+
+def build_internal_agent_messages(state: State) -> dict[str, Any]:
+    """Build a user message list from internal WeCom messages."""
+    results = state.get("results", {})
+    parser_result = results.get("wecom_events_parser", {})
+    content = ""
+    if isinstance(parser_result, Mapping):
+        content = str(parser_result.get("content", "")).strip()
+    if not content:
+        return {"messages": []}
+    return {"messages": [{"role": "user", "content": content}]}
+
+
+def build_cs_agent_messages(state: State) -> dict[str, Any]:
+    """Build a user message list from Customer Service messages."""
+    results = state.get("results", {})
+    sync_result = results.get("wecom_cs_sync", {})
+    content = ""
+    if isinstance(sync_result, Mapping):
+        content = str(sync_result.get("content", "")).strip()
+    if not content:
+        return {"messages": []}
+    return {"messages": [{"role": "user", "content": content}]}
+
+
+def extract_reply_from_messages(messages: list[Any]) -> str | None:
+    """Return the most recent assistant reply from LangGraph messages."""
+    for message in messages[::-1]:
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            role = message.get("type") or message.get("role")
+        else:
+            content = None
+            role = None
+            try:
+                content = message.content
+            except AttributeError:
+                content = None
+            try:
+                role = message.type
+            except AttributeError:
+                try:
+                    role = message.role
+                except AttributeError:
+                    role = None
+        if role in ("ai", "assistant") and isinstance(content, str):
+            stripped = content.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def extract_agent_reply(state: State) -> dict[str, Any]:
+    """Extract the latest agent reply or fall back to configured text."""
+    reply = None
+    messages = state.get("messages")
+    if isinstance(messages, list):
+        reply = extract_reply_from_messages(messages)
+
+    if not reply:
+        config = state.get("config", {})
+        configurable = (
+            config.get("configurable", {}) if isinstance(config, dict) else {}
+        )
+        fallback = configurable.get("reply_message", "")
+        if isinstance(fallback, str) and fallback.strip():
+            reply = fallback.strip()
+
+    return {"results": {"agent_reply": reply or ""}}
 
 
 async def build_graph() -> StateGraph:
@@ -58,7 +134,7 @@ async def build_graph() -> StateGraph:
         WeComSendMessageNode(
             name="send_message",
             agent_id="{{config.configurable.agent_id}}",
-            message="{{config.configurable.reply_message}}",
+            message="{{agent_reply}}",
         ),
     )
 
@@ -86,9 +162,26 @@ async def build_graph() -> StateGraph:
         "wecom_cs_send",
         WeComCustomerServiceSendNode(
             name="wecom_cs_send",
-            message="{{config.configurable.reply_message}}",
+            message="{{agent_reply}}",
         ),
     )
+
+    graph.add_node(
+        "agent",
+        AgentNode(
+            name="agent",
+            ai_model=DEFAULT_MODEL,
+            model_kwargs={"api_key": "[[openai_api_key]]"},
+            system_prompt=(
+                "You are a helpful assistant responding to WeCom users. "
+                "Reply concisely, be friendly and professional, and match "
+                "the user's language."
+            ),
+        ),
+    )
+    graph.add_node("build_internal_agent_messages", build_internal_agent_messages)
+    graph.add_node("build_cs_agent_messages", build_cs_agent_messages)
+    graph.add_node("extract_agent_reply", extract_agent_reply)
 
     # Entry point
     graph.set_entry_point("wecom_events_parser")
@@ -143,7 +236,10 @@ async def build_graph() -> StateGraph:
     )
 
     # --- Internal user path ---
-    graph.add_edge("get_access_token", "send_message")
+    graph.add_edge("get_access_token", "build_internal_agent_messages")
+    graph.add_edge("build_internal_agent_messages", "agent")
+    graph.add_edge("agent", "extract_agent_reply")
+    graph.add_edge("extract_agent_reply", "send_message")
     graph.add_edge("send_message", END)
 
     # --- External user (CS) path ---
@@ -164,9 +260,11 @@ async def build_graph() -> StateGraph:
         cs_sync_router,
         {
             "true": END,  # No message from external user
-            "false": "wecom_cs_send",  # Send reply
+            "false": "build_cs_agent_messages",  # Send reply
         },
     )
+    graph.add_edge("build_cs_agent_messages", "agent")
     graph.add_edge("wecom_cs_send", END)
+    graph.add_edge("extract_agent_reply", "wecom_cs_send")
 
     return graph

--- a/src/orcheo/config/app_settings.py
+++ b/src/orcheo/config/app_settings.py
@@ -31,6 +31,7 @@ class AppSettings(BaseModel):
     chatkit_storage_path: str = Field(
         default=cast(str, _DEFAULTS["CHATKIT_STORAGE_PATH"])
     )
+    chatkit_public_base_url: str | None = None
     chatkit_max_upload_size_bytes: int = Field(
         default=cast(int, _DEFAULTS["CHATKIT_MAX_UPLOAD_SIZE_BYTES"]), gt=0
     )
@@ -157,6 +158,14 @@ class AppSettings(BaseModel):
     @classmethod
     def _coerce_chatkit_storage_path(cls, value: object) -> str:
         return str(value) if value is not None else ""
+
+    @field_validator("chatkit_public_base_url", mode="before")
+    @classmethod
+    def _coerce_chatkit_public_base_url(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
 
     @field_validator("chatkit_max_upload_size_bytes", mode="before")
     @classmethod

--- a/src/orcheo/config/defaults.py
+++ b/src/orcheo/config/defaults.py
@@ -8,6 +8,7 @@ _DEFAULTS: dict[str, object] = {
     "CHATKIT_BACKEND": "sqlite",
     "CHATKIT_SQLITE_PATH": "~/.orcheo/chatkit.sqlite",
     "CHATKIT_STORAGE_PATH": "~/.orcheo/chatkit",
+    "CHATKIT_PUBLIC_BASE_URL": None,
     "CHATKIT_MAX_UPLOAD_SIZE_BYTES": 5_000_000,
     "CHATKIT_RETENTION_DAYS": 30,
     "POSTGRES_DSN": None,

--- a/src/orcheo/config/loader.py
+++ b/src/orcheo/config/loader.py
@@ -40,6 +40,9 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
             chatkit_storage_path=source.get(
                 "CHATKIT_STORAGE_PATH", _DEFAULTS["CHATKIT_STORAGE_PATH"]
             ),
+            chatkit_public_base_url=source.get(
+                "CHATKIT_PUBLIC_BASE_URL", _DEFAULTS["CHATKIT_PUBLIC_BASE_URL"]
+            ),
             chatkit_max_upload_size_bytes=source.get(
                 "CHATKIT_MAX_UPLOAD_SIZE_BYTES",
                 _DEFAULTS["CHATKIT_MAX_UPLOAD_SIZE_BYTES"],
@@ -108,6 +111,7 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
     normalized.set("CHATKIT_BACKEND", settings.chatkit_backend)
     normalized.set("CHATKIT_SQLITE_PATH", settings.chatkit_sqlite_path)
     normalized.set("CHATKIT_STORAGE_PATH", settings.chatkit_storage_path)
+    normalized.set("CHATKIT_PUBLIC_BASE_URL", settings.chatkit_public_base_url)
     normalized.set(
         "CHATKIT_MAX_UPLOAD_SIZE_BYTES", settings.chatkit_max_upload_size_bytes
     )

--- a/src/orcheo/models/workflow_entities.py
+++ b/src/orcheo/models/workflow_entities.py
@@ -66,6 +66,7 @@ class Workflow(TimestampedAuditModel):
     published_at: datetime | None = None
     published_by: str | None = None
     require_login: bool = False
+    share_url: str | None = None
 
     @field_validator("name", mode="before")
     @classmethod

--- a/tests/backend/api/test_public_workflow_metadata.py
+++ b/tests/backend/api/test_public_workflow_metadata.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from uuid import UUID
+from fastapi.testclient import TestClient
+
+
+def _create_workflow(client: TestClient) -> UUID:
+    response = client.post(
+        "/api/workflows",
+        json={"name": "Public Metadata Workflow", "actor": "tester"},
+    )
+    assert response.status_code == 201
+    return UUID(response.json()["id"])
+
+
+def test_public_workflow_metadata_requires_public_workflow(
+    api_client: TestClient,
+) -> None:
+    workflow_id = _create_workflow(api_client)
+
+    response = api_client.get(f"/api/workflows/{workflow_id}/public")
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["code"] == "workflow.not_public"
+
+
+def test_public_workflow_metadata_returns_published_workflow(
+    api_client: TestClient,
+) -> None:
+    workflow_id = _create_workflow(api_client)
+    publish_response = api_client.post(
+        f"/api/workflows/{workflow_id}/publish",
+        json={"require_login": True, "actor": "publisher"},
+    )
+    assert publish_response.status_code == 201
+
+    response = api_client.get(f"/api/workflows/{workflow_id}/public")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == str(workflow_id)
+    assert payload["is_public"] is True
+    assert payload["require_login"] is True

--- a/tests/backend/authentication_test_utils.py
+++ b/tests/backend/authentication_test_utils.py
@@ -41,7 +41,7 @@ def reset_auth_state(
         "ORCHEO_AUTH_RATE_LIMIT_INTERVAL",
         "ORCHEO_AUTH_SERVICE_TOKEN_DB_PATH",
     ):
-        monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv(key, "")
     reset_authentication_state()
     try:
         yield

--- a/tests/backend/test_authentication_settings_warnings.py
+++ b/tests/backend/test_authentication_settings_warnings.py
@@ -35,7 +35,7 @@ def test_required_mode_without_credentials_warns(
     monkeypatch.setenv("ORCHEO_AUTH_MODE", "required")
     # Ensure no credentials are set
     monkeypatch.delenv("ORCHEO_AUTH_JWT_SECRET", raising=False)
-    monkeypatch.delenv("ORCHEO_AUTH_JWKS_URL", raising=False)
+    monkeypatch.setenv("ORCHEO_AUTH_JWKS_URL", "")
     monkeypatch.delenv("ORCHEO_AUTH_JWKS_STATIC", raising=False)
     monkeypatch.delenv("ORCHEO_AUTH_SERVICE_TOKEN_DB_PATH", raising=False)
     monkeypatch.delenv("ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN", raising=False)

--- a/tests/backend/test_chatkit_store_postgres_core.py
+++ b/tests/backend/test_chatkit_store_postgres_core.py
@@ -500,7 +500,7 @@ async def test_get_pool_caching(monkeypatch: pytest.MonkeyPatch) -> None:
         async def __aexit__(self, *args):
             pass
 
-    store._init_lock = SideEffectLock()  # type: ignore
+    store._pool_lock = SideEffectLock()  # type: ignore
 
     pool = await store._get_pool()
     assert pool == "race_pool"
@@ -517,7 +517,7 @@ async def test_ensure_initialized_race(monkeypatch: pytest.MonkeyPatch) -> None:
         async def __aexit__(self, *args):
             pass
 
-    store._init_lock = SideEffectLock()  # type: ignore
+    store._schema_lock = SideEffectLock()  # type: ignore
 
     # Should return early inside lock and NO connection activity (no responses needed)
     await store._ensure_initialized()

--- a/tests/backend/test_workflows_router_publish.py
+++ b/tests/backend/test_workflows_router_publish.py
@@ -46,9 +46,11 @@ class _RevokeRepo:
 
 def test_publish_response_uses_message_helper() -> None:
     workflow = Workflow(name="Responder")
+    workflow.share_url = "https://canvas.example/chat/wf-1"
     response = workflows._publish_response(workflow, message="ok")
     assert response.workflow is workflow
     assert response.message == "ok"
+    assert response.share_url == "https://canvas.example/chat/wf-1"
 
 
 @pytest.mark.asyncio()

--- a/tests/nodes/test_ai_agent_node_prompt_handling.py
+++ b/tests/nodes/test_ai_agent_node_prompt_handling.py
@@ -56,3 +56,14 @@ def test_get_params_skips_non_trainable_system_prompt() -> None:
     )
 
     assert node.get_params() == []
+
+
+def test_model_dump_serializes_text_tensor_prompt() -> None:
+    node = AgentNode(name="agent", ai_model="provider:model")
+    node.system_prompt = TextTensor(
+        text="serialized", requires_grad=True, model=SimpleNamespace()
+    )
+
+    payload = node.model_dump(mode="json")
+
+    assert payload["system_prompt"] == "serialized"

--- a/tests/sdk/test_services_workflows_publish.py
+++ b/tests/sdk/test_services_workflows_publish.py
@@ -93,6 +93,30 @@ def test_publish_workflow_data_prefers_explicit_public_base() -> None:
     assert result["share_url"] == "https://canvas.example/chat/wf-2"
 
 
+def test_publish_workflow_data_uses_server_share_url_when_available() -> None:
+    payload = {
+        "workflow": {
+            "id": "wf-10",
+            "is_public": True,
+            "require_login": False,
+            "share_url": "https://canvas.example/chat/wf-10",
+        },
+        "share_url": "https://canvas.example/chat/wf-10",
+        "message": "Published",
+    }
+    client = DummyClient(base_url="http://api.example.com/api", response=payload)
+
+    result = publish_module.publish_workflow_data(
+        client,
+        "wf-10",
+        require_login=False,
+        actor="cli",
+    )
+
+    assert result["share_url"] == "https://canvas.example/chat/wf-10"
+    assert result["workflow"]["share_url"] == "https://canvas.example/chat/wf-10"
+
+
 def test_unpublish_workflow_returns_enriched_workflow() -> None:
     workflow = {"id": "wf-3", "is_public": False}
     client = DummyClient(base_url="http://api.test", response=workflow)


### PR DESCRIPTION
## Summary of Staged Changes

This is a feature enhancement that adds **public workflow metadata API** and **share URL generation** for published workflows. Here's what changed:

### **Core Feature: Public Workflow API**
- **New endpoint** `GET /api/workflows/{workflow_id}/public` that returns workflow metadata without authentication ([test_public_workflow_metadata.py](tests/backend/api/test_public_workflow_metadata.py))
- **New schema** `PublicWorkflow` containing safe public fields: id, name, description, is_public, require_login, share_url ([workflows.py](apps/backend/src/orcheo_backend/app/schemas/workflows.py#L103-L109))
- Returns 403 if workflow is not published ([workflows.py](apps/backend/src/orcheo_backend/app/routers/workflows.py#L98-L116))

### **Share URL Generation**
- Added `ORCHEO_CHATKIT_PUBLIC_BASE_URL` environment variable to specify the Canvas frontend URL ([environment_variables.md](docs/environment_variables.md#L32))
- Added `share_url` field to `Workflow` model ([workflow_entities.py](src/orcheo/models/workflow_entities.py#L69))
- All workflow endpoints now populate `share_url` when workflow is public and the config is set ([workflows.py](apps/backend/src/orcheo_backend/app/routers/workflows.py#L44-L68))
- Backend-generated share URLs take precedence over SDK-generated ones when available ([publish.py](packages/sdk/src/orcheo_sdk/services/workflows/publish.py#L31-L43))

### **Configuration Handling**
- Added config loading for `CHATKIT_PUBLIC_BASE_URL` in settings ([app_settings.py](src/orcheo/config/app_settings.py#L34), [defaults.py](src/orcheo/config/defaults.py#L11), [loader.py](src/orcheo/config/loader.py#L43-L45))
- Includes validation to handle empty strings as None ([app_settings.py](src/orcheo/config/app_settings.py#L162-L167))

### **Bug Fixes & Improvements**
- Fixed `AgentNode.system_prompt` serialization when using `TextTensor` objects ([ai.py](src/orcheo/nodes/ai.py#L126-L131))
- Fixed test isolation issues with environment variables (use `setenv("")` instead of `delenv`) ([authentication_test_utils.py](tests/backend/authentication_test_utils.py#L44))
- Updated chatkit_widgets example with correct default path ([chatkit_widgets.py](examples/chatkit_widgets/chatkit_widgets.py#L13))
- Added `docker-restart` command to Makefile ([Makefile](Makefile#L52-L53))

### **Test Coverage**
- Added comprehensive tests for public workflow endpoint ([test_public_workflow_metadata.py](tests/backend/api/test_public_workflow_metadata.py))
- Added tests for share URL generation and backend/SDK coordination ([test_workflow_publish.py](tests/backend/api/test_workflow_publish.py#L42-L65), [test_services_workflows_publish.py](tests/sdk/test_services_workflows_publish.py#L96-L117))
- Added test for TextTensor serialization fix ([test_ai_agent_node_prompt_handling.py](tests/nodes/test_ai_agent_node_prompt_handling.py#L61-L68))
