### PR TITLE
Add WeCom Event Agent workflow with MongoDB persistence and agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ After installation, restart your shell or source your shell configuration file.
 | `orcheo agent-tool list [--category <category>]` | List available agent tools with metadata. Filter by category. |
 | `orcheo agent-tool show <tool>` | Display detailed tool schema and parameter information. |
 | `orcheo workflow list [--include-archived]` | List workflows with owner, last run, and status. |
-| `orcheo workflow show <workflow>` | Print workflow summary, publish status/details, Mermaid graph, and latest runs. |
+| `orcheo workflow show <workflow> [--version <num>]` | Print workflow summary, publish status/details, Mermaid graph, and runs. Use `--version` to show a specific version instead of the latest. |
 | `orcheo workflow run <workflow> [--inputs <json> \| --inputs-file <path>] [--config <json> \| --config-file <path>]` | Trigger a workflow execution and stream status to the console. |
 | `orcheo workflow upload <file> [--name <name>] [--config <json> \| --config-file <path>]` | Upload a workflow from Python or JSON file. |
-| `orcheo workflow download <workflow> [-o <file>]` | Download workflow definition as Python or JSON. |
+| `orcheo workflow download <workflow> [-o <file>] [--version <num>]` | Download workflow definition as Python or JSON. Use `--version` to download a specific version. |
 | `orcheo workflow delete <workflow> [--force]` | Delete a workflow with confirmation safeguards. |
 | `orcheo workflow schedule <workflow>` | Activate cron scheduling based on the workflow's cron trigger (no-op if none). |
 | `orcheo workflow unschedule <workflow>` | Remove cron scheduling for the workflow. |

--- a/docs/wecom_event_agent/1_requirements.md
+++ b/docs/wecom_event_agent/1_requirements.md
@@ -1,0 +1,127 @@
+# Requirements Document: WeCom Event Agent
+
+## METADATA
+- **Authors:** Codex
+- **Project/Feature Name:** WeCom Event Agent Workflow
+- **Type:** Feature
+- **Summary:** WeCom Customer Service workflow to create/update events, capture RSVPs, and fetch RSVP lists with MongoDB storage.
+- **Owner (if different than authors):** Shaojie Jiang
+- **Date Started:** 2025-01-02
+
+## RELEVANT LINKS & STAKEHOLDERS
+
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| WeCom App Setup | https://open.work.weixin.qq.com/wwopen/manual/detail?t=selfBuildApp | WeCom | Official Docs |
+| WeCom Customer Service Overview | https://developer.work.weixin.qq.com/document/path/94638 | WeCom | Customer Service Setup |
+| WeCom Customer Service Sync | https://developer.work.weixin.qq.com/document/path/94670 | WeCom | sync_msg API |
+| WeCom Callback Verification | https://developer.work.weixin.qq.com/document/path/90930 | WeCom | Callback Verification |
+| WeCom Bot Responder Requirements | [../wecom_bot_responder/1_requirements.md](../wecom_bot_responder/1_requirements.md) | Shaojie Jiang | WeCom Bot Responder Requirements |
+| WeCom Bot Responder Design | [../wecom_bot_responder/2_design.md](../wecom_bot_responder/2_design.md) | Shaojie Jiang | WeCom Bot Responder Design |
+| WeCom Bot Responder Plan | [../wecom_bot_responder/3_plan.md](../wecom_bot_responder/3_plan.md) | Shaojie Jiang | WeCom Bot Responder Plan |
+
+## PROBLEM DEFINITION
+### Objectives
+Deliver a WeCom workflow that can create or update events, record RSVPs, and list current RSVPs through chat messages. The workflow must validate and decrypt WeCom callbacks, parse user requests, persist data in MongoDB, and reply via Customer Service or internal WeCom messaging.
+
+### Target users
+External WeChat users messaging the enterprise Customer Service account, internal WeCom users, and operators who manage the WeCom app and workflow configuration.
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+| Event organizer | Create or edit an event by chat | I can manage event details without a separate UI | P0 | Event record is created/updated with title, description, date, location, and host metadata |
+| Attendee | Send an RSVP via chat | My attendance status is captured | P0 | RSVP entry is created/updated with status and timestamp |
+| Operator | Request RSVP list for an event | I can follow up with attendees | P1 | Workflow returns a list of RSVPs for the specified event |
+| Attendee | Request an event list by chat | I can find an event to attend | P1 | Workflow returns a list of recent events with IDs |
+
+### Context, Problems, Opportunities
+WeCom Customer Service provides a chat-based entry point for lightweight event coordination. A workflow that combines WeCom callback handling with MongoDB persistence allows teams to track event metadata and RSVPs without additional infrastructure. This builds on the existing WeCom bot responder patterns while adding structured event and RSVP storage.
+
+### Product goals and Non-goals
+**Goals:** Customer Service integration for event operations, reliable callback validation/decryption, clear chat responses, and MongoDB-backed event/RSVP storage.
+
+**Non-goals:** Calendar invitations, reminder scheduling, or complex event analytics.
+
+## PRODUCT DEFINITION
+### Requirements
+**P0 (must have)**
+- WeCom webhook handling uses the same signature validation/decryption flow as the WeCom bot responder.
+- Customer Service callbacks are parsed, and the latest text message is extracted for processing.
+- Internal WeCom direct messages are processed with the same command parsing and persistence logic as Customer Service messages.
+- Commands supported via Customer Service messages:
+  - Update Event: create/update events with title, description, ISO date, location, and host metadata, generating IDs when missing.
+  - Update RSVP: create/update attendee status (yes/no/maybe/cancelled) with timestamps.
+  - Get Event RSVPs: return the current RSVP list for an event.
+  - List Events: return a list of recent events with IDs.
+- Events and RSVPs stored in MongoDB collections.
+- Workflow replies via Customer Service with confirmation or RSVP list.
+- Example workflow script provided at `examples/wecom_event_agent/workflow.py` with a README and config file.
+
+**P1 (nice to have)**
+- Friendly error replies when required fields are missing.
+- Optional response formatting improvements (e.g., sorted lists).
+
+### Designs (if applicable)
+See [2_design.md](2_design.md) for the Orcheo workflow design.
+
+### [Optional] Other Teams Impacted
+- None identified.
+
+## TECHNICAL CONSIDERATIONS
+### Architecture Overview
+The workflow receives WeCom Customer Service callbacks, validates the signature, decrypts the payload, and syncs the latest CS message. An AI agent parses the request into a structured command. MongoDB operations store or retrieve event/RSVP data. The workflow returns a reply via WeCom Customer Service.
+
+### Technical Requirements
+- WeCom callback verification using Token, EncodingAESKey, and the callback signature params.
+- Customer Service sync using access tokens from corp ID and secret.
+- MongoDB collections for events and RSVPs with upsert semantics.
+- Timestamp handling (created_at/updated_at) for event and RSVP updates.
+- Secrets stored in Orcheo vault: `wecom_corp_secret`, `wecom_token`, `wecom_encoding_aes_key`, `mdb_connection_string`.
+
+### AI/ML Considerations (if applicable)
+#### Data Requirements
+WeCom message content from Customer Service callbacks is used to extract structured commands. No long-term storage of raw messages is required beyond event/RSVP data.
+
+#### Algorithm selection
+Use a chat model with a structured JSON prompt to parse event and RSVP intents.
+
+#### Model performance requirements
+The parser should return valid JSON for at least 95% of test prompts, with graceful fallback messaging when parsing fails.
+
+## MARKET DEFINITION (for products or large features)
+Not applicable; this is an internal workflow.
+
+## LAUNCH/ROLLOUT PLAN
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| [Primary] Event update success | 95%+ of event update messages stored in MongoDB |
+| [Secondary] RSVP update success | 95%+ of RSVP updates stored with timestamps |
+| [Secondary] Reply delivery | 95%+ Customer Service replies delivered |
+
+### Rollout Strategy
+Validate in a staging WeCom app, then enable the workflow in production once MongoDB and vault secrets are verified.
+
+### Experiment Plan (if applicable)
+Not applicable.
+
+### Estimated Launch Phases (if applicable)
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | Staging app | Validate callbacks, parsing, and MongoDB persistence |
+| **Phase 2** | Production app | Enable for end users and monitor errors |
+
+## HYPOTHESIS & RISKS
+- **Hypothesis:** A chat-driven workflow can reliably capture event metadata and RSVPs without a separate UI.
+- **Risk:** Parsing errors could store incomplete event data.
+  - **Mitigation:** Validate required fields and return clear error responses.
+- **Risk:** WeCom callback verification failures could block message processing.
+  - **Mitigation:** Reuse proven validation/decryption flow from the bot responder and log failures.
+
+## APPENDIX
+### Example Commands
+- Update event: "Team sync on 2025-03-20 at HQ. Host: Alex. Agenda: roadmap."
+- RSVP: "RSVP yes for event 1234"
+- Get RSVPs: "Get RSVPs for event 1234"
+- List events: "Show me upcoming events"

--- a/docs/wecom_event_agent/2_design.md
+++ b/docs/wecom_event_agent/2_design.md
@@ -1,0 +1,174 @@
+# Design Document
+
+## For WeCom Event Agent Workflow
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2025-01-02
+- **Status:** Draft
+
+---
+
+## Overview
+
+The WeCom Event Agent extends the WeCom bot responder patterns to support event
+operations through Customer Service messages and internal WeCom direct messages.
+It validates and decrypts WeCom callbacks, syncs the latest CS message when
+needed, uses an AI agent to parse event intents, stores events and RSVPs in
+MongoDB, and replies to the user via Customer Service or internal messaging.
+
+Key goals: reliable WeCom callback handling, structured event/RSVP persistence,
+and clear chat responses for create/update and reporting workflows.
+
+## Components
+
+- **Webhook + Parser (WeCom)**
+  - `WebhookTriggerNode` for WeCom callbacks.
+  - `WeComEventsParserNode` for signature validation, decryption, and CS event
+    detection (shared with the WeCom bot responder).
+- **Customer Service Sync + Reply**
+  - `WeComAccessTokenNode` to fetch access tokens.
+  - `WeComCustomerServiceSyncNode` to fetch the latest external message.
+  - `WeComCustomerServiceSendNode` to send the reply.
+- **Internal Message Reply**
+  - `WeComSendMessageNode` to respond to internal WeCom direct messages.
+- **Command Parsing**
+  - `AgentNode` with a strict JSON schema prompt to classify actions and extract
+    event/RSVP fields.
+  - `ParseCommandNode` to validate JSON output and normalize action fields.
+- **Persistence Layer**
+  - `MongoDBNode` for event upserts (by `event_id`).
+  - `MongoDBNode` for RSVP upserts (by `event_id` + `attendee_id`).
+  - `MongoDBFindNode` to retrieve RSVP lists.
+  - `MongoDBFindNode` to retrieve recent events for listing.
+- **Response Formatting**
+  - Task nodes to format confirmation messages and RSVP lists.
+- **Observability**
+  - Node-level logging and error handling from core WeCom/MongoDB nodes.
+
+## Request Flows
+
+### Flow 1: Update Event
+
+1. WeCom sends a CS or internal message callback.
+2. `WeComEventsParserNode` validates and decrypts the callback.
+3. For CS messages, `WeComCustomerServiceSyncNode` fetches the latest CS text message.
+4. `AgentNode` parses the message into a JSON command.
+5. `PrepareEventUpdateNode` validates required fields and assigns a new event ID
+   if missing.
+6. `MongoDBNode` upserts the event record.
+7. Reply is sent via `WeComCustomerServiceSendNode` or `WeComSendMessageNode`.
+
+### Flow 2: Update RSVP
+
+1. WeCom CS or internal callback triggers the workflow.
+2. The latest CS message is synced and parsed into a command.
+3. `PrepareRsvpUpdateNode` validates event ID, attendee ID, and status.
+4. `MongoDBNode` upserts the RSVP record with updated timestamps.
+5. Reply is sent via `WeComCustomerServiceSendNode` or `WeComSendMessageNode`.
+
+### Flow 3: Get Event RSVPs
+
+1. WeCom CS or internal callback triggers the workflow.
+2. The latest CS message is parsed into a `get_rsvps` command.
+3. `MongoDBFindNode` fetches RSVPs for the event.
+4. Reply is sent via `WeComCustomerServiceSendNode` or `WeComSendMessageNode`.
+
+### Flow 4: List Events
+
+1. WeCom CS or internal callback triggers the workflow.
+2. The latest message is parsed into a `list_events` command.
+3. `MongoDBFindNode` fetches recent events sorted by date.
+4. Reply is sent via `WeComCustomerServiceSendNode` or `WeComSendMessageNode`.
+
+## API Contracts
+
+### WeCom Customer Service Callback
+```
+POST /api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true
+Headers:
+  Content-Type: text/xml
+Query:
+  msg_signature, timestamp, nonce
+Body:
+  <xml>
+    <ToUserName><![CDATA[corp_id]]></ToUserName>
+    <Encrypt><![CDATA[encrypted_payload]]></Encrypt>
+  </xml>
+Response:
+  200 OK -> success
+```
+
+### WeCom Customer Service Send
+```
+POST https://qyapi.weixin.qq.com/cgi-bin/kf/send_msg?access_token=ACCESS_TOKEN
+Body:
+  {
+    "touser": "EXTERNAL_USER_ID",
+    "open_kfid": "OPEN_KF_ID",
+    "msgtype": "text",
+    "text": {"content": "Event saved: ..."}
+  }
+Response:
+  200 OK -> { "errcode": 0, "errmsg": "ok" }
+```
+
+## Data Models / Schemas
+
+### Event Document (MongoDB)
+| Field | Type | Description |
+|-------|------|-------------|
+| event_id | string | Workflow-generated or user-provided ID |
+| title | string | Event title |
+| description | string | Event description |
+| iso_date | string | ISO 8601 date/time |
+| location | string | Location text |
+| host | object | Host metadata (name/id/email) |
+| created_at | string | ISO timestamp |
+| updated_at | string | ISO timestamp |
+
+### RSVP Document (MongoDB)
+| Field | Type | Description |
+|-------|------|-------------|
+| event_id | string | Event ID |
+| attendee_id | string | WeCom external user ID |
+| attendee_name | string | Optional name |
+| status | string | yes/no/maybe/cancelled |
+| created_at | string | ISO timestamp |
+| updated_at | string | ISO timestamp |
+
+## Security Considerations
+
+- Validate WeCom signatures and timestamps to prevent spoofed callbacks.
+- Decrypt callbacks with the configured Token and EncodingAESKey.
+- Store secrets in Orcheo vault and avoid logging raw secrets.
+- Restrict processing to CS events and validate required fields before writes.
+
+## Performance Considerations
+
+- MongoDB upserts avoid separate read-modify-write cycles.
+- RSVP list queries use a limit and sort by `updated_at` for predictable output.
+
+## Testing Strategy
+
+- **Unit tests**: command parsing, required field validation, RSVP status mapping.
+- **Integration tests**: MongoDB upsert and RSVP fetch behavior.
+- **Manual QA checklist**: send CS messages for each command and verify replies.
+
+## Rollout Plan
+
+1. Phase 1: Deploy to a staging WeCom app and validate callback handling.
+2. Phase 2: Enable in production and monitor MongoDB writes and reply delivery.
+
+## Open Issues
+
+- Message phrasing is flexible because the agent parses natural language.
+- Internal WeCom messages are handled with the same command parsing flow as CS.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2025-01-02 | Codex | Initial draft |

