### PR TITLE
Add CLI version flag, config-based OAuth, and machine-readable output

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
@@ -48,8 +48,8 @@ def login(
     except CLIError as exc:
         if state.human:
             state.console.print(f"[red]{exc}[/red]")
-            raise typer.Exit(code=1) from exc
-        print_json({"error": str(exc)})
+        else:
+            print_json({"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
@@ -46,7 +46,10 @@ def login(
             port=port,
         )
     except CLIError as exc:
-        state.console.print(f"[red]{exc}[/red]")
+        if state.human:
+            state.console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from exc
+        print_json({"error": str(exc)})
         raise typer.Exit(code=1) from exc
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/commands.py
@@ -11,7 +11,7 @@ from orcheo_sdk.cli.auth.tokens import (
     is_oauth_token_valid,
 )
 from orcheo_sdk.cli.errors import CLIError
-from orcheo_sdk.cli.output import machine_success, print_json
+from orcheo_sdk.cli.output import print_json, print_machine_success
 from orcheo_sdk.cli.state import CLIState
 
 
@@ -59,7 +59,7 @@ def logout(ctx: typer.Context) -> None:
     state = _state(ctx)
     logout_oauth(profile=state.settings.profile)
     if not state.human:
-        machine_success("Logged out successfully.")
+        print_machine_success("Logged out successfully.")
         return
     state.console.print("[green]Logged out successfully.[/green]")
 

--- a/packages/sdk/src/orcheo_sdk/cli/auth/config.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/config.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 import os
+import tomllib
 from dataclasses import dataclass
+from typing import Any
+from orcheo_sdk.cli.config import (
+    CONFIG_FILENAME,
+    DEFAULT_PROFILE,
+    PROFILE_ENV,
+    get_config_dir,
+    load_profiles,
+)
 from orcheo_sdk.cli.errors import CLIConfigurationError
 
 
@@ -27,29 +36,64 @@ class OAuthConfig:
     organization: str | None = None
 
 
-def get_oauth_config() -> OAuthConfig:
-    """Load OAuth configuration from environment variables.
+def _load_profile_oauth_settings(profile: str | None) -> dict[str, Any]:
+    """Load OAuth settings from the CLI config profile, if available."""
+    profile_name = profile or os.getenv(PROFILE_ENV) or DEFAULT_PROFILE
+    config_path = get_config_dir() / CONFIG_FILENAME
+    try:
+        profiles = load_profiles(config_path)
+    except tomllib.TOMLDecodeError as exc:
+        raise CLIConfigurationError(f"Invalid TOML in {config_path}.") from exc
+    return profiles.get(profile_name, {})
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
+    """Load OAuth configuration from CLI config and environment variables.
 
     Raises:
         CLIConfigurationError: If required OAuth config is missing.
     """
-    issuer = os.getenv(AUTH_ISSUER_ENV)
-    client_id = os.getenv(AUTH_CLIENT_ID_ENV)
+    profile_data = _load_profile_oauth_settings(profile)
+
+    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_ENV)) or os.getenv(
+        AUTH_ISSUER_ENV
+    )
+    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_ENV)) or os.getenv(
+        AUTH_CLIENT_ID_ENV
+    )
+    profile_scopes = _coerce_str(profile_data.get(AUTH_SCOPES_ENV))
+    profile_audience = _coerce_str(profile_data.get(AUTH_AUDIENCE_ENV))
+    profile_organization = _coerce_str(profile_data.get(AUTH_ORGANIZATION_ENV))
 
     if not issuer or not client_id:
         raise CLIConfigurationError(
             f"OAuth not configured. Set {AUTH_ISSUER_ENV} and {AUTH_CLIENT_ID_ENV}."
         )
 
+    scopes = profile_scopes or os.getenv(AUTH_SCOPES_ENV) or DEFAULT_SCOPES
+
     return OAuthConfig(
         issuer=issuer.rstrip("/"),
         client_id=client_id,
-        scopes=os.getenv(AUTH_SCOPES_ENV, DEFAULT_SCOPES),
-        audience=os.getenv(AUTH_AUDIENCE_ENV),
-        organization=os.getenv(AUTH_ORGANIZATION_ENV),
+        scopes=scopes,
+        audience=profile_audience or os.getenv(AUTH_AUDIENCE_ENV),
+        organization=profile_organization or os.getenv(AUTH_ORGANIZATION_ENV),
     )
 
 
-def is_oauth_configured() -> bool:
-    """Check if OAuth environment variables are set."""
-    return bool(os.getenv(AUTH_ISSUER_ENV) and os.getenv(AUTH_CLIENT_ID_ENV))
+def is_oauth_configured(*, profile: str | None = None) -> bool:
+    """Check if OAuth config is set via CLI config or environment."""
+    profile_data = _load_profile_oauth_settings(profile)
+    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_ENV)) or os.getenv(
+        AUTH_ISSUER_ENV
+    )
+    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_ENV)) or os.getenv(
+        AUTH_CLIENT_ID_ENV
+    )
+    return bool(issuer and client_id)

--- a/packages/sdk/src/orcheo_sdk/cli/auth/config.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/config.py
@@ -22,6 +22,12 @@ AUTH_SCOPES_ENV = "ORCHEO_AUTH_SCOPES"
 AUTH_AUDIENCE_ENV = "ORCHEO_AUTH_AUDIENCE"
 AUTH_ORGANIZATION_ENV = "ORCHEO_AUTH_ORGANIZATION"
 
+AUTH_ISSUER_KEY = "auth_issuer"
+AUTH_CLIENT_ID_KEY = "auth_client_id"
+AUTH_SCOPES_KEY = "auth_scopes"
+AUTH_AUDIENCE_KEY = "auth_audience"
+AUTH_ORGANIZATION_KEY = "auth_organization"
+
 DEFAULT_SCOPES = "openid profile email"
 
 
@@ -61,15 +67,15 @@ def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
     """
     profile_data = _load_profile_oauth_settings(profile)
 
-    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_ENV)) or os.getenv(
+    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_KEY)) or os.getenv(
         AUTH_ISSUER_ENV
     )
-    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_ENV)) or os.getenv(
+    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_KEY)) or os.getenv(
         AUTH_CLIENT_ID_ENV
     )
-    profile_scopes = _coerce_str(profile_data.get(AUTH_SCOPES_ENV))
-    profile_audience = _coerce_str(profile_data.get(AUTH_AUDIENCE_ENV))
-    profile_organization = _coerce_str(profile_data.get(AUTH_ORGANIZATION_ENV))
+    profile_scopes = _coerce_str(profile_data.get(AUTH_SCOPES_KEY))
+    profile_audience = _coerce_str(profile_data.get(AUTH_AUDIENCE_KEY))
+    profile_organization = _coerce_str(profile_data.get(AUTH_ORGANIZATION_KEY))
 
     if not issuer or not client_id:
         raise CLIConfigurationError(
@@ -90,10 +96,10 @@ def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
 def is_oauth_configured(*, profile: str | None = None) -> bool:
     """Check if OAuth config is set via CLI config or environment."""
     profile_data = _load_profile_oauth_settings(profile)
-    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_ENV)) or os.getenv(
+    issuer = _coerce_str(profile_data.get(AUTH_ISSUER_KEY)) or os.getenv(
         AUTH_ISSUER_ENV
     )
-    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_ENV)) or os.getenv(
+    client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_KEY)) or os.getenv(
         AUTH_CLIENT_ID_ENV
     )
     return bool(issuer and client_id)

--- a/packages/sdk/src/orcheo_sdk/cli/auth/config.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/config.py
@@ -95,7 +95,10 @@ def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
 
 def is_oauth_configured(*, profile: str | None = None) -> bool:
     """Check if OAuth config is set via CLI config or environment."""
-    profile_data = _load_profile_oauth_settings(profile)
+    try:
+        profile_data = _load_profile_oauth_settings(profile)
+    except CLIConfigurationError:
+        return False
     issuer = _coerce_str(profile_data.get(AUTH_ISSUER_KEY)) or os.getenv(
         AUTH_ISSUER_ENV
     )

--- a/packages/sdk/src/orcheo_sdk/cli/auth/config.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/config.py
@@ -59,6 +59,22 @@ def _coerce_str(value: Any) -> str | None:
     return None
 
 
