### PR TITLE
Add structured log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "mcp[cli]>=1.12.0",
   "pymongo>=4.13.2",
   "dynaconf>=3.2.4",
+  "structlog>=24.4.0",
   "cryptography>=43.0.1",
   "RestrictedPython>=7.2",
   "py-mini-racer>=0.6.0",

--- a/tests/backend/test_logging_config.py
+++ b/tests/backend/test_logging_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import importlib
+import json
 import logging
 import pytest
 
@@ -32,3 +33,30 @@ def test_configure_logging_applies_requested_log_level(
 
     assert reloaded.get_logger().name == "orcheo_backend.app"
     assert reloaded.get_logger("custom.logger").name == "custom.logger"
+
+
+def test_configure_logging_renders_extra_fields(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Structured logs should include extra fields from stdlib logging."""
+    monkeypatch.setenv("LOG_LEVEL", "info")
+    monkeypatch.setenv("LOG_FORMAT", "json")
+    importlib.reload(logging_config)
+
+    logger = logging.getLogger("orcheo.logging_test")
+    logger.info(
+        "WeCom Customer Service event received",
+        extra={
+            "event": "wecom_customer_service",
+            "status": "received",
+            "open_kf_id": "kf_123",
+        },
+    )
+
+    captured = capsys.readouterr().err.strip().splitlines()
+    payload = json.loads(captured[-1])
+
+    assert payload["message"] == "WeCom Customer Service event received"
+    assert payload["event"] == "wecom_customer_service"
+    assert payload["status"] == "received"
+    assert payload["open_kf_id"] == "kf_123"

--- a/uv.lock
+++ b/uv.lock
@@ -3390,6 +3390,7 @@ dependencies = [
     { name = "python-telegram-bot" },
     { name = "restrictedpython" },
     { name = "selenium" },
+    { name = "structlog" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -3459,6 +3460,7 @@ requires-dist = [
     { name = "python-telegram-bot", specifier = ">=22.0" },
     { name = "restrictedpython", specifier = ">=7.2" },
     { name = "selenium", specifier = ">=4.32.0" },
+    { name = "structlog", specifier = ">=24.4.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
@@ -5338,6 +5340,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033 },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510 },
 ]
 
 [[package]]


### PR DESCRIPTION
Switched backend logging to structlog so extra fields like event, status, and open_kf_id are rendered in output by default, with the log message moved to a message field to avoid clobbering your event key. Added a small test to lock this behavior in.

Details:
1. logging_config.py now configures structlog with JSON output by default and supports LOG_FORMAT=console; extra fields from stdlib logging are included.
1. test_logging_config.py verifies that extra fields are present in structured logs.
1. pyproject.toml adds structlog as a runtime dependency.