--- a/docs/wecom_event_agent/3_plan.md
+++ b/docs/wecom_event_agent/3_plan.md
@@ -1,0 +1,80 @@
+# Project Plan
+
+## For WeCom Event Agent Workflow
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Date:** 2025-01-02
+- **Status:** Draft
+
+---
+
+## Overview
+
+Deliver a WeCom workflow for Customer Service and internal messages that
+creates/updates events, captures RSVPs, and lists RSVPs backed by MongoDB
+storage. The plan aligns with the WeCom bot responder patterns for validation
+and reply delivery.
+
+**Related Documents:**
+- Requirements: [1_requirements.md](1_requirements.md)
+- Design: [2_design.md](2_design.md)
+
+---
+
+## Milestones
+
+### Milestone 1: Workflow Core and MongoDB Persistence
+
+**Description:** Build the CS workflow path and implement event/RSVP storage.
+
+#### Task Checklist
+
+- [x] Task 1.1: Configure WeCom CS webhook parsing and access token flow.
+  - Dependencies: None
+- [x] Task 1.2: Implement command parsing for update_event, update_rsvp, get_rsvps.
+  - Dependencies: Task 1.1
+- [x] Task 1.3: Add MongoDB upsert nodes for events and RSVPs.
+  - Dependencies: Task 1.2
+- [x] Task 1.4: Add MongoDB RSVP lookup and formatted replies.
+  - Dependencies: Task 1.3
+- [x] Task 1.5: Add MongoDB event list lookup and formatted replies.
+  - Dependencies: Task 1.3
+
+---
+
+### Milestone 2: Reply Handling and Validation
+
+**Description:** Harden the workflow with validation and error responses.
+
+#### Task Checklist
+
+- [x] Task 2.1: Validate required event fields and RSVP fields.
+  - Dependencies: Milestone 1
+- [x] Task 2.2: Add user-facing error replies for missing data or invalid status.
+  - Dependencies: Task 2.1
+- [x] Task 2.3: Document example prompts and configuration inputs.
+  - Dependencies: Task 2.1
+
+---
+
+### Milestone 3: Example Delivery and QA
+
+**Description:** Deliver the example workflow and run basic verification.
+
+#### Task Checklist
+
+- [x] Task 3.1: Create `examples/wecom_event_agent/workflow.py` and config.
+  - Dependencies: Milestone 2
+- [x] Task 3.2: Add README with setup steps and test instructions.
+  - Dependencies: Task 3.1
+- [x] Task 3.3: Run a local CS callback test in staging.
+  - Dependencies: Task 3.2
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2025-01-02 | Codex | Initial draft |

--- a/examples/wecom_echo_history/workflow.py
+++ b/examples/wecom_echo_history/workflow.py
@@ -1,0 +1,197 @@
+"""WeCom Customer Service echo history workflow.
+
+Configure WeCom to send callback requests to:
+`/api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true`
+so signatures can be verified.
+
+Configurable inputs (workflow_config.json):
+- corp_id (WeCom corp ID)
+
+Orcheo vault secrets required:
+- wecom_corp_secret: WeCom app secret for access token
+- wecom_token: Callback token for signature validation
+- wecom_encoding_aes_key: AES key for callback decryption
+"""
+
+from collections.abc import Mapping
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, StateGraph
+from orcheo.edges import Condition, IfElse
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.wecom import (
+    WeComAccessTokenNode,
+    WeComCustomerServiceSendNode,
+    WeComCustomerServiceSyncNode,
+    WeComEventsParserNode,
+)
+
+
+def normalize_role(role: str | None, direction: str | None) -> str:
+    """Return a standardized sender label based on role and direction."""
+    if role in {"ai", "assistant"}:
+        return "assistant"
+    if role == "user":
+        return "user"
+    if direction == "outbound":
+        return "assistant"
+    if direction == "inbound":
+        return "user"
+    return "unknown"
+
+
+class BuildEchoReplyNode(TaskNode):
+    """Build a reply that lists the full CS chat history."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Assemble the customer service chat history into a reply."""
+        results = state.get("results", {})
+        sync_result = results.get("wecom_cs_sync", {})
+        history = (
+            sync_result.get("messages") if isinstance(sync_result, Mapping) else None
+        )
+
+        entries: list[tuple[int, str, str]] = []
+        if isinstance(history, list):
+            for item in history:
+                if not isinstance(item, Mapping):
+                    continue
+                content = item.get("content")
+                if not isinstance(content, str):
+                    continue
+                cleaned = " ".join(content.splitlines()).strip()
+                if not cleaned:
+                    continue
+                role = normalize_role(item.get("role"), item.get("direction"))
+                msgtime = item.get("msgtime", 0)
+                if not isinstance(msgtime, int):
+                    msgtime = 0
+                entries.append((msgtime, role, cleaned))
+
+        entries.sort(key=lambda item: item[0])
+
+        if not entries:
+            reply = "No chat history yet."
+        else:
+            lines = ["Chat history:"]
+            index = 1
+            for _, role, content in entries:
+                lines.append(f"{index}. {role}: {content}")
+                index = index + 1
+            reply = "\n".join(lines)
+
+        return {"echo_reply": reply}
+
+
+async def build_graph() -> StateGraph:
+    """Build the WeCom CS echo history workflow."""
+    graph = StateGraph(State)
+
+    graph.add_node(
+        "wecom_events_parser",
+        WeComEventsParserNode(
+            name="wecom_events_parser",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "get_cs_access_token",
+        WeComAccessTokenNode(
+            name="get_cs_access_token",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "wecom_cs_sync",
+        WeComCustomerServiceSyncNode(
+            name="wecom_cs_sync",
+        ),
+    )
+
+    graph.add_node(
+        "wecom_cs_send",
+        WeComCustomerServiceSendNode(
+            name="wecom_cs_send",
+            message="{{build_echo_reply.echo_reply}}",
+        ),
+    )
+
+    graph.add_node(
+        "build_echo_reply",
+        BuildEchoReplyNode(
+            name="build_echo_reply",
+        ),
+    )
+
+    graph.set_entry_point("wecom_events_parser")
+
+    immediate_response_router = IfElse(
+        name="immediate_response_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.immediate_response}}",
+                operator="is_truthy",
+            ),
+            Condition(
+                left="{{wecom_events_parser.should_process}}",
+                operator="is_falsy",
+            ),
+        ],
+        condition_logic="or",
+    )
+
+    message_type_router = IfElse(
+        name="message_type_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.is_customer_service}}",
+                operator="is_truthy",
+            ),
+        ],
+    )
+
+    graph.add_conditional_edges(
+        "wecom_events_parser",
+        immediate_response_router,
+        {
+            "true": END,
+            "false": "route_by_type",
+        },
+    )
+
+    graph.add_node("route_by_type", lambda _: {})
+    graph.add_conditional_edges(
+        "route_by_type",
+        message_type_router,
+        {
+            "true": "get_cs_access_token",
+            "false": END,
+        },
+    )
+
+    graph.add_edge("get_cs_access_token", "wecom_cs_sync")
+
+    cs_sync_router = IfElse(
+        name="cs_sync_router",
+        conditions=[
+            Condition(
+                left="{{wecom_cs_sync.should_process}}",
+                operator="is_falsy",
+            ),
+        ],
+    )
+    graph.add_conditional_edges(
+        "wecom_cs_sync",
+        cs_sync_router,
+        {
+            "true": END,
+            "false": "build_echo_reply",
+        },
+    )
+    graph.add_edge("build_echo_reply", "wecom_cs_send")
+    graph.add_edge("wecom_cs_send", END)
+
+    return graph