+def _coerce_scopes(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        if not all(isinstance(scope, str) for scope in value):
+            raise CLIConfigurationError(
+                f"{AUTH_SCOPES_KEY} must be a string or list of strings."
+            )
+        return " ".join(value)
+    raise CLIConfigurationError(
+        f"{AUTH_SCOPES_KEY} must be a string or list of strings."
+    )
+
+
 def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
     """Load OAuth configuration from CLI config and environment variables.
 
@@ -73,7 +89,7 @@ def get_oauth_config(*, profile: str | None = None) -> OAuthConfig:
     client_id = _coerce_str(profile_data.get(AUTH_CLIENT_ID_KEY)) or os.getenv(
         AUTH_CLIENT_ID_ENV
     )
-    profile_scopes = _coerce_str(profile_data.get(AUTH_SCOPES_KEY))
+    profile_scopes = _coerce_scopes(profile_data.get(AUTH_SCOPES_KEY))
     profile_audience = _coerce_str(profile_data.get(AUTH_AUDIENCE_KEY))
     profile_organization = _coerce_str(profile_data.get(AUTH_ORGANIZATION_KEY))
 

--- a/packages/sdk/src/orcheo_sdk/cli/auth/oauth.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/oauth.py
@@ -141,7 +141,7 @@ def start_oauth_login(
     port: int = DEFAULT_CALLBACK_PORT,
 ) -> None:
     """Execute browser-based OAuth login flow."""
-    config = get_oauth_config()
+    config = get_oauth_config(profile=profile)
     discovery = _load_discovery(config.issuer)
 
     # Generate PKCE parameters

--- a/packages/sdk/src/orcheo_sdk/cli/auth/refresh.py
+++ b/packages/sdk/src/orcheo_sdk/cli/auth/refresh.py
@@ -40,7 +40,7 @@ def refresh_oauth_tokens(*, profile: str | None) -> AuthTokens | None:
 
     Returns refreshed tokens if successful, None if refresh not possible.
     """
-    if not is_oauth_configured():
+    if not is_oauth_configured(profile=profile):
         return None
 
     tokens = get_oauth_tokens(profile=profile)
@@ -48,7 +48,7 @@ def refresh_oauth_tokens(*, profile: str | None) -> AuthTokens | None:
         return None
 
     try:
-        config = get_oauth_config()
+        config = get_oauth_config(profile=profile)
         token_endpoint = _load_discovery_token_endpoint(config.issuer)
         if not token_endpoint:
             return None

--- a/packages/sdk/src/orcheo_sdk/cli/codegen.py
+++ b/packages/sdk/src/orcheo_sdk/cli/codegen.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Annotated
 import typer
 from orcheo_sdk.cli.errors import CLIError
-from orcheo_sdk.cli.output import render_json
+from orcheo_sdk.cli.output import print_json, render_json
 from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.cli.utils import load_with_cache
 from orcheo_sdk.services import (
@@ -56,6 +56,9 @@ def scaffold_workflow(
         workflow=workflow,
         versions=versions,
     )
+    if not state.human:
+        print_json(data)
+        return
     state.console.print(data["code"])
 
     render_json(state.console, data["workflow"], title="Workflow metadata")
@@ -125,6 +128,9 @@ def generate_template(
     except OSError as exc:  # pragma: no cover - filesystem error
         msg = f"Unable to write workflow template to {output_path}: {exc}".rstrip()
         raise CLIError(msg) from exc
+    if not state.human:
+        print_json({"status": "success", "path": str(output_path)})
+        return
     state.console.print(f"[green]Created workflow template: {output_path}[/green]")
     state.console.print("\nNext steps:")
     state.console.print(

--- a/packages/sdk/src/orcheo_sdk/cli/config_command.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config_command.py
@@ -251,6 +251,15 @@ def configure(
         auth_organization=auth_organization,
     )
 
+    has_issuer = AUTH_ISSUER_KEY in oauth_values
+    has_client_id = AUTH_CLIENT_ID_KEY in oauth_values
+    if has_issuer != has_client_id:
+        missing = AUTH_CLIENT_ID_KEY if has_issuer else AUTH_ISSUER_KEY
+        raise CLIError(
+            f"Incomplete OAuth configuration: '{missing}' is required when"
+            f" '{AUTH_ISSUER_KEY if has_issuer else AUTH_CLIENT_ID_KEY}' is set."
+        )
+
     for name in profile_names:
         profile_data = dict(profiles.get(name, {}))
         resolved_api_url = resolved_api_url_override or profile_data.get("api_url")

--- a/packages/sdk/src/orcheo_sdk/cli/config_command.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config_command.py
@@ -29,6 +29,7 @@ from orcheo_sdk.cli.config import (
     load_profiles,
 )
 from orcheo_sdk.cli.errors import CLIError
+from orcheo_sdk.cli.output import print_json
 from orcheo_sdk.cli.state import CLIState
 
 
@@ -267,8 +268,6 @@ def configure(
 
     _write_profiles(config_path, profiles)
     if not state.human:
-        from orcheo_sdk.cli.output import print_json
-
         print_json(
             {
                 "status": "success",

--- a/packages/sdk/src/orcheo_sdk/cli/config_command.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config_command.py
@@ -228,15 +228,9 @@ def configure(
     except tomllib.TOMLDecodeError as exc:
         raise CLIError(f"Invalid TOML in {config_path}.") from exc
 
-    existing_profile = profiles.get(profile_names[0], {})
-
-    resolved_api_url = _resolve_value(
+    resolved_api_url_override = _resolve_value(
         API_URL_ENV, env_data=env_data, override=api_url
-    ) or existing_profile.get("api_url")
-    if not resolved_api_url:
-        raise CLIError(
-            "Missing ORCHEO_API_URL. Provide --api-url or set ORCHEO_API_URL."
-        )
+    )
     resolved_service_token = _resolve_value(
         SERVICE_TOKEN_ENV,
         env_data=env_data,
@@ -258,6 +252,11 @@ def configure(
 
     for name in profile_names:
         profile_data = dict(profiles.get(name, {}))
+        resolved_api_url = resolved_api_url_override or profile_data.get("api_url")
+        if not resolved_api_url:
+            raise CLIError(
+                "Missing ORCHEO_API_URL. Provide --api-url or set ORCHEO_API_URL."
+            )
         profile_data["api_url"] = resolved_api_url
         if resolved_service_token:
             profile_data["service_token"] = resolved_service_token

--- a/packages/sdk/src/orcheo_sdk/cli/credential.py
+++ b/packages/sdk/src/orcheo_sdk/cli/credential.py
@@ -166,7 +166,7 @@ def update_credential(
         print_json(
             {"error": "Credential updates are not yet supported by the backend API."}
         )
-        raise typer.Exit(code=0)
+        raise typer.Exit(code=1)
     state.console.print(
         "Credential updates are not yet supported by the backend API. "
         "Rotate credentials via templates or recreate them."

--- a/packages/sdk/src/orcheo_sdk/cli/credential.py
+++ b/packages/sdk/src/orcheo_sdk/cli/credential.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 from typing import Annotated
 import typer
-from orcheo_sdk.cli.output import render_json, render_table
+from orcheo_sdk.cli.output import (
+    print_json,
+    print_markdown_table,
+    render_json,
+    render_table,
+)
 from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.services import (
     create_credential_data,
@@ -52,6 +57,9 @@ def list_credentials(
     """List credentials visible to the caller."""
     state = _state(ctx)
     credentials = list_credentials_data(state.client, workflow_id=workflow_id)
+    if not state.human:
+        print_markdown_table(credentials)
+        return
     rows = [
         [
             item.get("id"),
@@ -103,6 +111,9 @@ def create_credential(
         scopes=scopes,
         kind=kind,
     )
+    if not state.human:
+        print_json(response)
+        return
     render_json(state.console, response, title="Credential created")
 
 
@@ -118,6 +129,9 @@ def delete_credential(
 ) -> None:
     """Delete a credential from the vault."""
     state = _state(ctx)
+    if not state.human and not force:
+        print_json({"error": "Use --force to confirm deletion in machine mode."})
+        raise typer.Exit(code=1)
     if not force:
         typer.confirm(
             "Are you sure you want to delete this credential?",
@@ -128,6 +142,9 @@ def delete_credential(
         credential_id,
         workflow_id=workflow_id,
     )
+    if not state.human:
+        print_json(result)
+        return
     state.console.print(result.get("message", "Credential deleted."))
 
 
@@ -145,6 +162,11 @@ def update_credential(
 ) -> None:
     """Update credential metadata when supported by the backend."""
     state = _state(ctx)
+    if not state.human:
+        print_json(
+            {"error": "Credential updates are not yet supported by the backend API."}
+        )
+        raise typer.Exit(code=0)
     state.console.print(
         "Credential updates are not yet supported by the backend API. "
         "Rotate credentials via templates or recreate them."

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -185,6 +185,7 @@ def _print_cli_error_machine(exc: CLIError) -> None:
 def run() -> None:
     """Entry point used by console scripts."""
     human_mode = bool(os.getenv("ORCHEO_HUMAN")) or "--human" in sys.argv
+    original_rich_markup = app.rich_markup_mode
     if not human_mode:
         app.rich_markup_mode = None
     console = Console()
@@ -210,3 +211,5 @@ def run() -> None:
         else:
             _print_cli_error_machine(exc)
         sys.exit(1)
+    finally:
+        app.rich_markup_mode = original_rich_markup

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -5,6 +5,8 @@ import os
 import sys
 from collections.abc import Callable
 from datetime import timedelta
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from typing import Annotated
 import click
 import typer
@@ -31,6 +33,18 @@ def _is_completion_mode() -> bool:
         env_var.startswith("_TYPER_COMPLETE") or env_var.startswith("_ORCHEO_COMPLETE")
         for env_var in os.environ
     )
+
+
+def _version_callback(value: bool) -> None:
+    """Print CLI version and exit."""
+    if not value:
+        return
+    try:
+        version_value = package_version("orcheo-sdk")
+    except PackageNotFoundError:
+        version_value = "unknown"
+    typer.echo(f"orcheo {version_value}")
+    raise typer.Exit()
 
 
 app = typer.Typer(help="Command line interface for Orcheo workflows.")
@@ -63,6 +77,15 @@ def main(
         str | None,
         typer.Option("--profile", help="Profile name from the CLI config."),
     ] = None,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Show the Orcheo CLI version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = False,
     api_url: Annotated[
         str | None,
         typer.Option("--api-url", help="Override the API URL."),

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -27,6 +27,9 @@ from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.cli.workflow import workflow_app
 
 
+PACKAGE_NAME = "orcheo-sdk"
+
+
 def _is_completion_mode() -> bool:
     """Check if we're in shell completion mode."""
     return any(
@@ -50,7 +53,7 @@ def _version_callback(value: bool) -> None:
     if not value:
         return
     try:
-        version_value = package_version("orcheo-sdk")
+        version_value = package_version(PACKAGE_NAME)
     except PackageNotFoundError:
         version_value = "unknown"
     typer.echo(f"orcheo {version_value}")
@@ -116,7 +119,7 @@ def main(
         bool,
         typer.Option(
             "--human",
-            help="Use human-friendly Rich output instead of machine-readable format.",
+            help="Use human-friendly Rich output instead of machine-readable JSON.",
         ),
     ] = False,
 ) -> None:

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from datetime import timedelta
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
-from typing import Annotated
+from typing import Annotated, Any
 import click
 import typer
 from rich.console import Console
@@ -102,13 +102,21 @@ def main(
         int,
         typer.Option("--cache-ttl", help="Cache TTL in hours for offline data."),
     ] = 24,
+    human: Annotated[
+        bool,
+        typer.Option(
+            "--human",
+            help="Use human-friendly Rich output instead of machine-readable format.",
+        ),
+    ] = False,
 ) -> None:
     """Configure shared CLI state and validate configuration."""
     # Skip expensive initialization during shell completion
     if _is_completion_mode():
         return  # pragma: no cover
 
-    console = Console()
+    resolved_human = human or bool(os.getenv("ORCHEO_HUMAN"))
+    console = Console() if resolved_human else Console(no_color=True, highlight=False)
     try:
         settings = resolve_settings(
             profile=profile,
@@ -130,7 +138,13 @@ def main(
         public_base_url=settings.chatkit_public_base_url,
         token_provider=_create_token_provider(settings.profile),
     )
-    ctx.obj = CLIState(settings=settings, client=client, cache=cache, console=console)
+    ctx.obj = CLIState(
+        settings=settings,
+        client=client,
+        cache=cache,
+        console=console,
+        human=resolved_human,
+    )
 
 
 def _print_cli_error(console: Console, exc: CLIError) -> None:
@@ -158,17 +172,41 @@ def _print_cli_error(console: Console, exc: CLIError) -> None:
     console.print(f"[red]Error:[/red] {error_msg}")
 
 
+def _print_cli_error_machine(exc: CLIError) -> None:
+    """Print a machine-readable error as JSON."""
+    from orcheo_sdk.cli.output import print_json
+
+    error_data: dict[str, Any] = {"error": str(exc)}
+    if isinstance(exc, APICallError) and exc.status_code is not None:
+        error_data["status_code"] = exc.status_code
+    print_json(error_data)
+
+
 def run() -> None:
     """Entry point used by console scripts."""
+    human_mode = bool(os.getenv("ORCHEO_HUMAN")) or "--human" in sys.argv
+    if not human_mode:
+        app.rich_markup_mode = None
     console = Console()
     try:
         app(standalone_mode=False)
     except click.UsageError as exc:
-        console.print(f"[red]Error:[/red] {exc.message}")
-        if exc.ctx and exc.ctx.command_path:
-            help_cmd = f"{exc.ctx.command_path} --help"
-            console.print(f"\nRun '[cyan]{help_cmd}[/cyan]' for usage information.")
+        if human_mode:
+            console.print(f"[red]Error:[/red] {exc.message}")
+            if exc.ctx and exc.ctx.command_path:
+                help_cmd = f"{exc.ctx.command_path} --help"
+                console.print(f"\nRun '[cyan]{help_cmd}[/cyan]' for usage information.")
+        else:
+            from orcheo_sdk.cli.output import print_json
+
+            error_data: dict[str, Any] = {"error": exc.message}
+            if exc.ctx and exc.ctx.command_path:
+                error_data["help"] = f"{exc.ctx.command_path} --help"
+            print_json(error_data)
         sys.exit(1)
     except CLIError as exc:
-        _print_cli_error(console, exc)
+        if human_mode:
+            _print_cli_error(console, exc)
+        else:
+            _print_cli_error_machine(exc)
         sys.exit(1)

--- a/packages/sdk/src/orcheo_sdk/cli/node.py
+++ b/packages/sdk/src/orcheo_sdk/cli/node.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 from typing import Annotated
 import typer
-from rich.console import Console
-from orcheo_sdk.cli.output import render_json, render_table
+from orcheo_sdk.cli.output import (
+    print_json,
+    print_markdown_table,
+    render_json,
+    render_table,
+)
 from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.services import list_nodes_data, show_node_data
 
@@ -21,16 +25,18 @@ NameArgument = Annotated[
 ]
 
 
-def _get_console(ctx: typer.Context) -> Console:
-    state: CLIState = ctx.ensure_object(CLIState)
-    return state.console
+def _state(ctx: typer.Context) -> CLIState:
+    return ctx.ensure_object(CLIState)
 
 
 @node_app.command("list")
 def list_nodes(ctx: typer.Context, tag: TagOption = None) -> None:
     """List registered nodes with metadata."""
-    console = _get_console(ctx)
+    state = _state(ctx)
     nodes = list_nodes_data(tag=tag)
+    if not state.human:
+        print_markdown_table(nodes)
+        return
     rows = [
         [
             item.get("name"),
@@ -40,7 +46,7 @@ def list_nodes(ctx: typer.Context, tag: TagOption = None) -> None:
         for item in nodes
     ]
     render_table(
-        console,
+        state.console,
         title="Available Nodes",
         columns=["Name", "Category", "Description"],
         rows=rows,
@@ -50,19 +56,22 @@ def list_nodes(ctx: typer.Context, tag: TagOption = None) -> None:
 @node_app.command("show")
 def show_node(ctx: typer.Context, name: NameArgument) -> None:
     """Display metadata and schema information for ``name``."""
-    console = _get_console(ctx)
+    state = _state(ctx)
     data = show_node_data(name)
+    if not state.human:
+        print_json(data)
+        return
 
-    console.print(f"[bold]{data['name']}[/bold] ({data['category']})")
-    console.print(data["description"])
+    state.console.print(f"[bold]{data['name']}[/bold] ({data['category']})")
+    state.console.print(data["description"])
 
     schema = data.get("schema")
     if schema is not None:
-        render_json(console, schema, title="Pydantic schema")
+        render_json(state.console, schema, title="Pydantic schema")
         return
 
     attributes = data.get("attributes")
     if attributes:
-        render_json(console, {"attributes": attributes})
+        render_json(state.console, {"attributes": attributes})
     else:  # pragma: no cover - fallback when neither schema nor attributes present
-        console.print("\n[dim]No schema information available[/dim]")
+        state.console.print("\n[dim]No schema information available[/dim]")

--- a/packages/sdk/src/orcheo_sdk/cli/output.py
+++ b/packages/sdk/src/orcheo_sdk/cli/output.py
@@ -88,8 +88,3 @@ def print_json(data: Any) -> None:
 def machine_success(message: str) -> None:
     """Print a success message as JSON for machine consumption."""
     print_json({"status": "success", "message": message})
-
-
-def machine_warning(message: str) -> None:
-    """Print a warning message as JSON for machine consumption."""
-    print_json({"status": "warning", "message": message})

--- a/packages/sdk/src/orcheo_sdk/cli/output.py
+++ b/packages/sdk/src/orcheo_sdk/cli/output.py
@@ -85,6 +85,6 @@ def print_json(data: Any) -> None:
     print(json.dumps(data, indent=2, default=str))
 
 
-def machine_success(message: str) -> None:
+def print_machine_success(message: str) -> None:
     """Print a success message as JSON for machine consumption."""
     print_json({"status": "success", "message": message})

--- a/packages/sdk/src/orcheo_sdk/cli/output.py
+++ b/packages/sdk/src/orcheo_sdk/cli/output.py
@@ -1,6 +1,7 @@
 """Output helpers for rendering data in the CLI."""
 
 from __future__ import annotations
+import json
 from datetime import datetime
 from typing import Any, Literal
 from rich.console import Console
@@ -57,3 +58,38 @@ def warning(message: str) -> None:
     """Print a warning message."""
     console = Console()
     console.print(f"[yellow]⚠ {message}[/yellow]")
+
+
+def _escape_md_cell(value: str) -> str:
+    """Escape pipe characters in a Markdown table cell."""
+    return value.replace("|", "\\|")
+
+
+def print_markdown_table(data: list[dict[str, Any]]) -> None:
+    """Render a list of dicts as a Markdown table to stdout."""
+    if not data:
+        print("(empty)")
+        return
+    keys = list(data[0].keys())
+    header = "| " + " | ".join(keys) + " |"
+    separator = "| " + " | ".join("---" for _ in keys) + " |"
+    rows: list[str] = []
+    for item in data:
+        cells = [_escape_md_cell(str(item.get(k, ""))) for k in keys]
+        rows.append("| " + " | ".join(cells) + " |")
+    print("\n".join([header, separator, *rows]))
+
+
+def print_json(data: Any) -> None:
+    """Print data as indented JSON to stdout."""
+    print(json.dumps(data, indent=2, default=str))
+
+
+def machine_success(message: str) -> None:
+    """Print a success message as JSON for machine consumption."""
+    print_json({"status": "success", "message": message})
+
+
+def machine_warning(message: str) -> None:
+    """Print a warning message as JSON for machine consumption."""
+    print_json({"status": "warning", "message": message})

--- a/packages/sdk/src/orcheo_sdk/cli/service_token.py
+++ b/packages/sdk/src/orcheo_sdk/cli/service_token.py
@@ -6,8 +6,8 @@ import typer
 from rich.table import Table
 from orcheo_sdk.cli.output import (
     format_datetime,
-    machine_success,
     print_json,
+    print_machine_success,
     print_markdown_table,
     success,
     warning,
@@ -266,7 +266,7 @@ def revoke_token(
     revoke_service_token_data(state.client, token_id, reason)
 
     if not state.human:
-        machine_success(f"Service token '{token_id}' revoked successfully")
+        print_machine_success(f"Service token '{token_id}' revoked successfully")
         return
 
     success(f"Service token '{token_id}' revoked successfully")

--- a/packages/sdk/src/orcheo_sdk/cli/service_token.py
+++ b/packages/sdk/src/orcheo_sdk/cli/service_token.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 from typing import Annotated
 import typer
 from rich.table import Table
-from orcheo_sdk.cli.output import format_datetime, success, warning
+from orcheo_sdk.cli.output import (
+    format_datetime,
+    machine_success,
+    print_json,
+    print_markdown_table,
+    success,
+    warning,
+)
 from orcheo_sdk.cli.state import CLIState
 from orcheo_sdk.services.service_tokens import (
     create_service_token_data,
@@ -66,6 +73,10 @@ def create_token(
         expires_in_seconds=expires_in,
     )
 
+    if not state.human:
+        print_json(data)
+        return
+
     state.console.print()
     state.console.print(
         "[bold green]Service token created successfully![/]",
@@ -97,6 +108,10 @@ def list_tokens(ctx: typer.Context) -> None:
     data = list_service_tokens_data(state.client)
 
     tokens = data.get("tokens", [])
+
+    if not state.human:
+        print_markdown_table(tokens)
+        return
 
     table = Table(title=f"Service Tokens ({data['total']} total)")
     table.add_column("ID", style="cyan")
@@ -144,6 +159,10 @@ def show_token(
     state = _state(ctx)
 
     data = show_service_token_data(state.client, token_id)
+
+    if not state.human:
+        print_json(data)
+        return
 
     state.console.print()
     state.console.print(f"[bold]Service Token: {data['identifier']}[/]")
@@ -215,6 +234,10 @@ def rotate_token(
         expires_in_seconds=expires_in,
     )
 
+    if not state.human:
+        print_json(data)
+        return
+
     state.console.print()
     state.console.print("[bold green]Token rotated successfully![/]", style="green")
     state.console.print()
@@ -241,6 +264,10 @@ def revoke_token(
     state = _state(ctx)
 
     revoke_service_token_data(state.client, token_id, reason)
+
+    if not state.human:
+        machine_success(f"Service token '{token_id}' revoked successfully")
+        return
 
     success(f"Service token '{token_id}' revoked successfully")
     state.console.print(f"[dim]Reason: {reason}[/]")

--- a/packages/sdk/src/orcheo_sdk/cli/state.py
+++ b/packages/sdk/src/orcheo_sdk/cli/state.py
@@ -17,3 +17,4 @@ class CLIState:
     cache: CacheManager
     console: Console
     verbose_results: bool = False
+    human: bool = False

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/listing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/listing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import typer
-from orcheo_sdk.cli.output import format_datetime, render_table
+from orcheo_sdk.cli.output import format_datetime, print_markdown_table, render_table
 from orcheo_sdk.cli.utils import load_with_cache
 from orcheo_sdk.cli.workflow.app import _state, workflow_app
 from orcheo_sdk.cli.workflow.inputs import _cache_notice
@@ -27,6 +27,9 @@ def list_workflows(
     )
     if from_cache:
         _cache_notice(state, "workflow catalog", stale)
+    if not state.human:
+        print_markdown_table(payload)
+        return
     rows = []
     for item in payload:
         published_at = item.get("published_at")

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
@@ -138,6 +138,9 @@ def download_workflow(
             require_file=True,
         )
         output_file.write_text(content, encoding="utf-8")
+        if not state.human:
+            print_json({"status": "success", "path": str(output_path)})
+            return
         state.console.print(f"[green]Workflow downloaded to '{output_path}'.[/green]")
     else:
         state.console.print(content)

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/publishing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/publishing.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from orcheo_sdk.cli.cache import CacheManager
 from orcheo_sdk.cli.config import CLISettings
 from orcheo_sdk.cli.errors import APICallError, CLIError
-from orcheo_sdk.cli.output import format_datetime
+from orcheo_sdk.cli.output import format_datetime, print_json
 from orcheo_sdk.cli.workflow.app import (
     ForceOption,
     WorkflowIdArgument,
@@ -136,6 +136,9 @@ def publish_workflow(
     state = _state(ctx)
     _require_online(state.settings)
 
+    if not state.human and not force:
+        print_json({"error": "Use --force to confirm publish in machine mode."})
+        raise typer.Exit(code=1)
     if not force:
         prompt = (
             f"Publish workflow '{workflow_id}' as public"
@@ -159,6 +162,10 @@ def publish_workflow(
     workflow = result["workflow"]
     _update_workflow_cache(state.cache, workflow)
 
+    if not state.human:
+        print_json(result)
+        return
+
     _print_publish_summary(
         state.console,
         workflow=workflow,
@@ -177,6 +184,9 @@ def unpublish_workflow(
     state = _state(ctx)
     _require_online(state.settings)
 
+    if not state.human and not force:
+        print_json({"error": "Use --force to confirm unpublish in machine mode."})
+        raise typer.Exit(code=1)
     if not force:
         prompt = f"Unpublish workflow '{workflow_id}'? This revokes public access."
         typer.confirm(prompt, abort=True)
@@ -192,6 +202,10 @@ def unpublish_workflow(
 
     workflow = result["workflow"]
     _update_workflow_cache(state.cache, workflow)
+
+    if not state.human:
+        print_json(result)
+        return
 
     _print_publish_summary(
         state.console,

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/running.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import typer
 from orcheo_sdk.cli.errors import CLIError
-from orcheo_sdk.cli.output import render_json
+from orcheo_sdk.cli.output import print_json, render_json
 from orcheo_sdk.cli.workflow.app import (
     ActorOption,
     EvaluationFileOption,
@@ -83,6 +83,9 @@ def run_workflow(
         triggered_by=triggered_by,
         runnable_config=runnable_config,
     )
+    if not state.human:
+        print_json(result)
+        return
     render_json(state.console, result, title="Run created")
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/scheduling.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/scheduling.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import typer
 from orcheo_sdk.cli.errors import CLIError
-from orcheo_sdk.cli.output import render_json
+from orcheo_sdk.cli.output import print_json, render_json
 from orcheo_sdk.cli.workflow.app import WorkflowIdArgument, _state, workflow_app
 from orcheo_sdk.services import schedule_workflow_cron, unschedule_workflow_cron
 
@@ -19,6 +19,9 @@ def schedule_workflow(
         raise CLIError("Scheduling workflows requires network connectivity.")
 
     result = schedule_workflow_cron(state.client, workflow_id)
+    if not state.human:
+        print_json(result)
+        return
     status = result.get("status")
     if status == "noop":
         state.console.print(f"[yellow]{result['message']}[/yellow]")
@@ -39,6 +42,9 @@ def unschedule_workflow(
         raise CLIError("Unscheduling workflows requires network connectivity.")
 
     result = unschedule_workflow_cron(state.client, workflow_id)
+    if not state.human:
+        print_json(result)
+        return
     state.console.print(f"[green]{result['message']}[/green]")
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/showing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/showing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Annotated
 import typer
-from orcheo_sdk.cli.output import format_datetime, render_json, render_table
+from orcheo_sdk.cli.output import format_datetime, print_json, render_json, render_table
 from orcheo_sdk.cli.utils import load_with_cache
 from orcheo_sdk.cli.workflow.app import WorkflowIdArgument, _state, workflow_app
 from orcheo_sdk.cli.workflow.inputs import _cache_notice
@@ -56,6 +56,10 @@ def show_workflow(
         runs=runs,
         target_version=version,
     )
+
+    if not state.human:
+        print_json(data)
+        return
 
     workflow_details = data["workflow"]
     selected_version = data.get("selected_version")

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/inputs.py
@@ -133,6 +133,8 @@ def _resolve_evaluation_payload(
 
 def _cache_notice(state: CLIState, subject: str, stale: bool) -> None:
     """Display cache usage notice in the console."""
+    if not state.human:
+        return
     note = "[yellow]Using cached data[/yellow]"
     if stale:
         note += " (older than TTL)"

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -30,6 +30,24 @@ def env(tmp_path: Path) -> dict[str, str]:
 
 
 @pytest.fixture()
+def machine_env(tmp_path: Path) -> dict[str, str]:
+    """Environment with ORCHEO_HUMAN unset — triggers machine (JSON) output."""
+    config_dir = tmp_path / "config"
+    cache_dir = tmp_path / "cache"
+    config_dir.mkdir()
+    cache_dir.mkdir()
+    return {
+        "ORCHEO_API_URL": "http://api.test",
+        "ORCHEO_SERVICE_TOKEN": "token",
+        "ORCHEO_CONFIG_DIR": str(config_dir),
+        "ORCHEO_CACHE_DIR": str(cache_dir),
+        "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
+        "ORCHEO_HUMAN": "",
+        "NO_COLOR": "1",
+    }
+
+
+@pytest.fixture()
 def mock_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Set up mock environment variables for SDK tests."""
     config_dir = tmp_path / "config"

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -24,6 +24,7 @@ def env(tmp_path: Path) -> dict[str, str]:
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
         "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
+        "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
 
@@ -36,6 +37,7 @@ def mock_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
     monkeypatch.setenv("ORCHEO_API_URL", "http://api.test")
     monkeypatch.setenv("ORCHEO_SERVICE_TOKEN", "test-token")
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
     monkeypatch.delenv("ORCHEO_CHATKIT_PUBLIC_BASE_URL", raising=False)
 
 

--- a/tests/sdk/test_cli_auth_commands.py
+++ b/tests/sdk/test_cli_auth_commands.py
@@ -91,3 +91,72 @@ def test_auth_login_missing_config(
     # Error may be in output or exception
     error_text = result.output or str(result.exception)
     assert "OAuth not configured" in error_text
+
+
+def test_auth_logout_machine_output(
+    runner: CliRunner, auth_env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test logout in machine mode outputs JSON."""
+    import json
+
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", auth_env["ORCHEO_CONFIG_DIR"])
+    tokens = AuthTokens(access_token="oauth-token")
+    set_oauth_tokens(profile="default", tokens=tokens)
+
+    machine_env = {k: v for k, v in auth_env.items() if k != "ORCHEO_HUMAN"}
+    result = runner.invoke(app, ["auth", "logout"], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] == "success"
+    assert "Logged out" in data["message"]
+
+
+def test_auth_status_machine_not_authenticated(
+    runner: CliRunner, auth_env: dict[str, str]
+) -> None:
+    """Test auth status machine mode when not authenticated."""
+    import json
+
+    machine_env = {k: v for k, v in auth_env.items() if k != "ORCHEO_HUMAN"}
+    result = runner.invoke(app, ["auth", "status"], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] == "not_authenticated"
+    assert "profile" in data
+
+
+def test_auth_status_machine_with_service_token(
+    runner: CliRunner, auth_env: dict[str, str]
+) -> None:
+    """Test auth status machine mode with service token."""
+    import json
+
+    machine_env = {k: v for k, v in auth_env.items() if k != "ORCHEO_HUMAN"} | {
+        "ORCHEO_SERVICE_TOKEN": "svc-token-12345678"
+    }
+    result = runner.invoke(app, ["auth", "status"], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] == "authenticated"
+    assert data["method"] == "service_token"
+
+
+def test_auth_status_machine_with_oauth_token(
+    runner: CliRunner, auth_env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test auth status machine mode with valid OAuth token."""
+    import json
+
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", auth_env["ORCHEO_CONFIG_DIR"])
+
+    future = int(time.time() * 1000) + 3600000
+    tokens = AuthTokens(access_token="oauth-access-token", expires_at=future)
+    set_oauth_tokens(profile="default", tokens=tokens)
+
+    machine_env = {k: v for k, v in auth_env.items() if k != "ORCHEO_HUMAN"}
+    result = runner.invoke(app, ["auth", "status"], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] == "authenticated"
+    assert data["method"] == "oauth"
+    assert "expires" in data

--- a/tests/sdk/test_cli_auth_commands.py
+++ b/tests/sdk/test_cli_auth_commands.py
@@ -24,6 +24,7 @@ def auth_env(tmp_path: Path) -> dict[str, str]:
         "ORCHEO_API_URL": "http://api.test",
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
+        "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
 

--- a/tests/sdk/test_cli_auth_config.py
+++ b/tests/sdk/test_cli_auth_config.py
@@ -154,3 +154,21 @@ def test_coerce_str_returns_none_for_non_string() -> None:
     assert _coerce_str(None) is None
     assert _coerce_str(["a"]) is None
     assert _coerce_str("hello") == "hello"
+
+
+def test_is_oauth_configured_invalid_toml_returns_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Invalid TOML should cause is_oauth_configured to return False."""
+    from orcheo_sdk.cli.config import CONFIG_FILENAME
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    config_file = config_dir / CONFIG_FILENAME
+    config_file.write_text("this is not valid toml [[[", encoding="utf-8")
+
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv(AUTH_ISSUER_ENV, raising=False)
+    monkeypatch.delenv(AUTH_CLIENT_ID_ENV, raising=False)
+
+    assert not is_oauth_configured()

--- a/tests/sdk/test_cli_auth_config.py
+++ b/tests/sdk/test_cli_auth_config.py
@@ -127,6 +127,67 @@ def test_get_oauth_config_from_profile_keys(
     assert config.organization == "org_profile"
 
 
+def test_get_oauth_config_from_profile_scopes_list(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from orcheo_sdk.cli.config import CONFIG_FILENAME
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    config_file = config_dir / CONFIG_FILENAME
+    config_file.write_text(
+        "\n".join(
+            [
+                "[profiles.default]",
+                'auth_issuer = "https://profile.example.com/"',
+                'auth_client_id = "profile-client"',
+                'auth_scopes = ["openid", "profile", "custom"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv(AUTH_ISSUER_ENV, raising=False)
+    monkeypatch.delenv(AUTH_CLIENT_ID_ENV, raising=False)
+    monkeypatch.delenv(AUTH_SCOPES_ENV, raising=False)
+
+    config = get_oauth_config()
+
+    assert config.scopes == "openid profile custom"
+
+
+def test_get_oauth_config_invalid_profile_scopes_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from orcheo_sdk.cli.config import CONFIG_FILENAME
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    config_file = config_dir / CONFIG_FILENAME
+    config_file.write_text(
+        "\n".join(
+            [
+                "[profiles.default]",
+                'auth_issuer = "https://profile.example.com/"',
+                'auth_client_id = "profile-client"',
+                'auth_scopes = ["openid", 123]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv(AUTH_ISSUER_ENV, raising=False)
+    monkeypatch.delenv(AUTH_CLIENT_ID_ENV, raising=False)
+    monkeypatch.delenv(AUTH_SCOPES_ENV, raising=False)
+
+    with pytest.raises(CLIConfigurationError, match="auth_scopes must be a string"):
+        get_oauth_config()
+
+
 def test_load_profile_invalid_toml(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_auth_config.py
+++ b/tests/sdk/test_cli_auth_config.py
@@ -217,6 +217,14 @@ def test_coerce_str_returns_none_for_non_string() -> None:
     assert _coerce_str("hello") == "hello"
 
 
+def test_coerce_scopes_unsupported_type() -> None:
+    """Test _coerce_scopes raises for unsupported type (not str/list/None)."""
+    from orcheo_sdk.cli.auth.config import _coerce_scopes
+
+    with pytest.raises(CLIConfigurationError, match="auth_scopes must be a string"):
+        _coerce_scopes(42)
+
+
 def test_is_oauth_configured_invalid_toml_returns_false(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_auth_oauth.py
+++ b/tests/sdk/test_cli_auth_oauth.py
@@ -290,7 +290,7 @@ def test_start_oauth_login_no_browser_success(
         token_endpoint="https://auth.example.com/token",
     )
 
-    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda: config)
+    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda **_: config)
     monkeypatch.setattr(oauth_module, "_load_discovery", lambda _: discovery)
     monkeypatch.setattr(
         oauth_module,
@@ -377,7 +377,7 @@ def test_start_oauth_login_error(monkeypatch: pytest.MonkeyPatch) -> None:
         token_endpoint="https://auth.example.com/token",
     )
 
-    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda: config)
+    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda **_: config)
     monkeypatch.setattr(oauth_module, "_load_discovery", lambda _: discovery)
     monkeypatch.setattr(
         oauth_module,
@@ -417,7 +417,7 @@ def test_start_oauth_login_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
         token_endpoint="https://auth.example.com/token",
     )
 
-    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda: config)
+    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda **_: config)
     monkeypatch.setattr(oauth_module, "_load_discovery", lambda _: discovery)
     monkeypatch.setattr(
         oauth_module,
@@ -462,7 +462,7 @@ def test_start_oauth_login_state_mismatch(
     )
     opened: dict[str, str] = {}
 
-    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda: config)
+    monkeypatch.setattr(oauth_module, "get_oauth_config", lambda **_: config)
     monkeypatch.setattr(oauth_module, "_load_discovery", lambda _: discovery)
     monkeypatch.setattr(
         oauth_module,

--- a/tests/sdk/test_cli_code_template.py
+++ b/tests/sdk/test_cli_code_template.py
@@ -142,3 +142,23 @@ def test_code_template_creates_parent_directories(
     assert output_file.parent.is_dir()
     content = output_file.read_text()
     assert "from langgraph.graph import END, START, StateGraph" in content
+
+
+def test_code_template_machine_output(
+    runner: CliRunner, env: dict[str, str], tmp_path: Path
+) -> None:
+    """Test template command in machine mode outputs JSON."""
+    import json
+
+    output_file = tmp_path / "machine_workflow.py"
+    machine_env = {k: v for k, v in env.items() if k != "ORCHEO_HUMAN"}
+    result = runner.invoke(
+        app,
+        ["code", "template", "--output", str(output_file)],
+        env=machine_env,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["status"] == "success"
+    assert str(output_file) in data["path"]
+    assert output_file.exists()

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -373,6 +373,106 @@ def test_config_command_invalid_toml(
     assert "Invalid TOML" in str(exc_info.value)
 
 
+def test_config_command_incomplete_oauth_issuer_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that providing auth_issuer without auth_client_id raises CLIError."""
+    from unittest.mock import MagicMock
+    from rich.console import Console
+    from typer import Context
+    from orcheo_sdk.cli.auth.config import (
+        AUTH_AUDIENCE_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_ISSUER_ENV,
+        AUTH_ORGANIZATION_ENV,
+        AUTH_SCOPES_ENV,
+    )
+    from orcheo_sdk.cli.config_command import configure
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ORCHEO_API_URL", "http://api.test")
+    for key in [
+        AUTH_ISSUER_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_SCOPES_ENV,
+        AUTH_AUDIENCE_ENV,
+        AUTH_ORGANIZATION_ENV,
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    mock_state = MagicMock()
+    mock_state.console = Console()
+    mock_ctx = MagicMock(spec=Context)
+    mock_ctx.ensure_object.return_value = mock_state
+
+    with pytest.raises(CLIError, match="auth_client_id"):
+        configure(
+            ctx=mock_ctx,
+            profile=None,
+            api_url="http://api.test",
+            service_token=None,
+            chatkit_public_base_url=None,
+            auth_issuer="https://auth.example.com",
+            auth_client_id=None,
+            auth_scopes=None,
+            auth_audience=None,
+            auth_organization=None,
+            env_file=None,
+        )
+
+
+def test_config_command_incomplete_oauth_client_id_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that providing auth_client_id without auth_issuer raises CLIError."""
+    from unittest.mock import MagicMock
+    from rich.console import Console
+    from typer import Context
+    from orcheo_sdk.cli.auth.config import (
+        AUTH_AUDIENCE_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_ISSUER_ENV,
+        AUTH_ORGANIZATION_ENV,
+        AUTH_SCOPES_ENV,
+    )
+    from orcheo_sdk.cli.config_command import configure
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("ORCHEO_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ORCHEO_API_URL", "http://api.test")
+    for key in [
+        AUTH_ISSUER_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_SCOPES_ENV,
+        AUTH_AUDIENCE_ENV,
+        AUTH_ORGANIZATION_ENV,
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    mock_state = MagicMock()
+    mock_state.console = Console()
+    mock_ctx = MagicMock(spec=Context)
+    mock_ctx.ensure_object.return_value = mock_state
+
+    with pytest.raises(CLIError, match="auth_issuer"):
+        configure(
+            ctx=mock_ctx,
+            profile=None,
+            api_url="http://api.test",
+            service_token=None,
+            chatkit_public_base_url=None,
+            auth_issuer=None,
+            auth_client_id="my-client",
+            auth_scopes=None,
+            auth_audience=None,
+            auth_organization=None,
+            env_file=None,
+        )
+
+
 def test_resolve_oauth_values_all_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cover false branches when no OAuth values resolve."""
     from orcheo_sdk.cli.auth.config import (

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -249,7 +249,13 @@ def test_config_command_falls_back_to_existing_profile_api_url(
 
     result = runner.invoke(
         app,
-        ["config", "--auth-issuer", "https://auth.example.com/"],
+        [
+            "config",
+            "--auth-issuer",
+            "https://auth.example.com/",
+            "--auth-client-id",
+            "test-client-id",
+        ],
         env=minimal_env,
     )
 
@@ -258,6 +264,7 @@ def test_config_command_falls_back_to_existing_profile_api_url(
     profile = data["profiles"]["default"]
     assert profile["api_url"] == "http://existing.test"
     assert profile["auth_issuer"] == "https://auth.example.com/"
+    assert profile["auth_client_id"] == "test-client-id"
 
 
 def test_config_command_preserves_api_url_per_profile(
@@ -298,6 +305,8 @@ def test_config_command_preserves_api_url_per_profile(
             "beta",
             "--auth-issuer",
             "https://auth.example.com/",
+            "--auth-client-id",
+            "test-client-id",
         ],
         env=minimal_env,
     )

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -290,3 +290,34 @@ def test_config_command_invalid_toml(
         )
 
     assert "Invalid TOML" in str(exc_info.value)
+
+
+def test_resolve_oauth_values_all_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cover false branches when no OAuth values resolve."""
+    from orcheo_sdk.cli.auth.config import (
+        AUTH_AUDIENCE_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_ISSUER_ENV,
+        AUTH_ORGANIZATION_ENV,
+        AUTH_SCOPES_ENV,
+    )
+    from orcheo_sdk.cli.config_command import _resolve_oauth_values
+
+    for key in [
+        AUTH_ISSUER_ENV,
+        AUTH_CLIENT_ID_ENV,
+        AUTH_SCOPES_ENV,
+        AUTH_AUDIENCE_ENV,
+        AUTH_ORGANIZATION_ENV,
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    result = _resolve_oauth_values(
+        env_data=None,
+        auth_issuer=None,
+        auth_client_id=None,
+        auth_scopes=None,
+        auth_audience=None,
+        auth_organization=None,
+    )
+    assert result == {}

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -25,6 +25,11 @@ def test_config_command_writes_profiles_from_env_file(
                 "ORCHEO_API_URL=http://env-file.test",
                 "ORCHEO_SERVICE_TOKEN=env-token",
                 "ORCHEO_CHATKIT_PUBLIC_BASE_URL=http://canvas.test",
+                "ORCHEO_AUTH_ISSUER=https://auth.env-file.test",
+                "ORCHEO_AUTH_CLIENT_ID=env-client-id",
+                "ORCHEO_AUTH_SCOPES=openid email",
+                "ORCHEO_AUTH_AUDIENCE=https://api.env-file.test",
+                "ORCHEO_AUTH_ORGANIZATION=org-env",
             ]
         ),
         encoding="utf-8",
@@ -47,6 +52,11 @@ def test_config_command_writes_profiles_from_env_file(
         assert profile["api_url"] == "http://env-file.test"
         assert profile["service_token"] == "env-token"
         assert profile["chatkit_public_base_url"] == "http://canvas.test"
+        assert profile["ORCHEO_AUTH_ISSUER"] == "https://auth.env-file.test"
+        assert profile["ORCHEO_AUTH_CLIENT_ID"] == "env-client-id"
+        assert profile["ORCHEO_AUTH_SCOPES"] == "openid email"
+        assert profile["ORCHEO_AUTH_AUDIENCE"] == "https://api.env-file.test"
+        assert profile["ORCHEO_AUTH_ORGANIZATION"] == "org-env"
 
 
 def test_config_command_uses_environment_defaults(
@@ -223,6 +233,7 @@ def test_config_command_missing_api_url(runner: CliRunner, tmp_path: Path) -> No
     config_dir.mkdir()
     minimal_env = {
         "ORCHEO_CONFIG_DIR": str(config_dir),
+        "ORCHEO_API_URL": "",
         "NO_COLOR": "1",
     }
 

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -84,6 +84,7 @@ def test_config_command_without_service_token(
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(tmp_path / "cache"),
         "ORCHEO_API_URL": "http://api.test",
+        "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
 
@@ -234,6 +235,7 @@ def test_config_command_missing_api_url(runner: CliRunner, tmp_path: Path) -> No
     minimal_env = {
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_API_URL": "",
+        "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
 

--- a/tests/sdk/test_cli_credentials.py
+++ b/tests/sdk/test_cli_credentials.py
@@ -139,3 +139,90 @@ def test_credential_delete_without_force_prompts(
         )
     # Typer.confirm with abort=True will exit with code 1 when user says no
     assert result.exit_code == 1
+
+
+def test_credential_list_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode outputs markdown table for credential list."""
+    credentials = [{"id": "cred-1", "name": "Canvas", "provider": "api"}]
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/credentials").mock(
+            return_value=httpx.Response(200, json=credentials)
+        )
+        result = runner.invoke(app, ["credential", "list"], env=machine_env)
+    assert result.exit_code == 0
+    assert "| id |" in result.stdout or "cred-1" in result.stdout
+
+
+def test_credential_create_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode outputs JSON for credential create."""
+    created = {"id": "cred-1", "name": "Canvas", "provider": "api"}
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/credentials").mock(
+            return_value=httpx.Response(201, json=created)
+        )
+        result = runner.invoke(
+            app,
+            [
+                "credential",
+                "create",
+                "Canvas",
+                "--provider",
+                "api",
+                "--secret",
+                "secret",
+            ],
+            env=machine_env,
+        )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["id"] == "cred-1"
+
+
+def test_credential_delete_machine_no_force(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode without --force prints error JSON and exits 1."""
+    result = runner.invoke(
+        app,
+        ["credential", "delete", "cred-1"],
+        env=machine_env,
+    )
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert "error" in data
+    assert "--force" in data["error"]
+
+
+def test_credential_delete_machine_with_force(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode with --force outputs JSON result."""
+    with respx.mock(assert_all_called=True) as router:
+        router.delete("http://api.test/api/credentials/cred-1").mock(
+            return_value=httpx.Response(204)
+        )
+        result = runner.invoke(
+            app,
+            ["credential", "delete", "cred-1", "--force"],
+            env=machine_env,
+        )
+    assert result.exit_code == 0
+
+
+def test_credential_update_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode prints unsupported JSON for update."""
+    result = runner.invoke(
+        app,
+        ["credential", "update", "cred-1", "--secret", "new"],
+        env=machine_env,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert "error" in data
+    assert "not yet supported" in data["error"]

--- a/tests/sdk/test_cli_credentials.py
+++ b/tests/sdk/test_cli_credentials.py
@@ -222,7 +222,7 @@ def test_credential_update_machine_mode(
         ["credential", "update", "cred-1", "--secret", "new"],
         env=machine_env,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     data = json.loads(result.stdout)
     assert "error" in data
     assert "not yet supported" in data["error"]

--- a/tests/sdk/test_cli_edge.py
+++ b/tests/sdk/test_cli_edge.py
@@ -102,6 +102,16 @@ def test_edge_show_with_attributes_only(runner: CliRunner, env: dict[str, str]) 
         edge_registry._metadata.pop("TestEdgeWithAttrs", None)
 
 
+def test_edge_show_machine_mode(runner: CliRunner, machine_env: dict[str, str]) -> None:
+    """Machine mode outputs JSON for edge show."""
+    import json
+
+    result = runner.invoke(app, ["edge", "show", "IfElse"], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "IfElse"
+
+
 def test_edge_show_with_schema(runner: CliRunner, env: dict[str, str]) -> None:
     """Test edge show with edge that has a Pydantic schema."""
     from pydantic import BaseModel

--- a/tests/sdk/test_cli_machine_output.py
+++ b/tests/sdk/test_cli_machine_output.py
@@ -11,8 +11,8 @@ from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.main import app, run
 from orcheo_sdk.cli.output import (
     _escape_md_cell,
-    machine_success,
     print_json,
+    print_machine_success,
     print_markdown_table,
 )
 
@@ -76,9 +76,9 @@ class TestEscapeMdCell:
         assert _escape_md_cell("a|b") == "a\\|b"
 
 
-class TestMachineSuccess:
+class TestPrintMachineSuccess:
     def test_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        machine_success("Done")
+        print_machine_success("Done")
         out = capsys.readouterr().out
         parsed = json.loads(out)
         assert parsed == {"status": "success", "message": "Done"}

--- a/tests/sdk/test_cli_machine_output.py
+++ b/tests/sdk/test_cli_machine_output.py
@@ -1,0 +1,328 @@
+"""Tests for machine-readable CLI output (default mode without --human)."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+from orcheo_sdk.cli.errors import CLIError
+from orcheo_sdk.cli.main import app, run
+from orcheo_sdk.cli.output import (
+    _escape_md_cell,
+    machine_success,
+    machine_warning,
+    print_json,
+    print_markdown_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper output functions
+# ---------------------------------------------------------------------------
+
+
+class TestPrintJson:
+    def test_dict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_json({"a": 1, "b": "two"})
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed == {"a": 1, "b": "two"}
+
+    def test_list(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_json([1, 2, 3])
+        out = capsys.readouterr().out
+        assert json.loads(out) == [1, 2, 3]
+
+    def test_default_serializer(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-serializable values fall back to str()."""
+        print_json({"path": Path("/tmp/test")})
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["path"] == "/tmp/test"
+
+
+class TestPrintMarkdownTable:
+    def test_basic_table(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = [
+            {"name": "Alice", "age": "30"},
+            {"name": "Bob", "age": "25"},
+        ]
+        print_markdown_table(data)
+        out = capsys.readouterr().out
+        lines = out.strip().split("\n")
+        assert len(lines) == 4  # header + separator + 2 rows
+        assert "| name | age |" == lines[0]
+        assert "| --- | --- |" == lines[1]
+        assert "| Alice | 30 |" == lines[2]
+        assert "| Bob | 25 |" == lines[3]
+
+    def test_empty_list(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_markdown_table([])
+        assert capsys.readouterr().out.strip() == "(empty)"
+
+    def test_pipe_escaping(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = [{"val": "a|b"}]
+        print_markdown_table(data)
+        out = capsys.readouterr().out
+        assert "a\\|b" in out
+
+
+class TestEscapeMdCell:
+    def test_no_pipe(self) -> None:
+        assert _escape_md_cell("hello") == "hello"
+
+    def test_pipe(self) -> None:
+        assert _escape_md_cell("a|b") == "a\\|b"
+
+
+class TestMachineSuccess:
+    def test_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        machine_success("Done")
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed == {"status": "success", "message": "Done"}
+
+
+class TestMachineWarning:
+    def test_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        machine_warning("Careful")
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed == {"status": "warning", "message": "Careful"}
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: machine mode (no ORCHEO_HUMAN)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def machine_env(tmp_path: Path) -> dict[str, str]:
+    """Environment without ORCHEO_HUMAN — triggers machine output."""
+    config_dir = tmp_path / "config"
+    cache_dir = tmp_path / "cache"
+    config_dir.mkdir()
+    cache_dir.mkdir()
+    return {
+        "ORCHEO_API_URL": "http://api.test",
+        "ORCHEO_SERVICE_TOKEN": "token",
+        "ORCHEO_CONFIG_DIR": str(config_dir),
+        "ORCHEO_CACHE_DIR": str(cache_dir),
+        "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
+        "NO_COLOR": "1",
+    }
+
+
+class TestNodeListMachineMode:
+    def test_outputs_markdown_table(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        result = runner.invoke(app, ["node", "list"], env=machine_env)
+        assert result.exit_code == 0
+        lines = result.stdout.strip().split("\n")
+        # Should be markdown table or (empty)
+        assert "|" in lines[0] or lines[0] == "(empty)"
+
+    def test_human_flag_outputs_rich(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        result = runner.invoke(app, ["--human", "node", "list"], env=machine_env)
+        assert result.exit_code == 0
+        # Rich table output has "Available Nodes" title
+        assert "Available Nodes" in result.stdout
+
+
+class TestNodeShowMachineMode:
+    def test_outputs_json(self, runner: CliRunner, machine_env: dict[str, str]) -> None:
+        result = runner.invoke(app, ["node", "show", "AgentNode"], env=machine_env)
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "name" in data
+        assert data["name"] == "AgentNode"
+
+
+class TestWorkflowListMachineMode:
+    def test_outputs_markdown_table(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        payload = [{"id": "wf-1", "name": "Demo", "slug": "demo", "is_archived": False}]
+        with respx.mock(assert_all_called=True) as router:
+            router.get("http://api.test/api/workflows").mock(
+                return_value=httpx.Response(200, json=payload)
+            )
+            router.get("http://api.test/api/workflows/wf-1/triggers/cron/config").mock(
+                return_value=httpx.Response(404)
+            )
+            result = runner.invoke(app, ["workflow", "list"], env=machine_env)
+        assert result.exit_code == 0
+        # Should be markdown table
+        assert "|" in result.stdout
+        assert "Demo" in result.stdout
+
+
+class TestWorkflowShowMachineMode:
+    def test_outputs_json(self, runner: CliRunner, machine_env: dict[str, str]) -> None:
+        wf = {"id": "wf-1", "name": "Demo", "slug": "demo"}
+        versions: list[dict[str, str]] = []
+        runs: list[dict[str, str]] = []
+        with respx.mock(assert_all_called=True) as router:
+            router.get("http://api.test/api/workflows/wf-1").mock(
+                return_value=httpx.Response(200, json=wf)
+            )
+            router.get("http://api.test/api/workflows/wf-1/versions").mock(
+                return_value=httpx.Response(200, json=versions)
+            )
+            router.get("http://api.test/api/workflows/wf-1/runs").mock(
+                return_value=httpx.Response(200, json=runs)
+            )
+            result = runner.invoke(app, ["workflow", "show", "wf-1"], env=machine_env)
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["workflow"]["name"] == "Demo"
+
+
+class TestConfigMachineMode:
+    def test_outputs_json(self, runner: CliRunner, machine_env: dict[str, str]) -> None:
+        result = runner.invoke(app, ["config"], env=machine_env)
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "success"
+        assert "profiles" in data
+        assert "config_path" in data
+
+
+class TestEdgeListMachineMode:
+    def test_outputs_markdown_table(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        result = runner.invoke(app, ["edge", "list"], env=machine_env)
+        assert result.exit_code == 0
+        lines = result.stdout.strip().split("\n")
+        assert "|" in lines[0] or lines[0] == "(empty)"
+
+
+class TestRunErrorMachineMode:
+    def test_cli_error_outputs_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """In machine mode, CLIError is output as JSON."""
+
+        def mock_app(*args: object, **kwargs: object) -> None:
+            raise CLIError("Something went wrong")
+
+        monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+        monkeypatch.delenv("ORCHEO_HUMAN", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run()
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["error"] == "Something went wrong"
+
+    def test_usage_error_outputs_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """In machine mode, UsageError is output as JSON."""
+        import click
+
+        def mock_app(*args: object, **kwargs: object) -> None:
+            cmd = click.Command("workflow")
+            parent_ctx = click.Context(click.Command("orcheo"), info_name="orcheo")
+            ctx = click.Context(cmd, parent=parent_ctx, info_name="workflow")
+            raise click.UsageError("Missing command.", ctx=ctx)
+
+        monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+        monkeypatch.delenv("ORCHEO_HUMAN", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run()
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["error"] == "Missing command."
+        assert "help" in data
+
+
+class TestHelpMachineMode:
+    def test_top_level_help_plain_text(
+        self,
+        runner: CliRunner,
+        machine_env: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Top-level --help in machine mode uses plain Click formatting."""
+        monkeypatch.setattr(app, "rich_markup_mode", None)
+        result = runner.invoke(app, ["--help"], env=machine_env)
+        assert result.exit_code == 0
+        # No Rich panel box-drawing characters
+        assert "\u2500" not in result.stdout  # ─
+        assert "\u2502" not in result.stdout  # │
+        assert "\u256d" not in result.stdout  # ╭
+        assert "\u256e" not in result.stdout  # ╮
+        # Still contains commands and options
+        assert "workflow" in result.stdout
+        assert "--help" in result.stdout
+
+    def test_subcommand_help_plain_text(
+        self,
+        runner: CliRunner,
+        machine_env: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Subcommand --help in machine mode uses plain Click formatting."""
+        monkeypatch.setattr(app, "rich_markup_mode", None)
+        result = runner.invoke(app, ["node", "--help"], env=machine_env)
+        assert result.exit_code == 0
+        assert "\u256d" not in result.stdout  # ╭
+        assert "list" in result.stdout
+        assert "show" in result.stdout
+
+    def test_human_help_has_rich_panels(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        """--help with ORCHEO_HUMAN shows Rich panels."""
+        human_env = {**machine_env, "ORCHEO_HUMAN": "1"}
+        result = runner.invoke(app, ["--help"], env=human_env)
+        assert result.exit_code == 0
+        # Rich panel has box-drawing characters
+        assert "\u2500" in result.stdout  # ─
+
+
+class TestHumanFlagAndEnv:
+    def test_human_env_var(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        """ORCHEO_HUMAN=1 activates human mode."""
+        human_env = {**machine_env, "ORCHEO_HUMAN": "1"}
+        result = runner.invoke(app, ["node", "list"], env=human_env)
+        assert result.exit_code == 0
+        assert "Available Nodes" in result.stdout
+
+    def test_human_flag(self, runner: CliRunner, machine_env: dict[str, str]) -> None:
+        """--human flag activates human mode."""
+        result = runner.invoke(app, ["--human", "node", "list"], env=machine_env)
+        assert result.exit_code == 0
+        assert "Available Nodes" in result.stdout
+
+    def test_default_is_machine(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        """Without --human or ORCHEO_HUMAN, output is machine-readable."""
+        result = runner.invoke(app, ["node", "list"], env=machine_env)
+        assert result.exit_code == 0
+        # Machine output should not contain Rich table title
+        assert "Available Nodes" not in result.stdout
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()

--- a/tests/sdk/test_cli_machine_output.py
+++ b/tests/sdk/test_cli_machine_output.py
@@ -12,7 +12,6 @@ from orcheo_sdk.cli.main import app, run
 from orcheo_sdk.cli.output import (
     _escape_md_cell,
     machine_success,
-    machine_warning,
     print_json,
     print_markdown_table,
 )
@@ -85,34 +84,9 @@ class TestMachineSuccess:
         assert parsed == {"status": "success", "message": "Done"}
 
 
-class TestMachineWarning:
-    def test_output(self, capsys: pytest.CaptureFixture[str]) -> None:
-        machine_warning("Careful")
-        out = capsys.readouterr().out
-        parsed = json.loads(out)
-        assert parsed == {"status": "warning", "message": "Careful"}
-
-
 # ---------------------------------------------------------------------------
 # CLI integration: machine mode (no ORCHEO_HUMAN)
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def machine_env(tmp_path: Path) -> dict[str, str]:
-    """Environment without ORCHEO_HUMAN — triggers machine output."""
-    config_dir = tmp_path / "config"
-    cache_dir = tmp_path / "cache"
-    config_dir.mkdir()
-    cache_dir.mkdir()
-    return {
-        "ORCHEO_API_URL": "http://api.test",
-        "ORCHEO_SERVICE_TOKEN": "token",
-        "ORCHEO_CONFIG_DIR": str(config_dir),
-        "ORCHEO_CACHE_DIR": str(cache_dir),
-        "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
-        "NO_COLOR": "1",
-    }
 
 
 class TestNodeListMachineMode:

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -30,7 +30,9 @@ def test_main_config_error_handling(
         router.get(
             "http://localhost:8000/api/workflows/wf-1/triggers/cron/config"
         ).mock(return_value=httpx.Response(404))
-        result = runner.invoke(app, ["workflow", "list"], env={"NO_COLOR": "1"})
+        result = runner.invoke(
+            app, ["workflow", "list"], env={"NO_COLOR": "1", "ORCHEO_HUMAN": "1"}
+        )
     assert result.exit_code == 0
     assert "Demo" in result.stdout
 
@@ -42,6 +44,7 @@ def test_run_cli_error_handling(
         raise CLIError("Test error")
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()
@@ -67,6 +70,7 @@ def test_run_usage_error_handling(
         raise click.UsageError("Missing command.", ctx=ctx)
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()
@@ -89,6 +93,7 @@ def test_run_usage_error_without_context(
         raise click.UsageError("Invalid option.")
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()
@@ -109,6 +114,7 @@ def test_run_authentication_error_401(
         raise APICallError("Invalid bearer token", status_code=401)
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()
@@ -129,6 +135,7 @@ def test_run_authentication_error_403(
         raise APICallError("Missing required scopes: workflows:write", status_code=403)
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()
@@ -149,6 +156,7 @@ def test_run_api_error_without_hint(
         raise APICallError("Server error", status_code=500)
 
     monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.setenv("ORCHEO_HUMAN", "1")
 
     with pytest.raises(SystemExit) as exc_info:
         run()

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import httpx
 import pytest
 import respx
+import typer
 from typer.testing import CliRunner
 from orcheo_sdk.cli.errors import APICallError, CLIError
 from orcheo_sdk.cli.main import app, run
@@ -165,3 +166,103 @@ def test_run_api_error_without_hint(
     captured = capsys.readouterr()
     assert "Error: Server error" in captured.out
     assert "Hint:" not in captured.out
+
+
+def test_version_callback(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test _version_callback prints version and raises Exit."""
+    from orcheo_sdk.cli.main import _version_callback
+
+    with pytest.raises(typer.Exit):
+        _version_callback(True)
+    captured = capsys.readouterr()
+    assert "orcheo " in captured.out
+
+
+def test_version_callback_false() -> None:
+    """Test _version_callback returns early when value is False."""
+    from orcheo_sdk.cli.main import _version_callback
+
+    _version_callback(False)  # Should return without raising
+
+
+def test_version_callback_package_not_found(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test _version_callback prints 'unknown' when package is not installed."""
+    from importlib.metadata import PackageNotFoundError
+    from orcheo_sdk.cli import main as main_mod
+    from orcheo_sdk.cli.main import _version_callback
+
+    def _raise(name: str) -> str:
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(main_mod, "package_version", _raise)
+
+    with pytest.raises(typer.Exit):
+        _version_callback(True)
+    captured = capsys.readouterr()
+    assert "orcheo unknown" in captured.out
+
+
+def test_print_cli_error_machine_with_status_code(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that machine error output includes status_code for APICallError."""
+    import json
+    from orcheo_sdk.cli.main import _print_cli_error_machine
+
+    exc = APICallError("Unauthorized", status_code=401)
+    _print_cli_error_machine(exc)
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["error"] == "Unauthorized"
+    assert data["status_code"] == 401
+
+
+def test_run_usage_error_machine_mode_with_context(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Machine mode UsageError with context includes help key."""
+    import json
+    import click
+
+    def mock_app(*args: object, **kwargs: object) -> None:
+        cmd = click.Command("workflow")
+        parent_ctx = click.Context(click.Command("orcheo"), info_name="orcheo")
+        ctx = click.Context(cmd, parent=parent_ctx, info_name="workflow")
+        raise click.UsageError("Bad arg.", ctx=ctx)
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.delenv("ORCHEO_HUMAN", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run()
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["error"] == "Bad arg."
+    assert "orcheo workflow --help" in data["help"]
+
+
+def test_run_usage_error_machine_mode_without_context(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Machine mode UsageError without context omits help key."""
+    import json
+    import click
+
+    def mock_app(*args: object, **kwargs: object) -> None:
+        raise click.UsageError("No ctx.")
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.app", mock_app)
+    monkeypatch.delenv("ORCHEO_HUMAN", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run()
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["error"] == "No ctx."
+    assert "help" not in data

--- a/tests/sdk/test_cli_service_token_create.py
+++ b/tests/sdk/test_cli_service_token_create.py
@@ -154,3 +154,26 @@ def test_token_create_with_all_options(runner: CliRunner, env: dict[str, str]) -
     assert "secret-123" in result.stdout
     assert "read:all" in result.stdout
     assert "ws-1" in result.stdout
+
+
+def test_token_create_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode outputs JSON for token create."""
+    import json
+
+    response_data = {
+        "identifier": "token-123",
+        "secret": "secret-abc-xyz",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/admin/service-tokens").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+        result = runner.invoke(app, ["token", "create"], env=machine_env)
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["identifier"] == "token-123"
+    assert data["secret"] == "secret-abc-xyz"

--- a/tests/sdk/test_cli_workflow_download_basic.py
+++ b/tests/sdk/test_cli_workflow_download_basic.py
@@ -40,6 +40,35 @@ def test_workflow_download_json_to_stdout(
     assert '"metadata"' in result.stdout
 
 
+def test_workflow_download_machine_mode_no_output_path(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """Machine mode download without --output prints raw JSON payload."""
+    workflow = {"id": "wf-1", "name": "Test", "metadata": {"key": "value"}}
+    versions = [
+        {
+            "id": "ver-1",
+            "version": 1,
+            "graph": {"nodes": [{"id": "a"}], "edges": []},
+        }
+    ]
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/workflows/wf-1").mock(
+            return_value=httpx.Response(200, json=workflow)
+        )
+        router.get("http://api.test/api/workflows/wf-1/versions").mock(
+            return_value=httpx.Response(200, json=versions)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "download", "wf-1"],
+            env=machine_env,
+        )
+    assert result.exit_code == 0
+    assert '"content"' in result.stdout
+
+
 def test_workflow_download_json_to_file(
     runner: CliRunner, env: dict[str, str], tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_workflow_download_basic.py
+++ b/tests/sdk/test_cli_workflow_download_basic.py
@@ -102,6 +102,39 @@ def test_workflow_download_json_to_file(
     assert content["name"] == "Test"
 
 
+def test_workflow_download_machine_mode_to_file(
+    runner: CliRunner, machine_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Machine mode download with --output prints success JSON."""
+    workflow = {"id": "wf-1", "name": "Test"}
+    versions = [
+        {
+            "id": "ver-1",
+            "version": 1,
+            "graph": {"nodes": [{"id": "a"}], "edges": []},
+        }
+    ]
+    output_file = tmp_path / "output.json"
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get("http://api.test/api/workflows/wf-1").mock(
+            return_value=httpx.Response(200, json=workflow)
+        )
+        router.get("http://api.test/api/workflows/wf-1/versions").mock(
+            return_value=httpx.Response(200, json=versions)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "download", "wf-1", "--output", str(output_file)],
+            env=machine_env,
+        )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["path"] == str(output_file)
+    assert output_file.exists()
+
+
 def test_workflow_download_python_to_stdout(
     runner: CliRunner, env: dict[str, str]
 ) -> None:

--- a/tests/sdk/test_cli_workflow_inputs.py
+++ b/tests/sdk/test_cli_workflow_inputs.py
@@ -1,0 +1,19 @@
+"""Tests for workflow input helpers."""
+
+from __future__ import annotations
+from orcheo_sdk.cli.workflow.inputs import _cache_notice
+from tests.sdk.workflow_cli_test_utils import make_state
+
+
+def test_cache_notice_human_mode() -> None:
+    state = make_state()
+    _cache_notice(state, "workflow wf-1", stale=False)
+    assert state.console.messages
+    assert "Using cached data" in state.console.messages[-1]
+
+
+def test_cache_notice_machine_mode() -> None:
+    state = make_state()
+    state.human = False
+    _cache_notice(state, "workflow wf-1", stale=False)
+    assert state.console.messages == []

--- a/tests/sdk/test_cli_workflow_scheduling.py
+++ b/tests/sdk/test_cli_workflow_scheduling.py
@@ -35,6 +35,7 @@ def _make_state(*, offline: bool = False) -> CLIState:
         client=SimpleNamespace(),
         cache=SimpleNamespace(),
         console=_FakeConsole(),
+        human=True,
     )
 
 

--- a/tests/sdk/test_cli_workflow_scheduling.py
+++ b/tests/sdk/test_cli_workflow_scheduling.py
@@ -130,3 +130,45 @@ def test_unschedule_workflow_prints_success(monkeypatch: pytest.MonkeyPatch) -> 
     scheduling.unschedule_workflow(ctx, "wf-123")
 
     assert state.console.messages == ["[green]Cron removed[/green]"]
+
+
+def test_schedule_workflow_machine_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Machine mode schedule prints raw JSON result."""
+
+    state = _make_state()
+    state.human = False
+    ctx = _context(state)
+
+    captured: list[object] = []
+    monkeypatch.setattr(
+        scheduling,
+        "schedule_workflow_cron",
+        lambda *_args, **_kwargs: {"status": "scheduled", "message": "OK"},
+    )
+    monkeypatch.setattr(scheduling, "print_json", lambda data: captured.append(data))
+
+    scheduling.schedule_workflow(ctx, "wf-123")
+
+    assert captured == [{"status": "scheduled", "message": "OK"}]
+    assert state.console.messages == []
+
+
+def test_unschedule_workflow_machine_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Machine mode unschedule prints raw JSON result."""
+
+    state = _make_state()
+    state.human = False
+    ctx = _context(state)
+
+    captured: list[object] = []
+    monkeypatch.setattr(
+        scheduling,
+        "unschedule_workflow_cron",
+        lambda *_args, **_kwargs: {"message": "Cron removed"},
+    )
+    monkeypatch.setattr(scheduling, "print_json", lambda data: captured.append(data))
+
+    scheduling.unschedule_workflow(ctx, "wf-123")
+
+    assert captured == [{"message": "Cron removed"}]
+    assert state.console.messages == []

--- a/tests/sdk/test_cli_workflow_upload_json.py
+++ b/tests/sdk/test_cli_workflow_upload_json.py
@@ -57,6 +57,31 @@ def test_workflow_upload_json_file_update_existing(
     assert "updated successfully" in result.stdout
 
 
+def test_workflow_upload_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Machine mode upload prints raw JSON result."""
+    json_file = tmp_path / "workflow.json"
+    json_file.write_text(
+        json.dumps({"name": "TestWorkflow", "graph": {"nodes": [], "edges": []}}),
+        encoding="utf-8",
+    )
+
+    created = {"id": "wf-new", "name": "TestWorkflow"}
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://api.test/api/workflows").mock(
+            return_value=httpx.Response(201, json=created)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "upload", str(json_file)],
+            env=machine_env,
+        )
+    assert result.exit_code == 0
+    assert '"id"' in result.stdout
+    assert '"wf-new"' in result.stdout
+
+
 def test_workflow_upload_json_file_with_runnable_config(
     runner: CliRunner, env: dict[str, str], tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_workflow_cli_inputs.py
+++ b/tests/sdk/test_workflow_cli_inputs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 import pytest
 from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.state import CLIState
@@ -171,14 +171,14 @@ def test_cache_notice_reports_staleness_flags() -> None:
         client=MagicMock(),
         cache=MagicMock(),
         console=console,
+        human=True,
     )
 
     _cache_notice(state, "workflow run", stale=False)
-    console.print.assert_called_with(
-        "[yellow]Using cached data[/yellow] for workflow run."
-    )
-
     _cache_notice(state, "evaluation", stale=True)
-    console.print.assert_called_with(
-        "[yellow]Using cached data[/yellow] (older than TTL) for evaluation."
+    console.print.assert_has_calls(
+        [
+            call("[yellow]Using cached data[/yellow] for workflow run."),
+            call("[yellow]Using cached data[/yellow] (older than TTL) for evaluation."),
+        ]
     )

--- a/tests/sdk/workflow_cli_test_utils.py
+++ b/tests/sdk/workflow_cli_test_utils.py
@@ -56,6 +56,7 @@ def make_state(*, verbose_results: bool = False) -> CLIState:
         cache=object(),
         console=StubConsole(),
         verbose_results=verbose_results,
+        human=True,
     )
 
 


### PR DESCRIPTION
## Summary

- Add `--version` flag to print the Orcheo CLI version and exit
- Support OAuth settings (`auth_issuer`, `auth_client_id`, `auth_scopes`, `auth_audience`, `auth_organization`) in CLI config profiles (`cli.toml`), with env-var fallback preserved
- Introduce machine-readable (JSON) output as the default display mode; add `--human` flag (and `ORCHEO_HUMAN` env var) to opt into Rich-formatted output
- Add `print_json`, `print_markdown_table`, and `machine_success` output helpers
- Extend `orcheo config` command with `--auth-issuer`, `--auth-client-id`, `--auth-scopes`, `--auth-audience`, and `--auth-organization` options
- Harden config reading: preserve existing profile values when updating, validate TOML before writing
- Reject Slack retry requests in `SlackEventsParserNode` to prevent duplicate event processing
- Significant test coverage improvements across CLI commands (auth, config, credentials, edge, node, service tokens, workflows, machine output)