### PR TITLE
Fix Canvas deployment

### DIFF
--- a/apps/canvas/vitest.config.ts
+++ b/apps/canvas/vitest.config.ts
@@ -1,29 +1,25 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+/// <reference types="vitest" />
+import { defineConfig, mergeConfig } from 'vitest/config'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import viteConfig from './vite.config'
 
 // ES Module equivalent of __dirname
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@lib': path.resolve(__dirname, './src/lib'),
-      '@design-system': path.resolve(__dirname, './src/design-system'),
-      '@features': path.resolve(__dirname, './src/features'),
-    }
-  },
-  test: {
-    environment: 'jsdom',
-    setupFiles: './src/setupTests.ts',
-    alias: {
-      '@openai/chatkit-react': path.resolve(
-        __dirname,
-        './src/test-utils/chatkit-stub.ts',
-      ),
+// Extend vite.config.ts with test-specific configuration
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      setupFiles: './src/setupTests.ts',
+      alias: {
+        '@openai/chatkit-react': path.resolve(
+          __dirname,
+          './src/test-utils/chatkit-stub.ts',
+        ),
+      },
     },
-  }
-})
+  })
+)

--- a/apps/canvas/vitest.config.ts
+++ b/apps/canvas/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import { fileURLToPath } from 'url'
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'url'
 // ES Module equivalent of __dirname
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -17,9 +16,14 @@ export default defineConfig({
       '@features': path.resolve(__dirname, './src/features'),
     }
   },
-  server: {
-    allowedHosts: [
-      'orcheo-canvas.ai-colleagues.com'
-    ]
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    alias: {
+      '@openai/chatkit-react': path.resolve(
+        __dirname,
+        './src/test-utils/chatkit-stub.ts',
+      ),
+    },
   }
 })


### PR DESCRIPTION
This change fixes a deployment issue where the Canvas container fails to start when installed from npm. The vite.config.ts was importing from vitest/config, but vitest is a devDependency and isn't installed in production. Separating the configs allows the dev server to run without the vitest dependency.

Error that was occurring:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vitest' imported from vite.config.ts`