--- a/examples/wecom_event_agent/README.md
+++ b/examples/wecom_event_agent/README.md
@@ -1,0 +1,78 @@
+# WeCom Event Agent Workflow Example
+
+This example processes WeCom Customer Service (CS) and internal WeCom messages to:
+
+- Create or update events
+- Capture RSVPs (yes/no/maybe/cancelled)
+- List RSVPs for an event
+
+The workflow validates WeCom callbacks, syncs the latest CS message, parses the
+user request into a structured command, stores data in MongoDB, and replies to
+the user via Customer Service.
+
+## Configuration
+
+Edit `workflow_config.json` to set:
+
+```json
+{
+  "configurable": {
+    "corp_id": "YOUR_WECOM_CORP_ID",
+    "agent_id": 1000002,
+    "events_database": "events",
+    "events_collection": "events",
+    "rsvps_collection": "event_rsvps"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `corp_id` | WeCom corporation ID |
+| `agent_id` | WeCom app agent ID for internal messages |
+| `events_database` | MongoDB database name for events/RSVPs |
+| `events_collection` | MongoDB collection for events |
+| `rsvps_collection` | MongoDB collection for RSVPs |
+
+## Orcheo Vault Secrets
+
+Configure these secrets in the Orcheo vault (referenced via `[[key]]` syntax):
+
+| Secret Key | Description |
+|------------|-------------|
+| `wecom_corp_secret` | WeCom app secret for access token retrieval |
+| `wecom_token` | Callback token for signature validation |
+| `wecom_encoding_aes_key` | AES key for callback payload decryption |
+| `mdb_connection_string` | MongoDB connection string |
+| `openai_api_key` | API key for the agent model |
+
+## WeCom Customer Service Setup
+
+1. Create a self-built app in the WeCom admin console.
+2. Configure the callback URL to point to:
+   ```
+   https://your-domain/api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true
+   ```
+3. Set the callback Token and EncodingAESKey, then save them in the Orcheo vault.
+4. Enable WeChat Customer Service in the app settings and assign the app to the
+   Customer Service account.
+
+## Internal WeCom Messages
+
+Internal users can message the app directly. The workflow handles these messages
+with the same command parsing and MongoDB updates as CS messages, replying via
+the WeCom app using `agent_id`.
+
+## Example Prompts
+
+- "Update event: Team meetup on 2025-03-20 at HQ, hosted by Alex. Agenda: roadmap."
+- "RSVP yes for event 4f7a..."
+- "Get RSVPs for event 4f7a..."
+- "List upcoming events"
+
+## Testing
+
+1. Use an HTTPS tunnel (for example, Cloudflare Tunnel) to expose your local
+   server to WeCom.
+2. Start the Orcheo server with `make dev-server`.
+3. Send a Customer Service message and confirm the workflow reply.

--- a/examples/wecom_event_agent/workflow.py
+++ b/examples/wecom_event_agent/workflow.py
@@ -1,0 +1,1337 @@
+"""WeCom Event Agent workflow for Customer Service messages.
+
+Configure WeCom to send callback requests to:
+`/api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true`
+so signatures can be verified.
+
+Configurable inputs (workflow_config.json):
+- corp_id (WeCom corp ID)
+- agent_id (WeCom app agent ID for internal messages)
+- events_database (MongoDB database for events/RSVPs)
+- events_collection (MongoDB collection for events)
+- rsvps_collection (MongoDB collection for RSVPs)
+
+Orcheo vault secrets required:
+- wecom_corp_secret: WeCom app secret for access token
+- wecom_token: Callback token for signature validation
+- wecom_encoding_aes_key: AES key for callback decryption
+- mdb_connection_string: MongoDB connection string
+"""
+
+import json
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, StateGraph
+from orcheo.edges import Condition, IfElse
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.mongodb import MongoDBFindNode, MongoDBNode
+from orcheo.nodes.wecom import (
+    WeComAccessTokenNode,
+    WeComCustomerServiceSendNode,
+    WeComCustomerServiceSyncNode,
+    WeComEventsParserNode,
+    WeComSendMessageNode,
+)
+
+
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+
+
+def extract_reply_from_messages(messages: list[Any]) -> str | None:
+    """Return the most recent assistant reply from LangGraph messages."""
+    for message in messages[::-1]:
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            role = message.get("type") or message.get("role")
+        else:
+            content = None
+            role = None
+            try:
+                content = message.content
+            except AttributeError:
+                content = None
+            try:
+                role = message.type
+            except AttributeError:
+                try:
+                    role = message.role
+                except AttributeError:
+                    role = None
+        if role in ("ai", "assistant") and isinstance(content, str):
+            stripped = content.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+class ExtractAgentReplyNode(TaskNode):
+    """Extract the latest agent reply or fall back to an empty string."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return the agent's latest reply or an empty fallback."""
+        reply = None
+        messages = state.get("messages")
+        if isinstance(messages, list):
+            reply = extract_reply_from_messages(messages)
+        return {"agent_reply": reply or ""}
+
+
+class NoOpNode(TaskNode):
+    """No-op task node used as a routing placeholder."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return an empty payload for routing placeholders."""
+        return {}
+
+
+class ParseCommandNode(TaskNode):
+    """Parse agent JSON output into a command payload."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Parse the agent's JSON reply into structured action data."""
+        results = state.get("results", {})
+        agent_reply = ""
+        if isinstance(results, Mapping):
+            reply_result = results.get("extract_agent_reply", {})
+            if isinstance(reply_result, Mapping):
+                agent_reply = str(reply_result.get("agent_reply", ""))
+        agent_reply = agent_reply.strip()
+
+        if not agent_reply:
+            return {
+                "action": "unknown",
+                "event": {},
+                "rsvp": {},
+                "error": "Empty agent reply",
+            }
+
+        try:
+            data = json.loads(agent_reply)
+        except json.JSONDecodeError:
+            return {
+                "action": "unknown",
+                "event": {},
+                "rsvp": {},
+                "error": "Agent reply is not valid JSON",
+            }
+
+        if not isinstance(data, dict):
+            return {
+                "action": "unknown",
+                "event": {},
+                "rsvp": {},
+                "error": "Agent reply JSON must be an object",
+            }
+
+        action = str(data.get("action", "unknown")).strip().lower() or "unknown"
+        event = data.get("event") if isinstance(data.get("event"), dict) else {}
+        rsvp = data.get("rsvp") if isinstance(data.get("rsvp"), dict) else {}
+        return {"action": action, "event": event, "rsvp": rsvp, "error": None}
+
+
+class PrepareEventUpdateNode(TaskNode):
+    """Prepare MongoDB update payload for an event."""
+
+    @staticmethod
+    def coerce_host(host_value: Any) -> dict[str, str]:
+        """Normalize host information into a trimmed dict with allowed keys."""
+        if isinstance(host_value, dict):
+            host = {
+                key: str(value).strip()
+                for key, value in host_value.items()
+                if key in {"name", "id", "email"} and str(value).strip()
+            }
+            return host
+        if isinstance(host_value, str) and host_value.strip():
+            return {"name": host_value.strip()}
+        return {}
+
+    @staticmethod
+    def resolve_requester_id(results: Mapping) -> str:
+        """Resolve requester ID from internal or customer service messages."""
+        parser_result = results.get("wecom_events_parser", {})
+        cs_sync_result = results.get("wecom_cs_sync", {})
+
+        internal_user_id = ""
+        if isinstance(parser_result, Mapping):
+            internal_user_id = str(
+                parser_result.get("user") or parser_result.get("target_user") or ""
+            ).strip()
+
+        external_userid = ""
+        if isinstance(cs_sync_result, Mapping):
+            external_userid = str(cs_sync_result.get("external_userid") or "").strip()
+
+        return external_userid or internal_user_id
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Validate parsed event data and prepare a MongoDB update payload."""
+        results = state.get("results", {})
+        parse_result = results.get("parse_command", {})
+
+        requester_id = (
+            self.resolve_requester_id(results) if isinstance(results, Mapping) else ""
+        )
+        if not requester_id:
+            return {
+                "is_valid": False,
+                "reply_message": "无法识别请求者，请稍后再试。",
+            }
+
+        event_data = self._normalize_event(parse_result)
+        missing = self._missing_fields(event_data)
+        if missing:
+            missing_str = ", ".join(missing)
+            return {
+                "is_valid": False,
+                "reply_message": (f"请提供以下活动信息：{missing_str}。"),
+            }
+
+        event_id, generated_id = self._resolve_event_id(event_data)
+        if not event_id:
+            return {
+                "is_valid": False,
+                "reply_message": "请提供 event_id 以结束活动。",
+            }
+
+        now = datetime.now(UTC).isoformat()
+        update_doc = self._build_update_doc(event_data, event_id, requester_id, now)
+
+        return {
+            "is_valid": True,
+            "event_id": event_id,
+            "filter": {"event_id": event_id},
+            "update": update_doc,
+            "title": event_data["title"],
+            "description": event_data["description"],
+            "iso_date": event_data["iso_date"],
+            "location": event_data["location"],
+            "host": event_data["host"],
+            "generated_id": generated_id,
+            "requester_id": requester_id,
+            "is_end_request": event_data["is_end_request"],
+            "reply_message": "",
+        }
+
+    def _normalize_event(self, parse_result: Any) -> dict[str, Any]:
+        event = (
+            parse_result.get("event", {}) if isinstance(parse_result, Mapping) else {}
+        )
+        action = (
+            str(parse_result.get("action", "")).strip().lower()
+            if isinstance(parse_result, Mapping)
+            else ""
+        )
+        status_raw = str(event.get("status", "")).strip().lower()
+        return {
+            "action": action,
+            "is_end_request": action == "end_event" or status_raw in {"ended", "end"},
+            "status_raw": status_raw,
+            "event_id": str(event.get("event_id", "")).strip(),
+            "title": str(event.get("title", "")).strip(),
+            "description": str(event.get("description", "")).strip(),
+            "iso_date": str(event.get("iso_date") or event.get("date") or "").strip(),
+            "location": str(event.get("location", "")).strip(),
+            "host": self.coerce_host(event.get("host")),
+        }
+
+    def _missing_fields(self, event_data: Mapping[str, Any]) -> list[str]:
+        if event_data["is_end_request"]:
+            return []
+        missing: list[str] = []
+        for key in ("title", "description", "iso_date", "location"):
+            if not event_data[key]:
+                missing.append(key)
+        if not event_data["host"]:
+            missing.append("host")
+        return missing
+
+    def _resolve_event_id(self, event_data: Mapping[str, Any]) -> tuple[str, bool]:
+        event_id = event_data["event_id"]
+        generated_id = False
+        if not event_id and not event_data["is_end_request"]:
+            event_id = str(uuid.uuid4())
+            generated_id = True
+        return event_id, generated_id
+
+    def _build_update_doc(
+        self,
+        event_data: Mapping[str, Any],
+        event_id: str,
+        requester_id: str,
+        now: str,
+    ) -> dict[str, Any]:
+        update_fields: dict[str, Any] = {
+            "event_id": event_id,
+            "updated_at": now,
+        }
+        if event_data["is_end_request"]:
+            update_fields.update(
+                {
+                    "status": "ended",
+                    "ended_at": now,
+                }
+            )
+        else:
+            update_fields.update(
+                {
+                    "title": event_data["title"],
+                    "description": event_data["description"],
+                    "iso_date": event_data["iso_date"],
+                    "location": event_data["location"],
+                    "host": event_data["host"],
+                }
+            )
+        return {
+            "$set": update_fields,
+            "$setOnInsert": {"created_at": now, "creator_id": requester_id},
+        }
+
+
+class PrepareRsvpUpdateNode(TaskNode):
+    """Prepare MongoDB update payload for an RSVP."""
+
+    STATUS_MAP: ClassVar[dict[str, str]] = {
+        "yes": "yes",
+        "y": "yes",
+        "going": "yes",
+        "accept": "yes",
+        "accepted": "yes",
+        "no": "no",
+        "n": "no",
+        "decline": "no",
+        "declined": "no",
+        "maybe": "maybe",
+        "tentative": "maybe",
+        "cancel": "cancelled",
+        "canceled": "cancelled",
+        "cancelled": "cancelled",
+    }
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Validate RSVP data and prepare a MongoDB update payload."""
+        results = state.get("results", {})
+        parse_result = results.get("parse_command", {})
+        rsvp = parse_result.get("rsvp", {}) if isinstance(parse_result, dict) else {}
+        cs_result = results.get("wecom_cs_sync", {})
+
+        event_id = str(
+            rsvp.get("event_id") or parse_result.get("event_id") or ""
+        ).strip()
+        attendee_id = str(
+            rsvp.get("attendee_id")
+            or (cs_result.get("external_userid") if isinstance(cs_result, dict) else "")
+            or ""
+        ).strip()
+        attendee_name = str(rsvp.get("attendee_name", "")).strip()
+        external_username_raw = (
+            cs_result.get("external_username") if isinstance(cs_result, dict) else ""
+        )
+        external_username = ""
+        if external_username_raw not in (None, "None"):
+            external_username = str(external_username_raw).strip()
+        if not attendee_name and external_username:
+            attendee_name = external_username
+        status_raw = str(rsvp.get("status", "")).strip().lower()
+        status = self.STATUS_MAP.get(status_raw, status_raw)
+
+        missing = []
+        if not event_id:
+            missing.append("event_id")
+        if not attendee_id:
+            missing.append("attendee_id")
+        if not status:
+            missing.append("status")
+
+        if status and status not in {"yes", "no", "maybe", "cancelled"}:
+            return {
+                "is_valid": False,
+                "reply_message": ("RSVP 状态必须是 yes、no、maybe 或 cancelled。"),
+            }
+
+        if missing:
+            missing_str = ", ".join(missing)
+            return {
+                "is_valid": False,
+                "reply_message": (f"请提供 RSVP 详情：{missing_str}。"),
+            }
+
+        now = datetime.now(UTC).isoformat()
+        update_fields: dict[str, Any] = {
+            "event_id": event_id,
+            "attendee_id": attendee_id,
+            "status": status,
+            "updated_at": now,
+        }
+        if attendee_name:
+            update_fields["attendee_name"] = attendee_name
+        if external_username:
+            update_fields["external_username"] = external_username
+        update_doc = {"$set": update_fields, "$setOnInsert": {"created_at": now}}
+
+        return {
+            "is_valid": True,
+            "event_id": event_id,
+            "attendee_id": attendee_id,
+            "attendee_name": attendee_name,
+            "external_username": external_username,
+            "status": status,
+            "filter": {"event_id": event_id, "attendee_id": attendee_id},
+            "update": update_doc,
+            "reply_message": "",
+        }
+
+
+class PrepareGetRsvpsNode(TaskNode):
+    """Prepare parameters to fetch RSVPs for an event."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Ensure an event_id is present before querying RSVPs."""
+        results = state.get("results", {})
+        parse_result = results.get("parse_command", {})
+        event = parse_result.get("event", {}) if isinstance(parse_result, dict) else {}
+        rsvp = parse_result.get("rsvp", {}) if isinstance(parse_result, dict) else {}
+
+        event_id = str(
+            event.get("event_id")
+            or rsvp.get("event_id")
+            or parse_result.get("event_id")
+            or ""
+        ).strip()
+
+        if not event_id:
+            return {
+                "is_valid": False,
+                "reply_message": "请提供 event_id 以查询 RSVP。",
+            }
+
+        return {"is_valid": True, "event_id": event_id, "reply_message": ""}
+
+
+class PrepareListEventsNode(TaskNode):
+    """Prepare parameters to fetch recent events."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return default parameters for listing recent events."""
+        now = datetime.now(UTC).isoformat()
+        return {"limit": 20, "now": now}
+
+
+class ValidateEventOwnerNode(TaskNode):
+    """Validate that the requester can update or end the event."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Verify the requester is allowed to update or end the event."""
+        results = state.get("results", {})
+        prepare_result = results.get("prepare_event", {})
+        if not isinstance(prepare_result, Mapping):
+            return {
+                "is_valid": False,
+                "reply_message": "活动信息缺失，请稍后再试。",
+            }
+
+        requester_id = str(prepare_result.get("requester_id", "")).strip()
+        if not requester_id:
+            return {
+                "is_valid": False,
+                "reply_message": "无法识别请求者，请稍后再试。",
+            }
+
+        find_result = results.get("find_event_for_update", {})
+        data = find_result.get("data") if isinstance(find_result, Mapping) else None
+        existing = data[0] if isinstance(data, list) and data else None
+
+        creator_id = ""
+        if isinstance(existing, Mapping):
+            creator_id = str(existing.get("creator_id", "") or "").strip()
+
+        if existing and creator_id and creator_id != requester_id:
+            return {
+                "is_valid": False,
+                "reply_message": "只有活动创建者可以更新或结束该活动。",
+            }
+
+        if prepare_result.get("is_end_request") and not existing:
+            return {
+                "is_valid": False,
+                "reply_message": "未找到活动，无法结束。",
+            }
+
+        return {
+            "is_valid": True,
+            "reply_message": "",
+            "event_exists": bool(existing),
+        }
+
+
+class FormatEventErrorNode(TaskNode):
+    """Format error replies for event updates."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return the first event error message to send back to the user."""
+        results = state.get("results", {})
+        for key in ("validate_event_owner", "prepare_event"):
+            payload = results.get(key, {})
+            if isinstance(payload, Mapping):
+                message = str(payload.get("reply_message", "")).strip()
+                if message:
+                    return {"message": message}
+        return {"message": "活动处理失败，请稍后再试。"}
+
+
+class FormatEventReplyNode(TaskNode):
+    """Format reply after an event update."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Build the confirmation message after saving the event."""
+        results = state.get("results", {})
+        payload = results.get("prepare_event", {})
+
+        title = payload.get("title") or "未命名活动"
+        event_id = payload.get("event_id") or ""
+        iso_date = payload.get("iso_date") or ""
+        location = payload.get("location") or ""
+        host = payload.get("host") or {}
+        is_end_request = bool(payload.get("is_end_request"))
+
+        lines = []
+        if is_end_request:
+            if event_id:
+                lines.append(f"活动已结束（ID：{event_id}）。")
+            else:
+                lines.append("活动已结束。")
+            return {"message": "\n".join(lines)}
+        if event_id:
+            lines.append(f"活动已保存：{title}（ID：{event_id}）。")
+        else:
+            lines.append(f"活动已保存：{title}。")
+        if payload.get("generated_id"):
+            lines.append("已生成新的活动 ID。")
+        if iso_date:
+            lines.append(f"日期：{iso_date}。")
+        if location:
+            lines.append(f"地点：{location}。")
+        if isinstance(host, dict) and host:
+            host_label = host.get("name") or host.get("id") or host.get("email")
+            if host_label:
+                lines.append(f"主持人：{host_label}。")
+
+        return {"message": "\n".join(lines)}
+
+
+class FormatRsvpReplyNode(TaskNode):
+    """Format reply after an RSVP update."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Compose the RSVP update confirmation message."""
+        results = state.get("results", {})
+        payload = results.get("prepare_rsvp", {})
+
+        attendee = (
+            payload.get("attendee_name") or payload.get("attendee_id") or "参与者"
+        )
+        status = payload.get("status") or "已更新"
+        event_id = payload.get("event_id") or ""
+
+        message = f"RSVP 已记录：{attendee} 状态为 {status}"
+        if event_id:
+            message = f"{message}（活动 {event_id}）。"
+        else:
+            message = f"{message}。"
+        return {"message": message}
+
+
+class FormatRsvpListReplyNode(TaskNode):
+    """Format RSVP list reply."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Summarize the RSVP list response."""
+        results = state.get("results", {})
+        payload = results.get("prepare_get_rsvps", {})
+        event_id = payload.get("event_id") or ""
+        find_result = results.get("find_rsvps", {})
+        data = find_result.get("data") if isinstance(find_result, dict) else None
+
+        if not isinstance(data, list) or not data:
+            if event_id:
+                return {"message": f"活动 {event_id} 暂无 RSVP。"}
+            return {"message": "未找到 RSVP。"}
+
+        lines = []
+        if event_id:
+            lines.append(f"活动 {event_id} 的 RSVP：")
+        else:
+            lines.append("RSVP 列表：")
+
+        for item in data:
+            attendee_name = item.get("attendee_name") or ""
+            attendee_id = item.get("attendee_id") or ""
+            status = item.get("status") or "unknown"
+            if attendee_name and attendee_id and attendee_name != attendee_id:
+                label = f"{attendee_name} ({attendee_id})"
+            else:
+                label = attendee_name or attendee_id or "未知参与者"
+            lines.append(f"- {label}：{status}")
+
+        return {"message": "\n".join(lines)}
+
+
+class FormatEventListReplyNode(TaskNode):
+    """Format event list reply."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Compile the list of upcoming events for the reply."""
+        results = state.get("results", {})
+        find_result = (
+            results.get("find_events", {}) if isinstance(results, dict) else {}
+        )
+        data = find_result.get("data") if isinstance(find_result, dict) else None
+
+        if not isinstance(data, list) or not data:
+            return {"message": "未找到活动。"}
+
+        lines = ["近期活动："]
+        for item in data:
+            title = item.get("title") or "未命名活动"
+            event_id = item.get("event_id") or ""
+            iso_date = item.get("iso_date") or ""
+            location = item.get("location") or ""
+            details = [title]
+            if iso_date:
+                details.append(f"{iso_date}")
+            if location:
+                details.append(location)
+            label = " | ".join(details)
+            if event_id:
+                label = f"{label}（ID：{event_id}）"
+            lines.append(f"- {label}")
+
+        return {"message": "\n".join(lines)}
+
+
+class FormatUnknownReplyNode(TaskNode):
+    """Format reply for unknown commands."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Provide guidance when the command is not recognized."""
+        results = state.get("results", {})
+        fallback_result = results.get("extract_fallback_reply", {})
+        fallback_message = ""
+        if isinstance(fallback_result, Mapping):
+            fallback_message = str(fallback_result.get("agent_reply", "")).strip()
+        if fallback_message:
+            return {"message": fallback_message}
+        return {
+            "message": (
+                "我可以更新活动、记录 RSVP，或查询 RSVP。"
+                "示例：'更新活动 ...'、'为活动 <id> RSVP yes'，"
+                "或 '查询活动 <id> 的 RSVP'。"
+            )
+        }
+
+
+async def build_graph() -> StateGraph:
+    """Build the WeCom event agent workflow."""
+    graph = StateGraph(State)
+    _register_wecom_and_agent_nodes(graph)
+    _register_parser_nodes(graph)
+    _register_prepare_nodes(graph)
+    _register_mongodb_nodes(graph)
+    _register_format_nodes(graph)
+    _register_routing_nodes(graph)
+    _register_send_nodes(graph)
+    _setup_initial_routing(graph)
+    _setup_action_routing(graph)
+    _setup_event_flow(graph)
+    _setup_rsvp_flow(graph)
+    _setup_get_and_list_flow(graph)
+    _setup_unknown_flow(graph)
+    _setup_reply_channel(graph)
+    return graph
+
+
+def _register_wecom_and_agent_nodes(graph: StateGraph) -> None:
+    graph.add_node(
+        "wecom_events_parser",
+        WeComEventsParserNode(
+            name="wecom_events_parser",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "get_access_token",
+        WeComAccessTokenNode(
+            name="get_access_token",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "get_cs_access_token",
+        WeComAccessTokenNode(
+            name="get_cs_access_token",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "wecom_cs_sync",
+        WeComCustomerServiceSyncNode(
+            name="wecom_cs_sync",
+        ),
+    )
+
+    graph.add_node(
+        "agent",
+        AgentNode(
+            name="agent",
+            ai_model=DEFAULT_MODEL,
+            model_kwargs={"api_key": "[[openai_api_key]]"},
+            system_prompt=(
+                "你是活动运营助手。请仅输出 JSON（不要 markdown），将用户消息解析为"
+                "以下 schema："
+                '{"action": "update_event|end_event|update_rsvp|get_rsvps|'
+                '"list_events|unknown", '
+                '"event": {"event_id": "", "title": "", '
+                '"description": "", "iso_date": "", '
+                '"status": "active|ended", '
+                '"location": "", "host": {"name": "", "id": "", "email": ""}}, '
+                '"rsvp": {"event_id": "", "attendee_id": "", '
+                '"attendee_name": "", "status": '
+                '"yes|no|maybe|cancelled"}}。'
+                "日期使用 ISO 8601 格式。未知字段留空。"
+            ),
+            reset_command="/重置聊天",
+        ),
+    )
+    graph.add_node(
+        "fallback_agent",
+        AgentNode(
+            name="fallback_agent",
+            ai_model=DEFAULT_MODEL,
+            model_kwargs={"api_key": "[[openai_api_key]]"},
+            system_prompt=(
+                "你是活动运营助手。用户的请求无法处理或聊天被重置。请用用户最新消息的语言"
+                "回复简短、有帮助的指引，说明你可以做的事情：更新活动、"
+                "记录 RSVP、查询 RSVP 或列出活动。如有缺失信息，请提示补充。"
+                "不要返回 JSON 或 markdown。"
+            ),
+            reset_command="/重置聊天",
+        ),
+    )
+
+
+def _register_parser_nodes(graph: StateGraph) -> None:
+    graph.add_node(
+        "extract_agent_reply",
+        ExtractAgentReplyNode(name="extract_agent_reply"),
+    )
+    graph.add_node(
+        "extract_fallback_reply",
+        ExtractAgentReplyNode(name="extract_fallback_reply"),
+    )
+    graph.add_node("parse_command", ParseCommandNode(name="parse_command"))
+
+
+def _register_prepare_nodes(graph: StateGraph) -> None:
+    graph.add_node("prepare_event", PrepareEventUpdateNode(name="prepare_event"))
+    graph.add_node("prepare_rsvp", PrepareRsvpUpdateNode(name="prepare_rsvp"))
+    graph.add_node("prepare_get_rsvps", PrepareGetRsvpsNode(name="prepare_get_rsvps"))
+    graph.add_node(
+        "prepare_list_events", PrepareListEventsNode(name="prepare_list_events")
+    )
+    graph.add_node(
+        "validate_event_owner", ValidateEventOwnerNode(name="validate_event_owner")
+    )
+
+
+def _register_mongodb_nodes(graph: StateGraph) -> None:
+    graph.add_node(
+        "find_event_for_update",
+        MongoDBFindNode(
+            name="find_event_for_update",
+            database="{{config.configurable.events_database}}",
+            collection="{{config.configurable.events_collection}}",
+            filter={"event_id": "{{prepare_event.event_id}}"},
+            limit=1,
+        ),
+    )
+    graph.add_node(
+        "upsert_event",
+        MongoDBNode(
+            name="upsert_event",
+            operation="update_one",
+            database="{{config.configurable.events_database}}",
+            collection="{{config.configurable.events_collection}}",
+            filter="{{prepare_event.filter}}",
+            update="{{prepare_event.update}}",
+            options={"upsert": True},
+        ),
+    )
+    graph.add_node(
+        "upsert_rsvp",
+        MongoDBNode(
+            name="upsert_rsvp",
+            operation="update_one",
+            database="{{config.configurable.events_database}}",
+            collection="{{config.configurable.rsvps_collection}}",
+            filter="{{prepare_rsvp.filter}}",
+            update="{{prepare_rsvp.update}}",
+            options={"upsert": True},
+        ),
+    )
+    graph.add_node(
+        "find_rsvps",
+        MongoDBFindNode(
+            name="find_rsvps",
+            database="{{config.configurable.events_database}}",
+            collection="{{config.configurable.rsvps_collection}}",
+            filter={"event_id": "{{prepare_get_rsvps.event_id}}"},
+            sort={"updated_at": -1},
+            limit=200,
+        ),
+    )
+    graph.add_node(
+        "find_events",
+        MongoDBFindNode(
+            name="find_events",
+            database="{{config.configurable.events_database}}",
+            collection="{{config.configurable.events_collection}}",
+            filter={
+                "iso_date": {"$gte": "{{prepare_list_events.now}}"},
+                "status": {"$ne": "ended"},
+                "ended_at": {"$exists": False},
+            },
+            sort={"iso_date": 1},
+            limit="{{prepare_list_events.limit}}",
+        ),
+    )
+
+
+def _register_format_nodes(graph: StateGraph) -> None:
+    graph.add_node(
+        "format_event_reply", FormatEventReplyNode(name="format_event_reply")
+    )
+    graph.add_node(
+        "format_event_error", FormatEventErrorNode(name="format_event_error")
+    )
+    graph.add_node("format_rsvp_reply", FormatRsvpReplyNode(name="format_rsvp_reply"))
+    graph.add_node(
+        "format_rsvp_list_reply",
+        FormatRsvpListReplyNode(name="format_rsvp_list_reply"),
+    )
+    graph.add_node(
+        "format_event_list_reply",
+        FormatEventListReplyNode(name="format_event_list_reply"),
+    )
+    graph.add_node(
+        "format_unknown_reply",
+        FormatUnknownReplyNode(name="format_unknown_reply"),
+    )
+
+
+def _register_routing_nodes(graph: StateGraph) -> None:
+    graph.add_node("route_by_type", NoOpNode(name="route_by_type"))
+    graph.add_node("route_action_rsvp", NoOpNode(name="route_action_rsvp"))
+    graph.add_node("route_action_get", NoOpNode(name="route_action_get"))
+    graph.add_node("route_action_list", NoOpNode(name="route_action_list"))
+    graph.add_node("route_event_reply", NoOpNode(name="route_event_reply"))
+    graph.add_node("route_event_error", NoOpNode(name="route_event_error"))
+    graph.add_node("route_rsvp_reply", NoOpNode(name="route_rsvp_reply"))
+    graph.add_node("route_rsvp_error", NoOpNode(name="route_rsvp_error"))
+    graph.add_node("route_rsvp_list_reply", NoOpNode(name="route_rsvp_list_reply"))
+    graph.add_node("route_event_list_reply", NoOpNode(name="route_event_list_reply"))
+    graph.add_node("route_get_error", NoOpNode(name="route_get_error"))
+    graph.add_node("route_unknown_reply", NoOpNode(name="route_unknown_reply"))
+
+
+def _register_send_nodes(graph: StateGraph) -> None:
+    graph.add_node(
+        "send_event_reply",
+        WeComCustomerServiceSendNode(
+            name="send_event_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_event_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_event_reply_internal",
+        WeComSendMessageNode(
+            name="send_event_reply_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_event_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_event_error",
+        WeComCustomerServiceSendNode(
+            name="send_event_error",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_event_error.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_event_error_internal",
+        WeComSendMessageNode(
+            name="send_event_error_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_event_error.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_reply",
+        WeComCustomerServiceSendNode(
+            name="send_rsvp_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_rsvp_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_reply_internal",
+        WeComSendMessageNode(
+            name="send_rsvp_reply_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_rsvp_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_error",
+        WeComCustomerServiceSendNode(
+            name="send_rsvp_error",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{prepare_rsvp.reply_message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_error_internal",
+        WeComSendMessageNode(
+            name="send_rsvp_error_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{prepare_rsvp.reply_message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_list_reply",
+        WeComCustomerServiceSendNode(
+            name="send_rsvp_list_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_rsvp_list_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_rsvp_list_reply_internal",
+        WeComSendMessageNode(
+            name="send_rsvp_list_reply_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_rsvp_list_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_event_list_reply",
+        WeComCustomerServiceSendNode(
+            name="send_event_list_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_event_list_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_event_list_reply_internal",
+        WeComSendMessageNode(
+            name="send_event_list_reply_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_event_list_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_get_error",
+        WeComCustomerServiceSendNode(
+            name="send_get_error",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{prepare_get_rsvps.reply_message}}",
+        ),
+    )
+    graph.add_node(
+        "send_get_error_internal",
+        WeComSendMessageNode(
+            name="send_get_error_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{prepare_get_rsvps.reply_message}}",
+        ),
+    )
+    graph.add_node(
+        "send_unknown_reply",
+        WeComCustomerServiceSendNode(
+            name="send_unknown_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{format_unknown_reply.message}}",
+        ),
+    )
+    graph.add_node(
+        "send_unknown_reply_internal",
+        WeComSendMessageNode(
+            name="send_unknown_reply_internal",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{format_unknown_reply.message}}",
+        ),
+    )
+
+
+def _setup_initial_routing(graph: StateGraph) -> None:
+    graph.set_entry_point("wecom_events_parser")
+    immediate_response_router = IfElse(
+        name="immediate_response_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.immediate_response}}",
+                operator="is_truthy",
+            ),
+            Condition(
+                left="{{wecom_events_parser.should_process}}",
+                operator="is_falsy",
+            ),
+        ],
+        condition_logic="or",
+    )
+    message_type_router = IfElse(
+        name="message_type_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.is_customer_service}}",
+                operator="is_truthy",
+            ),
+        ],
+    )
+
+    graph.add_conditional_edges(
+        "wecom_events_parser",
+        immediate_response_router,
+        {
+            "true": END,
+            "false": "route_by_type",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_by_type",
+        message_type_router,
+        {
+            "true": "get_cs_access_token",
+            "false": "get_access_token",
+        },
+    )
+    graph.add_edge("get_cs_access_token", "wecom_cs_sync")
+    graph.add_edge("get_access_token", "agent")
+
+    cs_sync_router = IfElse(
+        name="cs_sync_router",
+        conditions=[
+            Condition(
+                left="{{wecom_cs_sync.should_process}}",
+                operator="is_falsy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "wecom_cs_sync",
+        cs_sync_router,
+        {
+            "true": END,
+            "false": "agent",
+        },
+    )
+
+
+def _setup_action_routing(graph: StateGraph) -> None:
+    graph.add_edge("agent", "extract_agent_reply")
+    graph.add_edge("extract_agent_reply", "parse_command")
+
+    action_event_router = IfElse(
+        name="action_event_router",
+        conditions=[
+            Condition(
+                left="{{parse_command.action}}",
+                operator="equals",
+                right="update_event",
+            ),
+            Condition(
+                left="{{parse_command.action}}",
+                operator="equals",
+                right="end_event",
+            ),
+        ],
+        condition_logic="or",
+    )
+    graph.add_conditional_edges(
+        "parse_command",
+        action_event_router,
+        {
+            "true": "prepare_event",
+            "false": "route_action_rsvp",
+        },
+    )
+
+    action_rsvp_router = IfElse(
+        name="action_rsvp_router",
+        conditions=[
+            Condition(
+                left="{{parse_command.action}}",
+                operator="equals",
+                right="update_rsvp",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "route_action_rsvp",
+        action_rsvp_router,
+        {
+            "true": "prepare_rsvp",
+            "false": "route_action_get",
+        },
+    )
+
+    action_get_router = IfElse(
+        name="action_get_router",
+        conditions=[
+            Condition(
+                left="{{parse_command.action}}",
+                operator="equals",
+                right="get_rsvps",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "route_action_get",
+        action_get_router,
+        {
+            "true": "prepare_get_rsvps",
+            "false": "route_action_list",
+        },
+    )
+
+    action_list_router = IfElse(
+        name="action_list_router",
+        conditions=[
+            Condition(
+                left="{{parse_command.action}}",
+                operator="equals",
+                right="list_events",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "route_action_list",
+        action_list_router,
+        {
+            "true": "prepare_list_events",
+            "false": "fallback_agent",
+        },
+    )
+
+
+def _setup_event_flow(graph: StateGraph) -> None:
+    event_valid_router = IfElse(
+        name="event_valid_router",
+        conditions=[
+            Condition(
+                left="{{prepare_event.is_valid}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "prepare_event",
+        event_valid_router,
+        {
+            "true": "find_event_for_update",
+            "false": "format_event_error",
+        },
+    )
+    graph.add_edge("find_event_for_update", "validate_event_owner")
+
+    event_owner_router = IfElse(
+        name="event_owner_router",
+        conditions=[
+            Condition(
+                left="{{validate_event_owner.is_valid}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "validate_event_owner",
+        event_owner_router,
+        {
+            "true": "upsert_event",
+            "false": "format_event_error",
+        },
+    )
+    graph.add_edge("upsert_event", "format_event_reply")
+    graph.add_edge("format_event_reply", "route_event_reply")
+    graph.add_edge("format_event_error", "route_event_error")
+
+
+def _setup_rsvp_flow(graph: StateGraph) -> None:
+    rsvp_valid_router = IfElse(
+        name="rsvp_valid_router",
+        conditions=[
+            Condition(
+                left="{{prepare_rsvp.is_valid}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "prepare_rsvp",
+        rsvp_valid_router,
+        {
+            "true": "upsert_rsvp",
+            "false": "route_rsvp_error",
+        },
+    )
+    graph.add_edge("upsert_rsvp", "format_rsvp_reply")
+    graph.add_edge("format_rsvp_reply", "route_rsvp_reply")
+
+
+def _setup_get_and_list_flow(graph: StateGraph) -> None:
+    get_valid_router = IfElse(
+        name="get_valid_router",
+        conditions=[
+            Condition(
+                left="{{prepare_get_rsvps.is_valid}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "prepare_get_rsvps",
+        get_valid_router,
+        {
+            "true": "find_rsvps",
+            "false": "route_get_error",
+        },
+    )
+    graph.add_edge("find_rsvps", "format_rsvp_list_reply")
+    graph.add_edge("format_rsvp_list_reply", "route_rsvp_list_reply")
+
+    graph.add_edge("prepare_list_events", "find_events")
+    graph.add_edge("find_events", "format_event_list_reply")
+    graph.add_edge("format_event_list_reply", "route_event_list_reply")
+
+
+def _setup_unknown_flow(graph: StateGraph) -> None:
+    graph.add_edge("fallback_agent", "extract_fallback_reply")
+    graph.add_edge("extract_fallback_reply", "format_unknown_reply")
+    graph.add_edge("format_unknown_reply", "route_unknown_reply")
+
+
+def _setup_reply_channel(graph: StateGraph) -> None:
+    reply_channel_router = IfElse(
+        name="reply_channel_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.is_customer_service}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "route_event_reply",
+        reply_channel_router,
+        {
+            "true": "send_event_reply",
+            "false": "send_event_reply_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_event_error",
+        reply_channel_router,
+        {
+            "true": "send_event_error",
+            "false": "send_event_error_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_rsvp_reply",
+        reply_channel_router,
+        {
+            "true": "send_rsvp_reply",
+            "false": "send_rsvp_reply_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_rsvp_error",
+        reply_channel_router,
+        {
+            "true": "send_rsvp_error",
+            "false": "send_rsvp_error_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_rsvp_list_reply",
+        reply_channel_router,
+        {
+            "true": "send_rsvp_list_reply",
+            "false": "send_rsvp_list_reply_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_event_list_reply",
+        reply_channel_router,
+        {
+            "true": "send_event_list_reply",
+            "false": "send_event_list_reply_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_get_error",
+        reply_channel_router,
+        {
+            "true": "send_get_error",
+            "false": "send_get_error_internal",
+        },
+    )
+    graph.add_conditional_edges(
+        "route_unknown_reply",
+        reply_channel_router,
+        {
+            "true": "send_unknown_reply",
+            "false": "send_unknown_reply_internal",
+        },
+    )
+    graph.add_edge("send_event_reply", END)
+    graph.add_edge("send_event_reply_internal", END)
+    graph.add_edge("send_event_error", END)
+    graph.add_edge("send_event_error_internal", END)
+    graph.add_edge("send_rsvp_reply", END)
+    graph.add_edge("send_rsvp_reply_internal", END)
+    graph.add_edge("send_rsvp_error", END)
+    graph.add_edge("send_rsvp_error_internal", END)
+    graph.add_edge("send_rsvp_list_reply", END)
+    graph.add_edge("send_rsvp_list_reply_internal", END)
+    graph.add_edge("send_event_list_reply", END)
+    graph.add_edge("send_event_list_reply_internal", END)
+    graph.add_edge("send_get_error", END)
+    graph.add_edge("send_get_error_internal", END)
+    graph.add_edge("send_unknown_reply", END)
+    graph.add_edge("send_unknown_reply_internal", END)

--- a/examples/wecom_event_agent/workflow_pure_agent.py
+++ b/examples/wecom_event_agent/workflow_pure_agent.py
@@ -1,0 +1,313 @@
+"""WeCom Event Agent workflow with a single tool-using agent.
+
+Configure WeCom to send callback requests to:
+`/api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true`
+so signatures can be verified.
+
+Configurable inputs (workflow_config.json):
+- corp_id (WeCom corp ID)
+- agent_id (WeCom app agent ID for internal messages)
+- events_database (MongoDB database for events/RSVPs)
+- events_collection (MongoDB collection for events)
+- rsvps_collection (MongoDB collection for RSVPs)
+
+Orcheo vault secrets required:
+- wecom_corp_secret: WeCom app secret for access token
+- wecom_token: Callback token for signature validation
+- wecom_encoding_aes_key: AES key for callback decryption
+- mdb_connection_string: MongoDB connection string
+"""
+
+from collections.abc import Mapping
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, StateGraph
+from orcheo.edges import Condition, IfElse
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.wecom import (
+    WeComAccessTokenNode,
+    WeComCustomerServiceSendNode,
+    WeComCustomerServiceSyncNode,
+    WeComEventsParserNode,
+    WeComSendMessageNode,
+)
+
+
+DEFAULT_MODEL = "openai:gpt-4o-mini"
+SYSTEM_PROMPT = (
+    "你是一个企业微信活动助理。使用对话历史来推断用户意图，调用工具"
+    "读写 MongoDB，并用纯文本回复。不要输出 JSON 或 Markdown。\n\n"
+    "上下文：\n"
+    "- internal_user_id: {{resolve_attendee_id.internal_user_id}}\n"
+    "- external_userid: {{resolve_attendee_id.external_userid}}\n"
+    "- attendee_id: {{resolve_attendee_id.attendee_id}}\n\n"
+    "MongoDB 配置（在工具调用中使用以下令牌）：\n"
+    "- events_database\n"
+    "- events_collection\n"
+    "- rsvps_collection\n\n"
+    "工具：\n"
+    "- mongodb_update_one：使用 filter/update/options 调用 update_one。\n"
+    "- mongodb_find：使用 filter/sort/limit 调用 find。\n\n"
+    "指南：\n"
+    "- 用户标识：\n"
+    "  - internal_user_id（来自企业微信内部消息）\n"
+    "  - external_userid（来自客服同步）\n"
+    "- 用户可发送 /重置聊天 重置对话。\n"
+    "- 工具调用中必须包含上面配置的 database/collection。\n"
+    "- RSVP 更新时，必须同时按 event_id 和 attendee_id 过滤。使用：\n"
+    "  - 客服消息：attendee_id = external_userid\n"
+    "  - 内部消息：attendee_id = internal_user_id\n"
+    "- 取消请求时，将 status 设为 cancelled，且不要新建 RSVP。\n"
+    "- 如缺少必填字段，需提出澄清问题。\n"
+    "- 日期使用 ISO 8601。\n"
+    "- 回复应简洁、面向用户。\n"
+    "- 用户首次发送消息时，介绍自己和功能。"
+)
+
+
+def extract_reply_from_messages(messages: list[Any]) -> str | None:
+    """Return the most recent assistant reply from LangGraph messages."""
+    for message in messages[::-1]:
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            role = message.get("type") or message.get("role")
+        else:
+            content = None
+            role = None
+            try:
+                content = message.content
+            except AttributeError:
+                content = None
+            try:
+                role = message.type
+            except AttributeError:
+                try:
+                    role = message.role
+                except AttributeError:
+                    role = None
+        if role in ("ai", "assistant") and isinstance(content, str):
+            stripped = content.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+class ExtractAgentReplyNode(TaskNode):
+    """Extract the latest agent reply or fall back to an empty string."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return the agent's latest reply or an empty fallback."""
+        reply = None
+        messages = state.get("messages")
+        if isinstance(messages, list):
+            reply = extract_reply_from_messages(messages)
+        return {"agent_reply": reply or ""}
+
+
+class NoOpNode(TaskNode):
+    """No-op task node used as a routing placeholder."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Return an empty payload to keep routing nodes consistent."""
+        return {}
+
+
+class ResolveAttendeeNode(TaskNode):
+    """Resolve attendee identifiers for internal or customer service messages."""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Resolve the internal and external attendee identifiers."""
+        results = state.get("results", {})
+        parser_result = results.get("wecom_events_parser", {})
+        cs_sync_result = results.get("wecom_cs_sync", {})
+
+        internal_user_id = ""
+        if isinstance(parser_result, Mapping):
+            internal_user_id = str(parser_result.get("user", "") or "").strip()
+
+        external_userid = ""
+        if isinstance(cs_sync_result, Mapping):
+            external_userid = str(
+                cs_sync_result.get("external_userid", "") or ""
+            ).strip()
+
+        attendee_id = external_userid or internal_user_id
+        return {
+            "internal_user_id": internal_user_id,
+            "external_userid": external_userid,
+            "attendee_id": attendee_id,
+        }
+
+
+async def build_graph() -> StateGraph:
+    """Build the WeCom event workflow powered by a single agent."""
+    graph = StateGraph(State)
+
+    graph.add_node(
+        "wecom_events_parser",
+        WeComEventsParserNode(
+            name="wecom_events_parser",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "get_access_token",
+        WeComAccessTokenNode(
+            name="get_access_token",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "get_cs_access_token",
+        WeComAccessTokenNode(
+            name="get_cs_access_token",
+            corp_id="{{config.configurable.corp_id}}",
+        ),
+    )
+
+    graph.add_node(
+        "wecom_cs_sync",
+        WeComCustomerServiceSyncNode(
+            name="wecom_cs_sync",
+        ),
+    )
+
+    graph.add_node(
+        "agent",
+        AgentNode(
+            name="agent",
+            ai_model=DEFAULT_MODEL,
+            model_kwargs={"api_key": "[[openai_api_key]]"},
+            system_prompt=SYSTEM_PROMPT,
+            reset_command="/重置聊天",
+            predefined_tools=["mongodb_update_one", "mongodb_find"],
+        ),
+    )
+
+    graph.add_node(
+        "resolve_attendee_id",
+        ResolveAttendeeNode(name="resolve_attendee_id"),
+    )
+
+    graph.add_node(
+        "extract_agent_reply",
+        ExtractAgentReplyNode(name="extract_agent_reply"),
+    )
+
+    graph.add_node(
+        "send_cs_reply",
+        WeComCustomerServiceSendNode(
+            name="send_cs_reply",
+            open_kf_id="{{wecom_cs_sync.open_kf_id}}",
+            external_userid="{{wecom_cs_sync.external_userid}}",
+            message="{{extract_agent_reply.agent_reply}}",
+        ),
+    )
+    graph.add_node(
+        "send_internal_reply",
+        WeComSendMessageNode(
+            name="send_internal_reply",
+            agent_id="{{config.configurable.agent_id}}",
+            to_user="{{wecom_events_parser.target_user}}",
+            message="{{extract_agent_reply.agent_reply}}",
+        ),
+    )
+
+    graph.set_entry_point("wecom_events_parser")
+
+    immediate_response_router = IfElse(
+        name="immediate_response_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.immediate_response}}",
+                operator="is_truthy",
+            ),
+            Condition(
+                left="{{wecom_events_parser.should_process}}",
+                operator="is_falsy",
+            ),
+        ],
+        condition_logic="or",
+    )
+
+    message_type_router = IfElse(
+        name="message_type_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.is_customer_service}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+
+    graph.add_conditional_edges(
+        "wecom_events_parser",
+        immediate_response_router,
+        {
+            "true": END,
+            "false": "route_by_type",
+        },
+    )
+
+    graph.add_node("route_by_type", NoOpNode(name="route_by_type"))
+    graph.add_conditional_edges(
+        "route_by_type",
+        message_type_router,
+        {
+            "true": "get_cs_access_token",
+            "false": "get_access_token",
+        },
+    )
+
+    graph.add_edge("get_access_token", "resolve_attendee_id")
+    graph.add_edge("resolve_attendee_id", "agent")
+
+    graph.add_edge("get_cs_access_token", "wecom_cs_sync")
+    cs_sync_router = IfElse(
+        name="cs_sync_router",
+        conditions=[
+            Condition(
+                left="{{wecom_cs_sync.should_process}}",
+                operator="is_falsy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "wecom_cs_sync",
+        cs_sync_router,
+        {
+            "true": END,
+            "false": "resolve_attendee_id",
+        },
+    )
+
+    graph.add_edge("agent", "extract_agent_reply")
+    graph.add_node("route_reply", NoOpNode(name="route_reply"))
+    graph.add_edge("extract_agent_reply", "route_reply")
+
+    reply_channel_router = IfElse(
+        name="reply_channel_router",
+        conditions=[
+            Condition(
+                left="{{wecom_events_parser.is_customer_service}}",
+                operator="is_truthy",
+            )
+        ],
+    )
+    graph.add_conditional_edges(
+        "route_reply",
+        reply_channel_router,
+        {
+            "true": "send_cs_reply",
+            "false": "send_internal_reply",
+        },
+    )
+
+    graph.add_edge("send_cs_reply", END)
+    graph.add_edge("send_internal_reply", END)
+
+    return graph

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
@@ -84,6 +84,10 @@ FormatOption = Annotated[
     str,
     typer.Option("--format", "-f", help="Output format (auto, json, or python)."),
 ]
+VersionOption = Annotated[
+    int | None,
+    typer.Option("--version", "-v", help="Specific version number to use."),
+]
 
 
 def _state(ctx: typer.Context) -> CLIState:
@@ -108,5 +112,6 @@ __all__ = [
     "WorkflowNameOption",
     "OutputPathOption",
     "FormatOption",
+    "VersionOption",
     "_state",
 ]

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
@@ -13,6 +13,7 @@ from orcheo_sdk.cli.workflow.app import (
     OutputPathOption,
     RunnableConfigFileOption,
     RunnableConfigOption,
+    VersionOption,
     WorkflowIdArgument,
     WorkflowIdOption,
     WorkflowNameOption,
@@ -95,17 +96,20 @@ def download_workflow(
     workflow_id: WorkflowIdArgument,
     output_path: OutputPathOption = None,
     format_type: FormatOption = "auto",
+    version: VersionOption = None,
 ) -> None:
     """Download a workflow configuration to a file or stdout."""
     state = _state(ctx)
+    version_suffix = f":{version}" if version else ""
     payload, from_cache, stale = load_with_cache(
         state,
-        f"workflow:{workflow_id}:download:{format_type}",
+        f"workflow:{workflow_id}:download:{format_type}{version_suffix}",
         lambda: download_workflow_data(
             state.client,
             workflow_id,
             output_path=None,
             format_type=format_type,
+            target_version=version,
         ),
     )
     if from_cache:

--- a/packages/sdk/src/orcheo_sdk/services/workflows/listing.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/listing.py
@@ -45,20 +45,39 @@ def show_workflow_data(
     workflow: dict[str, Any] | None = None,
     versions: list[dict[str, Any]] | None = None,
     runs: list[dict[str, Any]] | None = None,
+    target_version: int | None = None,
 ) -> dict[str, Any]:
-    """Return workflow metadata plus optional latest version and runs."""
+    """Return workflow metadata plus optional version and runs.
+
+    Args:
+        client: API client for making requests.
+        workflow_id: ID of the workflow.
+        include_runs: Whether to include recent runs.
+        workflow: Pre-fetched workflow data (optional).
+        versions: Pre-fetched versions list (optional).
+        runs: Pre-fetched runs list (optional).
+        target_version: Specific version number to retrieve. If None,
+            returns the latest version.
+
+    Returns:
+        Dictionary containing workflow details, selected version, and recent runs.
+    """
     if workflow is None:
         workflow = client.get(f"/api/workflows/{workflow_id}")
 
-    if versions is None:
-        versions = client.get(f"/api/workflows/{workflow_id}/versions")
-
-    latest_version = None
-    if versions:
-        latest_version = max(
-            versions,
-            key=lambda entry: entry.get("version", 0),
+    selected_version: dict[str, Any] | None = None
+    if target_version is not None:
+        selected_version = client.get(
+            f"/api/workflows/{workflow_id}/versions/{target_version}"
         )
+    else:
+        if versions is None:
+            versions = client.get(f"/api/workflows/{workflow_id}/versions")
+        if versions:
+            selected_version = max(
+                versions,
+                key=lambda entry: entry.get("version", 0),
+            )
 
     recent_runs: list[dict[str, Any]] = []
     if include_runs:
@@ -75,6 +94,6 @@ def show_workflow_data(
 
     return {
         "workflow": enriched_workflow,
-        "latest_version": latest_version,
+        "selected_version": selected_version,
         "recent_runs": recent_runs,
     }

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -71,6 +71,7 @@ class AsyncAllowingTransformer(RestrictingNodeTransformer):
 TraceFunc = Callable[[FrameType | None, str, object], object]
 
 _SAFE_MODULE_PREFIXES: tuple[str, ...] = (
+    "json",
     "langgraph",
     "langchain",
     "langchain_core",
@@ -88,6 +89,7 @@ _SAFE_MODULE_PREFIXES: tuple[str, ...] = (
     "math",
     "operator",
     "pydantic",
+    "uuid",
 )
 
 

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -1,7 +1,7 @@
 """Node registry and metadata definitions for Orcheo."""
 
 from orcheo.nodes.agentensor import AgentensorNode
-from orcheo.nodes.ai import AgentNode
+from orcheo.nodes.ai import AgentNode, LLMNode
 from orcheo.nodes.code import PythonCode
 from orcheo.nodes.communication import DiscordWebhookNode, EmailNode
 from orcheo.nodes.conversational_search import (
@@ -55,6 +55,7 @@ __all__ = [
     "NodeRegistry",
     "registry",
     "AgentNode",
+    "LLMNode",
     "AgentensorNode",
     "PythonCode",
     "HttpRequestNode",

--- a/src/orcheo/nodes/agent_tools/context.py
+++ b/src/orcheo/nodes/agent_tools/context.py
@@ -1,0 +1,30 @@
+"""Context for agent tool execution."""
+
+from __future__ import annotations
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+from langchain_core.runnables import RunnableConfig
+
+
+_ACTIVE_TOOL_CONFIG: ContextVar[RunnableConfig | None] = ContextVar(
+    "orcheo_active_tool_config", default=None
+)
+
+
+@contextmanager
+def tool_execution_context(config: RunnableConfig | None) -> Any:
+    """Bind a RunnableConfig for tool executions within this context."""
+    token = _ACTIVE_TOOL_CONFIG.set(config)
+    try:
+        yield config
+    finally:
+        _ACTIVE_TOOL_CONFIG.reset(token)
+
+
+def get_active_tool_config() -> RunnableConfig | None:
+    """Return the currently bound tool execution config, if any."""
+    return _ACTIVE_TOOL_CONFIG.get()
+
+
+__all__ = ["get_active_tool_config", "tool_execution_context"]

--- a/src/orcheo/nodes/agent_tools/tools.py
+++ b/src/orcheo/nodes/agent_tools/tools.py
@@ -25,7 +25,7 @@ def greet_user(username: str) -> str:
 async def _run_mongodb_node(
     node: MongoDBNode, config: RunnableConfig | None = None
 ) -> dict[str, Any]:
-    if config is None:
+    if config is None:  # pragma: no branch
         config = get_active_tool_config()
     state: State = {
         "inputs": {},

--- a/src/orcheo/nodes/agent_tools/tools.py
+++ b/src/orcheo/nodes/agent_tools/tools.py
@@ -1,7 +1,12 @@
 """Tools for AI agents."""
 
+from typing import Any
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
+from orcheo.graph.state import State
+from orcheo.nodes.agent_tools.context import get_active_tool_config
 from orcheo.nodes.agent_tools.registry import ToolMetadata, tool_registry
+from orcheo.nodes.mongodb import MongoDBFindNode, MongoDBNode
 
 
 @tool_registry.register(
@@ -15,3 +20,161 @@ from orcheo.nodes.agent_tools.registry import ToolMetadata, tool_registry
 def greet_user(username: str) -> str:
     """Print a greeting to the user."""
     return f"Hello, {username}!"
+
+
+async def _run_mongodb_node(
+    node: MongoDBNode, config: RunnableConfig | None = None
+) -> dict[str, Any]:
+    if config is None:
+        config = get_active_tool_config()
+    state: State = {
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+        "config": None,
+        "messages": [],
+    }
+    runnable_config = config or RunnableConfig()
+    node.decode_variables(state, config=runnable_config)
+    return await node.run(state, runnable_config)
+
+
+def _normalize_mongodb_sort(
+    sort: dict[str, int] | list[dict[str, int]] | None,
+) -> dict[str, int] | list[tuple[str, int]] | None:
+    if sort is None:
+        return None
+    if isinstance(sort, dict):
+        return sort
+    if not isinstance(sort, list):
+        raise ValueError("mongodb_find sort must be a dict or list")
+    sort_items: list[tuple[str, int]] = []
+    for entry in sort:
+        if not isinstance(entry, dict):
+            raise ValueError("mongodb_find sort list entries must be dicts")
+        for key, value in entry.items():
+            sort_items.append((key, value))
+    return sort_items
+
+
+def _resolve_config_token(
+    value: str, configurable: dict[str, Any], mapping: dict[str, str]
+) -> str | None:
+    if value in mapping:
+        return configurable.get(mapping[value])  # type: ignore[return-value]
+    prefix = "{{config.configurable."
+    suffix = "}}"
+    if value.startswith(prefix) and value.endswith(suffix):
+        key = value[len(prefix) : -len(suffix)].strip()
+        if key:
+            return configurable.get(key)  # type: ignore[return-value]
+    return None
+
+
+def _resolve_mongodb_target(
+    database: str,
+    collection: str,
+    config: RunnableConfig | None,
+) -> tuple[str, str]:
+    if config is None:
+        return database, collection
+    configurable = config.get("configurable", {})
+    if not isinstance(configurable, dict):
+        return database, collection
+
+    token_map = {
+        "events_database": "events_database",
+        "events_collection": "events_collection",
+        "rsvps_collection": "rsvps_collection",
+    }
+    resolved_database = _resolve_config_token(database, configurable, token_map)
+    resolved_collection = _resolve_config_token(collection, configurable, token_map)
+    return (
+        resolved_database or database,
+        resolved_collection or collection,
+    )
+
+
+@tool_registry.register(
+    ToolMetadata(
+        name="mongodb_update_one",
+        description="Update a single MongoDB document.",
+        category="mongodb",
+    )
+)
+@tool
+async def mongodb_update_one(
+    database: str,
+    collection: str,
+    filter: dict[str, Any],
+    update: dict[str, Any],
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Update a single MongoDB document."""
+    if not isinstance(database, str) or not database:
+        raise ValueError("mongodb_update_one requires a database name")
+    if not isinstance(collection, str) or not collection:
+        raise ValueError("mongodb_update_one requires a collection name")
+    if not isinstance(filter, dict):
+        raise ValueError("mongodb_update_one requires a filter document")
+    if not isinstance(update, dict):
+        raise ValueError("mongodb_update_one requires an update document")
+    if options is None:
+        options = {}
+    if not isinstance(options, dict):
+        raise ValueError("mongodb_update_one options must be a dict")
+
+    tool_config = get_active_tool_config()
+    database, collection = _resolve_mongodb_target(database, collection, tool_config)
+
+    node = MongoDBNode(
+        name="mongodb_update_one",
+        operation="update_one",
+        database=database,
+        collection=collection,
+        filter=filter,
+        update=update,
+        options=options,
+    )
+    return await _run_mongodb_node(node, config=tool_config)
+
+
+@tool_registry.register(
+    ToolMetadata(
+        name="mongodb_find",
+        description="Find MongoDB documents with optional sort and limit.",
+        category="mongodb",
+    )
+)
+@tool
+async def mongodb_find(
+    database: str,
+    collection: str,
+    filter: dict[str, Any] | None = None,
+    sort: dict[str, int] | list[dict[str, int]] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Find MongoDB documents."""
+    if not isinstance(database, str) or not database:
+        raise ValueError("mongodb_find requires a database name")
+    if not isinstance(collection, str) or not collection:
+        raise ValueError("mongodb_find requires a collection name")
+    if filter is None:
+        filter = {}
+    if not isinstance(filter, dict):
+        raise ValueError("mongodb_find requires a filter document")
+    if limit is not None and not isinstance(limit, int):
+        raise ValueError("mongodb_find limit must be an int")
+
+    tool_config = get_active_tool_config()
+    database, collection = _resolve_mongodb_target(database, collection, tool_config)
+
+    node = MongoDBFindNode(
+        name="mongodb_find",
+        database=database,
+        collection=collection,
+        filter=filter,
+        sort=_normalize_mongodb_sort(sort),
+        limit=limit,
+    )
+    return await _run_mongodb_node(node, config=tool_config)

--- a/src/orcheo/nodes/mongodb.py
+++ b/src/orcheo/nodes/mongodb.py
@@ -89,10 +89,10 @@ class MongoDBNode(TaskNode):
     ]
     query: dict | list[dict[str, Any]] = Field(default_factory=dict)
     """Legacy query payload passed directly to the operation."""
-    filter: dict[str, Any] | None = Field(
+    filter: dict[str, Any] | str | None = Field(
         default=None, description="Filter document for query/update operations"
     )
-    update: dict[str, Any] | None = Field(
+    update: dict[str, Any] | str | None = Field(
         default=None, description="Update document for update operations"
     )
     pipeline: list[dict[str, Any]] | None = Field(
@@ -140,6 +140,9 @@ class MongoDBNode(TaskNode):
         provided as a dict, otherwise defaults to an empty filter.
         """
         if self.filter is not None:
+            if isinstance(self.filter, str):
+                msg = "filter must resolve to a dict before execution"
+                raise ValueError(msg)
             return dict(self.filter)
         if isinstance(self.query, dict):
             return dict(self.query)
@@ -148,6 +151,9 @@ class MongoDBNode(TaskNode):
     def _resolve_update(self) -> dict[str, Any]:
         """Resolve an update/replacement document from inputs."""
         if self.update is not None:
+            if isinstance(self.update, str):
+                msg = "update must resolve to a dict before execution"
+                raise ValueError(msg)
             return dict(self.update)
         if isinstance(self.query, dict):  # pragma: no branch
             candidate = self.query.get("update")

--- a/src/orcheo/nodes/wecom.py
+++ b/src/orcheo/nodes/wecom.py
@@ -500,7 +500,7 @@ class WeComEventsParserNode(TaskNode):
         result = await self.run(state, config)
         serialized = self._serialize_result(result)
         output: dict[str, Any] = {"results": {self.name: serialized}}
-        if isinstance(serialized, dict):
+        if isinstance(serialized, dict):  # pragma: no branch
             agent_messages = serialized.pop("agent_messages", None)
             if isinstance(agent_messages, list):
                 output["messages"] = agent_messages
@@ -1518,7 +1518,7 @@ async def _process_cs_page(
             continue
         if already_exists:
             saw_existing = True
-        elif stored:
+        elif stored:  # pragma: no branch
             new_messages.append(entry)
     return new_messages, latest_message, saw_existing, redis_failed
 
@@ -1692,7 +1692,7 @@ def _select_cs_customer_nickname(customer_list: Any, external_userid: str) -> st
             or customer.get("display_name")
             or ""
         )
-        if nickname:
+        if nickname:  # pragma: no branch
             return nickname
     if customer_list and isinstance(customer_list[0], Mapping):
         fallback = customer_list[0]
@@ -1809,7 +1809,9 @@ class WeComCustomerServiceSyncNode(TaskNode):
             role = item.get("role") or item.get("type")
             if role == "ai":
                 role = "assistant"
-            if role in {"user", "assistant"} and isinstance(content, str):
+            if role in {"user", "assistant"} and isinstance(
+                content, str
+            ):  # pragma: no branch
                 content = content.strip()
                 if content:
                     messages.append({"role": role, "content": content})
@@ -1916,7 +1918,7 @@ class WeComCustomerServiceSyncNode(TaskNode):
         result = await self.run(state, config)
         serialized = self._serialize_result(result)
         output: dict[str, Any] = {"results": {self.name: serialized}}
-        if isinstance(serialized, dict):
+        if isinstance(serialized, dict):  # pragma: no branch
             agent_messages = serialized.pop("agent_messages", None)
             if isinstance(agent_messages, list):
                 output["messages"] = agent_messages
@@ -2041,7 +2043,7 @@ class WeComCustomerServiceSendNode(TaskNode):
                 },
             )
         finally:
-            if redis_client is not None:
+            if redis_client is not None:  # pragma: no branch
                 await redis_client.close()
         return {
             "is_error": False,

--- a/tests/nodes/test_agent_tools_helpers.py
+++ b/tests/nodes/test_agent_tools_helpers.py
@@ -1,0 +1,185 @@
+"""Helper tests for MongoDB agent tools."""
+
+from __future__ import annotations
+from typing import Any
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.nodes.agent_tools import tools
+
+
+@pytest.mark.asyncio
+async def test_run_mongodb_node_uses_active_config(monkeypatch) -> None:
+    captured: dict[str, RunnableConfig | None] = {}
+
+    class FakeNode:
+        def decode_variables(self, state, config=None):  # type: ignore[no-untyped-def]
+            captured["decode_config"] = config
+
+        async def run(self, state, config):  # type: ignore[no-untyped-def]
+            captured["run_config"] = config
+            return {"ok": True}
+
+    config = RunnableConfig(configurable={"value": "A"})
+    called: dict[str, bool] = {}
+
+    def fake_get_config() -> RunnableConfig:
+        called["requested"] = True
+        return config
+
+    monkeypatch.setattr(tools, "get_active_tool_config", fake_get_config)
+
+    result = await tools._run_mongodb_node(FakeNode())
+    assert result == {"ok": True}
+    assert captured["decode_config"] is config
+    assert captured["run_config"] is config
+    assert called.get("requested")
+
+
+def test_normalize_mongodb_sort_with_list() -> None:
+    tuples = tools._normalize_mongodb_sort(
+        [{"first": 1}, {"second": -1}],
+    )
+    assert tuples == [("first", 1), ("second", -1)]
+
+
+def test_normalize_mongodb_sort_requires_dict_or_list() -> None:
+    with pytest.raises(ValueError, match="dict or list"):
+        tools._normalize_mongodb_sort("invalid")  # type: ignore[arg-type]
+
+
+def test_normalize_mongodb_sort_list_entries_must_be_dicts() -> None:
+    with pytest.raises(ValueError, match="must be dicts"):
+        tools._normalize_mongodb_sort([{"a": 1}, "invalid"])  # type: ignore[arg-type]
+
+
+def test_resolve_config_token_handles_mapping_and_templates() -> None:
+    configurable = {"mapped": "value", "templated": "value"}
+    mapping = {"mapped": "mapped"}
+
+    assert tools._resolve_config_token("mapped", configurable, mapping) == "value"
+    assert (
+        tools._resolve_config_token(
+            "{{config.configurable.templated}}",
+            configurable,
+            mapping,
+        )
+        == "value"
+    )
+    assert tools._resolve_config_token("missing", configurable, mapping) is None
+
+
+def test_resolve_config_token_handles_empty_templates() -> None:
+    configurable = {"key": "value"}
+    mapping: dict[str, str] = {}
+
+    assert (
+        tools._resolve_config_token(
+            "{{config.configurable.}}",
+            configurable,
+            mapping,
+        )
+        is None
+    )
+
+
+def test_resolve_mongodb_target_returns_original_without_config() -> None:
+    assert tools._resolve_mongodb_target("db", "col", None) == ("db", "col")
+
+
+def test_resolve_mongodb_target_ignores_non_dict_config() -> None:
+    config = RunnableConfig(configurable="invalid")  # type: ignore[arg-type]
+    assert tools._resolve_mongodb_target("db", "col", config) == ("db", "col")
+
+
+def test_resolve_mongodb_target_resolves_tokens() -> None:
+    config = RunnableConfig(
+        configurable={
+            "events_database": "AIC",
+            "events_collection": "events",
+        }
+    )
+
+    assert tools._resolve_mongodb_target(
+        "events_database",
+        "events_collection",
+        config,
+    ) == ("AIC", "events")
+
+
+@pytest.mark.asyncio
+async def test_mongodb_update_one_defaults_options(monkeypatch) -> None:
+    captured: dict[str, dict[str, Any]] = {}
+
+    async def fake_run(node, config=None):
+        captured["options"] = node.options
+        return {"ok": True}
+
+    monkeypatch.setattr(tools, "_run_mongodb_node", fake_run)
+
+    await tools.mongodb_update_one.coroutine(
+        database="db",
+        collection="col",
+        filter={},
+        update={},
+    )
+
+    assert captured["options"] == {}
+
+
+@pytest.mark.asyncio
+async def test_mongodb_update_one_validates_required_fields() -> None:
+    payload = {
+        "database": "",
+        "collection": "c",
+        "filter": {},
+        "update": {},
+    }
+    with pytest.raises(ValueError, match="requires a database name"):
+        await tools.mongodb_update_one.coroutine(**payload)
+
+    payload["database"] = "db"
+    payload["collection"] = ""
+    with pytest.raises(ValueError, match="requires a collection name"):
+        await tools.mongodb_update_one.coroutine(**payload)
+
+    payload["collection"] = "c"
+    payload["filter"] = "bad"
+    with pytest.raises(ValueError, match="filter document"):
+        await tools.mongodb_update_one.coroutine(**payload)
+
+    payload["filter"] = {}
+    payload["update"] = "bad"
+    with pytest.raises(ValueError, match="update document"):
+        await tools.mongodb_update_one.coroutine(**payload)
+
+    payload["update"] = {}
+    with pytest.raises(ValueError, match="options must be a dict"):
+        await tools.mongodb_update_one.coroutine(
+            **{**payload, "options": "invalid"},  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_mongodb_find_validates_arguments() -> None:
+    payload = {
+        "database": "",
+        "collection": "col",
+        "filter": {},
+    }
+    with pytest.raises(ValueError, match="requires a database name"):
+        await tools.mongodb_find.coroutine(**payload)
+
+    payload["database"] = "db"
+    payload["collection"] = ""
+    with pytest.raises(ValueError, match="requires a collection name"):
+        await tools.mongodb_find.coroutine(**payload)
+
+    payload["collection"] = "col"
+    payload["filter"] = "bad"
+    with pytest.raises(ValueError, match="filter document"):
+        await tools.mongodb_find.coroutine(**payload)
+
+    payload["filter"] = {}
+    payload["limit"] = "five"
+    with pytest.raises(ValueError, match="limit must be an int"):
+        await tools.mongodb_find.coroutine(**payload)

--- a/tests/nodes/test_agent_tools_mongodb.py
+++ b/tests/nodes/test_agent_tools_mongodb.py
@@ -1,0 +1,125 @@
+"""Tests for MongoDB agent tools."""
+
+from __future__ import annotations
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.nodes.agent_tools import tools
+from orcheo.nodes.agent_tools.context import tool_execution_context
+from orcheo.nodes.mongodb import MongoDBFindNode, MongoDBNode
+
+
+@pytest.mark.asyncio
+async def test_mongodb_update_one_tool_builds_node(monkeypatch):
+    """mongodb_update_one should build a MongoDBNode with provided inputs."""
+    captured: dict[str, MongoDBNode] = {}
+
+    async def fake_run(node, config=None):
+        captured["node"] = node
+        return {"ok": True}
+
+    monkeypatch.setattr(tools, "_run_mongodb_node", fake_run)
+
+    result = await tools.mongodb_update_one.ainvoke(
+        {
+            "database": "db",
+            "collection": "events",
+            "filter": {"event_id": "1"},
+            "update": {"$set": {"title": "Test"}},
+            "options": {"upsert": True},
+        }
+    )
+
+    assert result == {"ok": True}
+    node = captured["node"]
+    assert isinstance(node, MongoDBNode)
+    assert node.operation == "update_one"
+    assert node.database == "db"
+    assert node.collection == "events"
+    assert node.filter == {"event_id": "1"}
+    assert node.update == {"$set": {"title": "Test"}}
+    assert node.options == {"upsert": True}
+
+
+@pytest.mark.asyncio
+async def test_mongodb_find_tool_builds_node(monkeypatch):
+    """mongodb_find should build a MongoDBFindNode with provided inputs."""
+    captured: dict[str, MongoDBFindNode] = {}
+
+    async def fake_run(node, config=None):
+        captured["node"] = node
+        return {"data": []}
+
+    monkeypatch.setattr(tools, "_run_mongodb_node", fake_run)
+
+    result = await tools.mongodb_find.ainvoke(
+        {
+            "database": "db",
+            "collection": "rsvps",
+            "filter": {"event_id": "1"},
+            "sort": {"updated_at": -1},
+            "limit": 5,
+        }
+    )
+
+    assert result == {"data": []}
+    node = captured["node"]
+    assert isinstance(node, MongoDBFindNode)
+    assert node.operation == "find"
+    assert node.database == "db"
+    assert node.collection == "rsvps"
+    assert node.filter == {"event_id": "1"}
+    assert node.sort == {"updated_at": -1}
+    assert node.limit == 5
+
+
+@pytest.mark.asyncio
+async def test_mongodb_find_tool_default_filter(monkeypatch):
+    """mongodb_find should default to an empty filter when omitted."""
+    captured: dict[str, MongoDBFindNode] = {}
+
+    async def fake_run(node, config=None):
+        captured["node"] = node
+        return {"data": []}
+
+    monkeypatch.setattr(tools, "_run_mongodb_node", fake_run)
+
+    await tools.mongodb_find.ainvoke(
+        {
+            "database": "db",
+            "collection": "events",
+        }
+    )
+
+    node = captured["node"]
+    assert node.filter == {}
+
+
+@pytest.mark.asyncio
+async def test_mongodb_tool_resolves_config_tokens(monkeypatch):
+    """mongodb_find should resolve config token values."""
+    captured: dict[str, MongoDBFindNode] = {}
+
+    async def fake_run(node, config=None):
+        captured["node"] = node
+        return {"data": []}
+
+    monkeypatch.setattr(tools, "_run_mongodb_node", fake_run)
+
+    config = RunnableConfig(
+        configurable={
+            "events_database": "AIC",
+            "rsvps_collection": "event_rsvps",
+        }
+    )
+
+    with tool_execution_context(config):
+        await tools.mongodb_find.ainvoke(
+            {
+                "database": "events_database",
+                "collection": "rsvps_collection",
+            }
+        )
+
+    node = captured["node"]
+    assert node.database == "AIC"
+    assert node.collection == "event_rsvps"

--- a/tests/nodes/test_ai_agent_node_messages.py
+++ b/tests/nodes/test_ai_agent_node_messages.py
@@ -181,3 +181,52 @@ def test_build_messages_prefers_existing_state_messages() -> None:
     messages = node._build_messages(state)
     assert len(messages) == 1
     assert messages[0].content == "Existing"
+
+
+def test_apply_reset_command_filters_to_latest_reset() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        reset_command="RESET",
+    )
+    messages = [
+        HumanMessage(content="before"),
+        HumanMessage(content="RESET"),
+        HumanMessage(content="after"),
+    ]
+    trimmed = node._apply_reset_command(messages)
+    assert trimmed == messages[1:]
+
+
+def test_apply_reset_command_returns_original_when_command_missing() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        reset_command="RESET",
+    )
+    messages = [
+        HumanMessage(content="keep one"),
+        HumanMessage(content="keep two"),
+    ]
+    assert node._apply_reset_command(messages) == messages
+
+
+def test_build_messages_respects_max_messages_limit() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        max_messages=1,
+    )
+    state = State(
+        messages=[
+            {"role": "assistant", "content": "first"},
+            {"role": "user", "content": "last"},
+        ],
+        inputs={},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+    messages = node._build_messages(state)
+    assert len(messages) == 1
+    assert messages[0].content == "last"

--- a/tests/nodes/test_ai_llm_node.py
+++ b/tests/nodes/test_ai_llm_node.py
@@ -1,0 +1,58 @@
+"""LLMNode message construction tests."""
+
+from __future__ import annotations
+from unittest.mock import AsyncMock
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from orcheo.graph.state import State
+from orcheo.nodes.ai import LLMNode
+
+
+@pytest.mark.asyncio
+async def test_llmnode_run_builds_single_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMNode should wrap input text and instruction into one message."""
+
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: LLMNode):  # type: ignore[unused-argument]
+        return []
+
+    def fake_init_chat_model(*args, **kwargs):
+        return "model"
+
+    def fake_create_agent(model, tools, system_prompt=None, response_format=None):
+        return fake_agent
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", fake_init_chat_model)
+    monkeypatch.setattr("orcheo.nodes.ai.create_agent", fake_create_agent)
+    monkeypatch.setattr(LLMNode, "_prepare_tools", fake_prepare_tools)
+
+    node = LLMNode(
+        name="llm",
+        ai_model="test-model",
+        user_message="Bonjour",
+        draft_reply="Hello there",
+        instruction="Translate to French",
+    )
+    state = State(inputs={}, results={}, structured_response=None)
+
+    result = await node.run(state, {})
+
+    assert result == {"messages": [AIMessage(content="done")]}
+    payload = fake_agent.ainvoke.await_args.args[0]
+    messages = payload["messages"]
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == (
+        "Instruction:\nTranslate to French\n\nText:\nUser message:\nBonjour\n\n"
+        "Draft reply:\nHello there"
+    )
+
+
+def test_llmnode_build_messages_skips_empty_input() -> None:
+    node = LLMNode(name="llm", ai_model="test-model", input_text="  ")
+    state = State(inputs={}, results={}, structured_response=None)
+    assert node._build_messages(state) == []

--- a/tests/nodes/test_llm_node.py
+++ b/tests/nodes/test_llm_node.py
@@ -1,0 +1,111 @@
+"""Tests for LLMNode message construction."""
+
+from __future__ import annotations
+import contextlib
+from typing import Any
+from unittest.mock import AsyncMock
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.state import State
+from orcheo.nodes.ai import LLMNode
+
+
+def _empty_state() -> State:
+    return State(
+        messages=[],
+        inputs={},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+
+def test_llm_build_messages_formats_user_and_instruction() -> None:
+    node = LLMNode(
+        name="llm",
+        ai_model="test-model",
+        draft_reply="  draft reply  ",
+        user_message="  user context  ",
+        instruction="  Do this  ",
+    )
+    messages = node._build_messages(_empty_state())
+    assert len(messages) == 1
+    assert messages[0].content == (
+        "Instruction:\n"
+        "Do this\n\n"
+        "Text:\n"
+        "User message:\n"
+        "user context\n\n"
+        "Draft reply:\n"
+        "draft reply"
+    )
+
+
+def test_llm_build_messages_without_user_message_or_instruction() -> None:
+    node = LLMNode(
+        name="llm",
+        ai_model="test-model",
+        input_text="  just input  ",
+    )
+    messages = node._build_messages(_empty_state())
+    assert len(messages) == 1
+    assert messages[0].content == "just input"
+
+
+def test_llm_build_messages_returns_empty_when_no_text() -> None:
+    node = LLMNode(name="llm", ai_model="test-model")
+    assert node._build_messages(_empty_state()) == []
+
+
+def test_llm_normalize_text_trims_and_handles_none() -> None:
+    assert LLMNode._normalize_text("  trimmed  ") == "trimmed"
+    assert LLMNode._normalize_text(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_llm_run_returns_empty_when_no_messages(monkeypatch) -> None:
+    node = LLMNode(name="llm", ai_model="test-model")
+    monkeypatch.setattr(node, "_build_messages", lambda state: [])
+
+    result = await node.run(_empty_state(), RunnableConfig())
+    assert result == {"messages": []}
+
+
+@pytest.mark.asyncio
+async def test_llm_run_uses_response_format(monkeypatch) -> None:
+    node = LLMNode(
+        name="llm",
+        ai_model="test-model",
+        response_format={"type": "json"},
+    )
+    monkeypatch.setattr(
+        node, "_build_messages", lambda state: [HumanMessage(content="hi")]
+    )
+
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": []}
+
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "model"
+    )
+    called: dict[str, Any] = {}
+
+    def fake_provider_strategy(fmt: dict[str, Any]) -> str:
+        called["format"] = fmt
+        return "strategy"
+
+    monkeypatch.setattr("orcheo.nodes.ai.ProviderStrategy", fake_provider_strategy)
+
+    def fake_create_agent(model, tools, system_prompt=None, response_format=None):
+        assert response_format == "strategy"
+        return fake_agent
+
+    monkeypatch.setattr("orcheo.nodes.ai.create_agent", fake_create_agent)
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.tool_execution_context", contextlib.nullcontext
+    )
+
+    result = await node.run(_empty_state(), RunnableConfig())
+    assert result == {"messages": []}
+    assert called["format"] == {"type": "json"}

--- a/tests/nodes/test_mongodb_helpers.py
+++ b/tests/nodes/test_mongodb_helpers.py
@@ -68,6 +68,15 @@ def test_resolve_filter_prefers_filter_and_falls_back_to_empty() -> None:
     assert node._resolve_filter() == {}
 
 
+def test_resolve_filter_rejects_unresolved_template() -> None:
+    node = _build_node(operation="find", filter="{{prepare_event.filter}}")
+
+    with pytest.raises(
+        ValueError, match="filter must resolve to a dict before execution"
+    ):
+        node._resolve_filter()
+
+
 def test_resolve_update_handles_explicit_and_query_updates() -> None:
     node = _build_node(operation="update_one", update={"$set": {"count": 1}})
     assert node._resolve_update() == {"$set": {"count": 1}}
@@ -78,6 +87,15 @@ def test_resolve_update_handles_explicit_and_query_updates() -> None:
 
     node.query = {"other": "value"}
     with pytest.raises(ValueError, match="update is required for update operations"):
+        node._resolve_update()
+
+
+def test_resolve_update_rejects_unresolved_template() -> None:
+    node = _build_node(operation="update_one", update="{{prepare_event.update}}")
+
+    with pytest.raises(
+        ValueError, match="update must resolve to a dict before execution"
+    ):
         node._resolve_update()
 
 

--- a/tests/nodes/test_wecom.py
+++ b/tests/nodes/test_wecom.py
@@ -3,21 +3,45 @@
 from __future__ import annotations
 import base64
 import hashlib
+import json
 import struct
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
 import pytest
+import redis
 from Crypto.Cipher import AES
 from langchain_core.runnables import RunnableConfig
 from orcheo.graph.state import State
 from orcheo.nodes.wecom import (
+    CS_MESSAGE_TTL_SECONDS,
     WeComAccessTokenNode,
     WeComCustomerServiceSendNode,
     WeComCustomerServiceSyncNode,
     WeComEventsParserNode,
     WeComGroupPushNode,
     WeComSendMessageNode,
+    _build_cs_inbound_entry,
+    _build_cs_message_id,
+    _build_cs_sync_payload,
+    _close_cs_redis_client,
+    _coerce_msgtime,
+    _compute_message_ttl,
+    _create_cs_redis_client,
+    _cs_message_index_key,
+    _cs_message_key,
+    _fetch_cs_customer_username,
+    _fetch_cs_message_history,
+    _fetch_cs_page,
+    _normalize_cs_sync_response,
+    _pick_latest_message,
+    _process_cs_page,
+    _pull_cs_pages,
+    _resolve_cs_history,
+    _resolve_cs_sync_inputs,
+    _select_cs_customer_nickname,
+    _store_cs_message,
     decrypt_wecom_message,
     get_access_token_from_state,
     verify_wecom_signature,
@@ -1835,6 +1859,117 @@ class TestWeComCustomerServiceSendNode:
         call_kwargs = mock_client.post.call_args
         assert call_kwargs[1]["json"]["text"]["content"] == "Hello from non-text!"
 
+    @pytest.mark.asyncio
+    async def test_send_message_generates_fallback_msgid(
+        self, patch_redis: FakeRedis
+    ) -> None:
+        """Fallback to hashed msgid when API response omits msgid."""
+        node = WeComCustomerServiceSendNode(
+            name="wecom_cs_send",
+            open_kf_id="wkABC123",
+            external_userid="wmXYZ789",
+            message="Fallback ID",
+        )
+
+        state = State(
+            messages=[],
+            inputs={},
+            results={"get_access_token": {"access_token": "test_token"}},
+        )
+
+        send_response = MagicMock()
+        send_response.json.return_value = {"errcode": 0, "errmsg": "ok"}
+        send_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=send_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("orcheo.nodes.wecom.httpx.AsyncClient", return_value=mock_client):
+            with patch("orcheo.nodes.wecom.hashlib.sha1") as mock_sha1:
+                mock_sha1.return_value.hexdigest.return_value = "fallback-hash"
+                result = await node.run(state, RunnableConfig())
+
+        assert result["is_error"] is False
+        mock_sha1.assert_called_once()
+        assert result["msgid"] is None
+
+    @pytest.mark.asyncio
+    async def test_send_message_redis_write_failure_logged(
+        self, patch_redis: FakeRedis
+    ) -> None:
+        """Redis write failures are caught and do not block API success."""
+        node = WeComCustomerServiceSendNode(
+            name="wecom_cs_send",
+            open_kf_id="wkABC123",
+            external_userid="wmXYZ789",
+            message="Hello!",
+        )
+
+        state = State(
+            messages=[],
+            inputs={},
+            results={"get_access_token": {"access_token": "test_token"}},
+        )
+
+        send_response = MagicMock()
+        send_response.json.return_value = {
+            "errcode": 0,
+            "errmsg": "ok",
+            "msgid": "msg123",
+        }
+        send_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=send_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("orcheo.nodes.wecom.httpx.AsyncClient", return_value=mock_client):
+            with patch(
+                "orcheo.nodes.wecom._store_cs_message",
+                new=AsyncMock(side_effect=redis.RedisError("write failure")),
+            ):
+                result = await node.run(state, RunnableConfig())
+
+        assert result["is_error"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_message_closes_redis_client(self) -> None:
+        node = WeComCustomerServiceSendNode(
+            name="wecom_cs_send",
+            open_kf_id="wkABC123",
+            external_userid="wmXYZ789",
+            message="Close Redis!",
+        )
+
+        state = State(
+            messages=[],
+            inputs={},
+            results={"get_access_token": {"access_token": "test_token"}},
+        )
+
+        send_response = MagicMock()
+        send_response.json.return_value = {
+            "errcode": 0,
+            "errmsg": "ok",
+            "msgid": "msg123",
+        }
+        send_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=send_response)
+        mock_client.aclose = AsyncMock()
+
+        fake_redis = AsyncMock()
+        fake_redis.close = AsyncMock()
+
+        with patch("orcheo.nodes.wecom.httpx.AsyncClient", return_value=mock_client):
+            with patch("orcheo.nodes.wecom.redis.from_url", return_value=fake_redis):
+                result = await node.run(state, RunnableConfig())
+
+        assert result["is_error"] is False
+        fake_redis.close.assert_awaited_once()
+
 
 # get_access_token_from_state tests
 
@@ -1866,3 +2001,518 @@ class TestGetAccessTokenFromState:
         """Test returns None when access_token is empty string."""
         results = {"get_access_token": {"access_token": ""}}
         assert get_access_token_from_state(results) is None
+
+
+class TestWeComNodeCallBehaviors:
+    """Tests for TaskNode __call__ message merging."""
+
+    @pytest.mark.asyncio
+    async def test_events_parser_call_merges_agent_messages(self) -> None:
+        node = WeComEventsParserNode(
+            name="wecom_parser",
+            token="token",
+            encoding_aes_key="key",
+            corp_id="corp123",
+        )
+        run_result = {"agent_messages": [{"role": "user", "content": "hi"}]}
+
+        with patch.object(
+            WeComEventsParserNode,
+            "run",
+            new=AsyncMock(return_value=run_result),
+        ):
+            output = await node.__call__(
+                State(messages=[], inputs={}, results={}), RunnableConfig()
+            )
+
+        assert "agent_messages" not in output["results"]["wecom_parser"]
+        assert output["messages"] == run_result["agent_messages"]
+
+    @pytest.mark.asyncio
+    async def test_customer_service_sync_call_merges_agent_messages(self) -> None:
+        node = WeComCustomerServiceSyncNode(name="wecom_cs_sync")
+        run_result = {"agent_messages": [{"role": "assistant", "content": "hi"}]}
+
+        with patch.object(
+            WeComCustomerServiceSyncNode,
+            "run",
+            new=AsyncMock(return_value=run_result),
+        ):
+            output = await node.__call__(
+                State(messages=[], inputs={}, results={}), RunnableConfig()
+            )
+
+        assert "agent_messages" not in output["results"]["wecom_cs_sync"]
+        assert output["messages"] == run_result["agent_messages"]
+
+
+class TestWeComHelperFunctions:
+    """Tests for WeCom helper utilities."""
+
+    def test_coerce_msgtime_handles_various_inputs(self, monkeypatch):
+        monkeypatch.setattr("orcheo.nodes.wecom.time.time", lambda: 1000)
+        assert _coerce_msgtime(None) == 1000
+        assert _coerce_msgtime(0) == 1000
+        assert _coerce_msgtime(1_600_000_000) == 1_600_000_000
+        assert _coerce_msgtime(1_500_000_000_000) == 1_500_000_000_000 // 1000
+
+    def test_compute_message_ttl_uses_constant(self, monkeypatch):
+        monkeypatch.setattr("orcheo.nodes.wecom.time.time", lambda: 1_000_000)
+        expected = max(0, 1_000_000 + CS_MESSAGE_TTL_SECONDS - 1_000_000)
+        assert _compute_message_ttl(1_000_000) == expected
+
+    def test_build_cs_message_id_prefers_existing_id(self):
+        assert _build_cs_message_id({"msgid": "abc"}) == "abc"
+
+    def test_build_cs_message_id_hashes_payload(self):
+        payload = {"z": 1, "a": 2}
+        expected = hashlib.sha1(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        assert _build_cs_message_id(payload) == expected
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_message_history_returns_empty_when_index_missing(
+        self, fake_redis
+    ):
+        history = await _fetch_cs_message_history(fake_redis, "user")
+        assert history == []
+
+    @pytest.mark.asyncio
+    async def test_store_cs_message_detects_existing_key(self, fake_redis):
+        message_key = _cs_message_key("user", "msg")
+        fake_redis.store[message_key] = "value"
+        result = await _store_cs_message(
+            fake_redis,
+            message_key,
+            _cs_message_index_key("user"),
+            int(time.time()),
+            {"content": "value"},
+        )
+        assert result == (False, True)
+
+    @pytest.mark.asyncio
+    async def test_store_cs_message_handles_expired_ttl(self, fake_redis, monkeypatch):
+        msgtime = 1_000
+        monkeypatch.setattr(
+            "orcheo.nodes.wecom.time.time",
+            lambda: msgtime + CS_MESSAGE_TTL_SECONDS + 5,
+        )
+        message_key = _cs_message_key("user", "expired")
+        result = await _store_cs_message(
+            fake_redis,
+            message_key,
+            _cs_message_index_key("user"),
+            msgtime,
+            {"content": "dead"},
+        )
+        assert result == (False, False)
+
+    @pytest.mark.asyncio
+    async def test_store_cs_message_success(self, fake_redis, monkeypatch):
+        msgtime = 1_000_000
+        monkeypatch.setattr("orcheo.nodes.wecom.time.time", lambda: msgtime)
+        message_key = _cs_message_key("user", "fresh")
+        result = await _store_cs_message(
+            fake_redis,
+            message_key,
+            _cs_message_index_key("user"),
+            msgtime,
+            {"content": "alive"},
+        )
+        assert result == (True, False)
+        assert fake_redis.store[message_key] == json.dumps({"content": "alive"})
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_message_history_filters_stale_entries(self, fake_redis):
+        index_key = _cs_message_index_key("user")
+        keys = [
+            _cs_message_key("user", "one"),
+            _cs_message_key("user", "two"),
+            _cs_message_key("user", "three"),
+        ]
+        fake_redis.zsets[index_key] = {keys[0]: 1, keys[1]: 2, keys[2]: 3}
+        fake_redis.store[keys[0]] = '{"content":"v1"}'
+        fake_redis.store[keys[2]] = "not json"
+
+        history = await _fetch_cs_message_history(fake_redis, "user")
+
+        assert history == [{"content": "v1"}]
+        assert keys[1] not in fake_redis.zsets[index_key]
+        assert keys[2] not in fake_redis.zsets[index_key]
+
+    def test_build_cs_sync_payload_adds_cursor(self):
+        base = {"open_kfid": "open"}
+        payload = _build_cs_sync_payload(base, "cursor123")
+        assert payload["cursor"] == "cursor123"
+        assert base == {"open_kfid": "open"}
+
+    def test_normalize_cs_sync_response_converts_flags(self):
+        data = {
+            "errcode": 1,
+            "errmsg": "bad",
+            "msg_list": [{"msg": "value"}],
+            "next_cursor": "next",
+            "has_more": 1,
+        }
+        errcode, errmsg, msg_list, next_cursor, has_more = _normalize_cs_sync_response(
+            data
+        )
+        assert errcode == 1
+        assert errmsg == "bad"
+        assert next_cursor == "next"
+        assert has_more is True
+        assert msg_list == [{"msg": "value"}]
+
+    def test_build_cs_inbound_entry_validation(self):
+        empty_origin = _build_cs_inbound_entry("open", {"origin": 2, "msgtype": "text"})
+        assert empty_origin is None
+        empty_data = _build_cs_inbound_entry(
+            "open",
+            {
+                "origin": 3,
+                "msgtype": "text",
+                "external_userid": "",
+                "text": {"content": "hi"},
+            },
+        )
+        assert empty_data is None
+
+    def test_build_cs_inbound_entry_returns_entry(self):
+        msg = {
+            "origin": 3,
+            "msgtype": "text",
+            "external_userid": "user",
+            "text": {"content": "hello"},
+            "msgtime": 1_234,
+            "msgid": "abc123",
+        }
+        entry = _build_cs_inbound_entry("open", msg)
+        assert entry is not None
+        assert entry["id"] == "abc123"
+        assert entry["content"] == "hello"
+
+    def test_pick_latest_message_prefers_newer(self):
+        current = {"msgtime": 10}
+        candidate = {"msgtime": 20}
+        assert _pick_latest_message(current, candidate) == candidate
+        assert _pick_latest_message(None, candidate) == candidate
+        assert _pick_latest_message(current, None) == current
+
+    @pytest.mark.asyncio
+    async def test_process_cs_page_without_redis_client(self):
+        msg = {
+            "origin": 3,
+            "msgtype": "text",
+            "external_userid": "user",
+            "text": {"content": "hello"},
+            "msgtime": 1,
+            "msgid": "id1",
+        }
+        new_messages, latest, saw_existing, redis_failed = await _process_cs_page(
+            [msg], "open", None
+        )
+        assert len(new_messages) == 1
+        assert latest["external_userid"] == "user"
+        assert saw_existing is False
+        assert redis_failed is False
+
+    @pytest.mark.asyncio
+    async def test_process_cs_page_handles_redis_write_error(self, fake_redis):
+        msg = {
+            "origin": 3,
+            "msgtype": "text",
+            "external_userid": "user",
+            "text": {"content": "hello"},
+            "msgtime": 1,
+            "msgid": "id1",
+        }
+        with patch(
+            "orcheo.nodes.wecom._store_cs_entry",
+            new=AsyncMock(side_effect=redis.RedisError("boom")),
+        ):
+            new_messages, latest, saw_existing, redis_failed = await _process_cs_page(
+                [msg], "open", fake_redis
+            )
+        assert new_messages
+        assert latest is not None
+        assert saw_existing is False
+        assert redis_failed is True
+
+    @pytest.mark.asyncio
+    async def test_process_cs_page_detects_existing_entry(self, fake_redis):
+        msg = {
+            "origin": 3,
+            "msgtype": "text",
+            "external_userid": "user",
+            "text": {"content": "hello"},
+            "msgtime": 1,
+            "msgid": "id_existing",
+        }
+        with patch(
+            "orcheo.nodes.wecom._store_cs_entry",
+            new=AsyncMock(return_value=(False, True)),
+        ):
+            new_messages, latest, saw_existing, redis_failed = await _process_cs_page(
+                [msg], "open", fake_redis
+            )
+        assert new_messages == []
+        assert saw_existing is True
+        assert redis_failed is False
+
+    def test_resolve_cs_sync_inputs_prefers_explicit_values(self):
+        direct = _resolve_cs_sync_inputs("open", "token", {"open_kf_id": "parser"})
+        assert direct == ("open", "token")
+        fallback = _resolve_cs_sync_inputs(
+            None, None, {"open_kf_id": "parser", "kf_token": "abc"}
+        )
+        assert fallback == ("parser", "abc")
+
+    def test_create_cs_redis_client_handles_unavailable(self):
+        with patch(
+            "orcheo.nodes.wecom.redis.from_url",
+            side_effect=redis.RedisError("unavailable"),
+        ):
+            assert _create_cs_redis_client() is None
+
+    @pytest.mark.asyncio
+    async def test_close_cs_redis_client_ignores_errors(self):
+        class Dummy:
+            async def close(self) -> None:
+                raise redis.RedisError("boom")
+
+        await _close_cs_redis_client(Dummy())
+
+    @pytest.mark.asyncio
+    async def test_close_cs_redis_client_handles_none(self):
+        await _close_cs_redis_client(None)
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_page_includes_cursor(self):
+        client = AsyncMock()
+        response = MagicMock()
+        response.json.return_value = {"errcode": 0}
+        response.raise_for_status = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        payload = {"open_kfid": "open"}
+        result = await _fetch_cs_page(
+            client, "url", {"access_token": "token"}, payload, "cursor123"
+        )
+        client.post.assert_awaited_once()
+        assert result == {"errcode": 0}
+        assert client.post.call_args[1]["json"]["cursor"] == "cursor123"
+
+    @pytest.mark.asyncio
+    async def test_pull_cs_pages_handles_api_error(self):
+        client = AsyncMock()
+        with patch(
+            "orcheo.nodes.wecom._fetch_cs_page",
+            new=AsyncMock(return_value={"errcode": 123, "errmsg": "bad"}),
+        ):
+            result = await _pull_cs_pages(client, None, "url", {}, {}, None)
+        assert result["is_error"] is True
+
+    @pytest.mark.asyncio
+    async def test_pull_cs_pages_closes_redis_on_failure(self, fake_redis):
+        client = AsyncMock()
+        normalized = MagicMock(return_value=(0, "", [], "", False))
+        processed = AsyncMock(
+            return_value=([], {"external_userid": "user"}, True, True)
+        )
+        closer = AsyncMock()
+        with (
+            patch(
+                "orcheo.nodes.wecom._fetch_cs_page",
+                new=AsyncMock(
+                    return_value={
+                        "errcode": 0,
+                        "msg_list": [],
+                        "next_cursor": "",
+                        "has_more": 0,
+                    }
+                ),
+            ),
+            patch(
+                "orcheo.nodes.wecom._normalize_cs_sync_response",
+                new=normalized,
+            ),
+            patch(
+                "orcheo.nodes.wecom._process_cs_page",
+                new=processed,
+            ),
+            patch(
+                "orcheo.nodes.wecom._close_cs_redis_client",
+                new=closer,
+            ),
+        ):
+            result = await _pull_cs_pages(
+                client,
+                fake_redis,
+                "url",
+                {"access_token": "token"},
+                {"open_kfid": "open"},
+                None,
+            )
+        closer.assert_awaited_once_with(fake_redis)
+        assert result["redis_client"] is None
+
+    @pytest.mark.asyncio
+    async def test_pull_cs_pages_uses_cursor_for_pagination(self):
+        client = AsyncMock()
+        fetch = AsyncMock(
+            side_effect=[
+                {"errcode": 0, "msg_list": [], "next_cursor": "next123", "has_more": 1},
+                {"errcode": 0, "msg_list": [], "next_cursor": "", "has_more": 0},
+            ]
+        )
+        normalized = MagicMock(
+            side_effect=[(0, "", [], "next123", True), (0, "", [], "", False)]
+        )
+        processed = AsyncMock(return_value=([], None, False, False))
+        with (
+            patch("orcheo.nodes.wecom._fetch_cs_page", new=fetch),
+            patch("orcheo.nodes.wecom._normalize_cs_sync_response", new=normalized),
+            patch("orcheo.nodes.wecom._process_cs_page", new=processed),
+        ):
+            result = await _pull_cs_pages(
+                client,
+                None,
+                "url",
+                {"access_token": "token"},
+                {"open_kfid": "open"},
+                None,
+            )
+        assert fetch.call_count == 2
+        assert fetch.call_args_list[1][0][4] == "next123"
+        assert result["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_resolve_cs_history_returns_empty_without_latest(self):
+        external_userid, history = await _resolve_cs_history(None, None, [])
+        assert external_userid == ""
+        assert history == []
+
+    @pytest.mark.asyncio
+    async def test_resolve_cs_history_falls_back_to_new_messages(self):
+        latest = {"external_userid": "user"}
+        new_messages = [
+            {"external_userid": "user", "msgtime": 200},
+            {"external_userid": "user", "msgtime": 100},
+        ]
+        external_userid, history = await _resolve_cs_history(None, latest, new_messages)
+        assert external_userid == "user"
+        assert history[0]["msgtime"] == 100
+
+    @pytest.mark.asyncio
+    async def test_resolve_cs_history_handles_missing_external_userid(self):
+        latest = {"external_userid": ""}
+        external_userid, history = await _resolve_cs_history(None, latest, [])
+        assert external_userid == ""
+        assert history == []
+
+    @pytest.mark.asyncio
+    async def test_resolve_cs_history_prefers_redis_history(self, fake_redis):
+        latest = {"external_userid": "user"}
+        history_payload = [{"external_userid": "user", "msgtime": 5}]
+        with patch(
+            "orcheo.nodes.wecom._fetch_cs_message_history",
+            new=AsyncMock(return_value=history_payload),
+        ):
+            external_userid, history = await _resolve_cs_history(fake_redis, latest, [])
+        assert external_userid == "user"
+        assert history == history_payload
+
+    @pytest.mark.asyncio
+    async def test_resolve_cs_history_handles_redis_error(self, fake_redis):
+        latest = {"external_userid": "user"}
+        fallback_messages = [{"external_userid": "user", "msgtime": 1}]
+        with patch(
+            "orcheo.nodes.wecom._fetch_cs_message_history",
+            new=AsyncMock(side_effect=redis.RedisError("boom")),
+        ):
+            external_userid, history = await _resolve_cs_history(
+                fake_redis, latest, fallback_messages
+            )
+        assert external_userid == "user"
+        assert history == fallback_messages
+
+    def test_select_cs_customer_nickname_handles_various(self):
+        assert _select_cs_customer_nickname("notalist", "user") == ""
+        matches = [
+            {"external_userid": "user", "nickname": "Nick"},
+            {"external_userid": "other", "nickname": "Other"},
+        ]
+        assert _select_cs_customer_nickname(matches, "user") == "Nick"
+        fallback = [{"external_userid": "none", "name": "Name"}]
+        assert _select_cs_customer_nickname(fallback, "user") == "Name"
+
+    def test_select_cs_customer_nickname_skips_non_mapping_entries(self):
+        customers = [
+            "invalid",
+            {"external_userid": "user", "nickname": "Nick"},
+        ]
+        assert _select_cs_customer_nickname(customers, "user") == "Nick"
+
+    def test_select_cs_customer_nickname_returns_empty_when_no_mapping(self):
+        customers = ["invalid", 123]
+        assert _select_cs_customer_nickname(customers, "user") == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_customer_username_returns_empty_on_missing_userid(self):
+        client = AsyncMock()
+        result = await _fetch_cs_customer_username(client, "token", "")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_customer_username_handles_http_error(self):
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=httpx.HTTPError("fail"))
+        result = await _fetch_cs_customer_username(client, "token", "user")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_customer_username_handles_errcode(self):
+        client = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"errcode": 1, "errmsg": "bad"}
+        client.post = AsyncMock(return_value=response)
+        result = await _fetch_cs_customer_username(client, "token", "user")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_cs_customer_username_returns_nickname(self):
+        client = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "errcode": 0,
+            "customer_list": [{"external_userid": "user", "nickname": "Display"}],
+        }
+        client.post = AsyncMock(return_value=response)
+        result = await _fetch_cs_customer_username(client, "token", "user")
+        assert result == "Display"
+
+    def test_build_agent_messages_filters_roles(self):
+        history = [
+            {"role": "user", "content": " hi "},
+            {"role": "ai", "content": "assistant"},
+            {"role": "assistant", "content": " "},
+            "invalid",
+        ]
+        messages = WeComCustomerServiceSyncNode._build_agent_messages(history)
+        assert messages == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "assistant"},
+        ]
+
+    def test_build_agent_messages_handles_non_list(self):
+        assert WeComCustomerServiceSyncNode._build_agent_messages(None) == []
+
+    def test_build_agent_messages_skips_non_mapping_items(self):
+        history = [
+            "bad",
+            {"role": "user", "content": "hello"},
+        ]
+        messages = WeComCustomerServiceSyncNode._build_agent_messages(history)
+        assert messages == [{"role": "user", "content": "hello"}]

--- a/tests/sdk/test_mcp_server_workflows_overview.py
+++ b/tests/sdk/test_mcp_server_workflows_overview.py
@@ -128,7 +128,7 @@ def test_show_workflow_success(mock_env: None) -> None:
 
     assert result["workflow"]["share_url"] == "http://api.test/chat/wf-1"
     assert result["workflow"]["is_public"] is True
-    assert result["latest_version"] == versions[0]
+    assert result["selected_version"] == versions[0]
     assert len(result["recent_runs"]) == 1
 
 
@@ -158,7 +158,7 @@ def test_show_workflow_with_cached_runs(mock_env: None) -> None:
         )
 
     assert result["workflow"]["share_url"] is None
-    assert result["latest_version"] == versions[0]
+    assert result["selected_version"] == versions[0]
     assert len(result["recent_runs"]) == 1
 
 
@@ -192,7 +192,7 @@ def test_show_workflow_with_runs_none_path(mock_env: None) -> None:
         )
 
     assert result["workflow"]["share_url"] is None
-    assert result["latest_version"] == versions[0]
+    assert result["selected_version"] == versions[0]
     assert len(result["recent_runs"]) == 1
 
 
@@ -220,5 +220,5 @@ def test_show_workflow_without_runs(mock_env: None) -> None:
         )
 
     assert result["workflow"]["share_url"] is None
-    assert result["latest_version"] == versions[0]
+    assert result["selected_version"] == versions[0]
     assert result["recent_runs"] == []


### PR DESCRIPTION
### Summary
- Adds a new WeCom Event Agent workflow that handles event management (create/update events, RSVPs) through WeCom Customer Service and internal messages
- Introduces agent tools for MongoDB operations, enabling AI agents to interact with databases
- Enhances WeCom nodes with Customer Service sync, send, and internal message capabilities

### Key Changes

**New Features:**
- **WeCom Event Agent workflow** (`examples/wecom_event_agent/`) - Full workflow for event/RSVP management via chat
- **WeCom Echo History workflow** (`examples/wecom_echo_history/`) - Demo workflow that echoes chat history
- **Agent Tools for MongoDB** (`src/orcheo/nodes/agent_tools/`) - New `mongodb_update_one` and `mongodb_find` tools for agents
- **Agent context management** (`src/orcheo/nodes/agent_tools/context.py`) - Thread-local context for passing config to agent tools

**WeCom Enhancements:**
- `WeComCustomerServiceSyncNode` - Sync and fetch Customer Service messages with history support
- `WeComCustomerServiceSendNode` - Send replies to Customer Service users
- `WeComSendMessageNode` - Send internal WeCom messages
- Enhanced `WeComEventsParserNode` with CS event detection and message extraction

**AI Node Improvements:**
- `AgentNode` now supports `history_messages` attribute for conversation context
- Automatic user message injection from WeCom parser/CS sync results
- New `run_tools_on_final_output` configuration option

**MongoDB Enhancements:**
- Added `upsert` support to `MongoDBNode`
- Helper functions for building filters and update documents

**Documentation:**
- Requirements, design, and plan documents for WeCom Event Agent (`docs/wecom_event_agent/`)