### PR TITLE
Add vault credential support and fix demo API key references

### DIFF
--- a/examples/conversational_search/demo_3_hybrid_search/demo_3.py
+++ b/examples/conversational_search/demo_3_hybrid_search/demo_3.py
@@ -90,6 +90,7 @@ async def orcheo_workflow() -> StateGraph:
         embedding_method="{{config.configurable.dense_embedding_method}}",
         top_k="{{config.configurable.dense_top_k}}",
         score_threshold="{{config.configurable.dense_similarity_threshold}}",
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     sparse_search = SparseSearchNode(
         name="sparse_search",
@@ -98,6 +99,7 @@ async def orcheo_workflow() -> StateGraph:
         top_k="{{config.configurable.sparse_top_k}}",
         score_threshold="{{config.configurable.sparse_score_threshold}}",
         vector_store_candidate_k="{{config.configurable.sparse_vector_store_candidate_k}}",
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     web_search = WebSearchNode(
         name="web_search",

--- a/examples/conversational_search/demo_4_conversational/demo_4.py
+++ b/examples/conversational_search/demo_4_conversational/demo_4.py
@@ -137,12 +137,14 @@ async def orcheo_workflow() -> StateGraph:
         top_k="{{config.configurable.retrieval.top_k}}",
         score_threshold="{{config.configurable.retrieval.score_threshold}}",
         embedding_method=OPENAI_TEXT_EMBEDDING_3_SMALL,
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     generator = GroundedGeneratorNode(
         name="generator",
         context_result_key=dense_search.name,
         citation_style="{{config.configurable.generation.citation_style}}",
         ai_model="openai:gpt-4o-mini",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     citations = CitationsFormatterNode(
         name="citations",

--- a/examples/conversational_search/demo_5_production/demo_5.py
+++ b/examples/conversational_search/demo_5_production/demo_5.py
@@ -188,6 +188,7 @@ def build_demo_nodes(
         top_k=retrieval_cfg.get("top_k", 4),
         score_threshold=retrieval_cfg.get("score_threshold", 0.0),
         query_key="search_query",
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     nodes["source_router"] = SourceRouterNode(
         name="source_router",
@@ -200,6 +201,7 @@ def build_demo_nodes(
         context_result_key=nodes["dense_search"].name,
         ai_model="openai:gpt-4o-mini",
         citation_style="inline",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
 
     nodes["citations"] = CitationsFormatterNode(
@@ -252,6 +254,7 @@ def build_demo_nodes(
         chunk_size=streaming_cfg.get("chunk_size", 8),
         buffer_limit=streaming_cfg.get("buffer_limit", 64),
         ai_model="openai:gpt-4o-mini",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     nodes["streaming_generator"] = streaming
 

--- a/examples/conversational_search/demo_6_evaluation/demo_6.py
+++ b/examples/conversational_search/demo_6_evaluation/demo_6.py
@@ -509,6 +509,7 @@ def build_retrieval_nodes(
         embedding_method="{{config.configurable.retrieval.embedding_method}}",
         top_k="{{config.configurable.retrieval.top_k}}",
         query_key="query",
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     sparse_search = SparseSearchNode(
         name="sparse_search",
@@ -518,6 +519,7 @@ def build_retrieval_nodes(
         vector_store_candidate_k="{{config.configurable.retrieval.sparse_candidate_k}}",
         score_threshold="{{config.configurable.retrieval.sparse_score_threshold}}",
         query_key="query",
+        credential_env_vars={"OPENAI_API_KEY": "[[openai_api_key]]"},
     )
     hybrid_fusion = HybridFusionNode(
         name="hybrid_fusion",
@@ -574,6 +576,7 @@ def build_generation_nodes() -> dict[str, TaskNode]:
         context_result_key="generation_context",
         citation_style="{{config.configurable.generation.citation_style}}",
         ai_model="{{config.configurable.generation.model}}",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     batch_generator = BatchGenerationNode(
         name="batch_generator",
@@ -609,6 +612,7 @@ def build_feedback_and_analysis_nodes() -> dict[str, TaskNode]:
         answers_key="answers",
         min_score="{{config.configurable.llm_judge.min_score}}",
         ai_model="{{config.configurable.llm_judge.model}}",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     variant_scoring = VariantScoringNode(name="variant_scoring")
     variant_to_inputs = ResultToInputsNode(

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -24,6 +24,11 @@ def env(tmp_path: Path) -> dict[str, str]:
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
         "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
+        "ORCHEO_AUTH_ISSUER": "",
+        "ORCHEO_AUTH_CLIENT_ID": "",
+        "ORCHEO_AUTH_SCOPES": "",
+        "ORCHEO_AUTH_AUDIENCE": "",
+        "ORCHEO_AUTH_ORGANIZATION": "",
         "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
@@ -42,6 +47,11 @@ def machine_env(tmp_path: Path) -> dict[str, str]:
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
         "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
+        "ORCHEO_AUTH_ISSUER": "",
+        "ORCHEO_AUTH_CLIENT_ID": "",
+        "ORCHEO_AUTH_SCOPES": "",
+        "ORCHEO_AUTH_AUDIENCE": "",
+        "ORCHEO_AUTH_ORGANIZATION": "",
         "ORCHEO_HUMAN": "",
         "NO_COLOR": "1",
     }

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -84,6 +84,11 @@ def test_config_command_without_service_token(
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(tmp_path / "cache"),
         "ORCHEO_API_URL": "http://api.test",
+        "ORCHEO_AUTH_ISSUER": "",
+        "ORCHEO_AUTH_CLIENT_ID": "",
+        "ORCHEO_AUTH_SCOPES": "",
+        "ORCHEO_AUTH_AUDIENCE": "",
+        "ORCHEO_AUTH_ORGANIZATION": "",
         "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }
@@ -325,6 +330,11 @@ def test_config_command_missing_api_url(runner: CliRunner, tmp_path: Path) -> No
     minimal_env = {
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_API_URL": "",
+        "ORCHEO_AUTH_ISSUER": "",
+        "ORCHEO_AUTH_CLIENT_ID": "",
+        "ORCHEO_AUTH_SCOPES": "",
+        "ORCHEO_AUTH_AUDIENCE": "",
+        "ORCHEO_AUTH_ORGANIZATION": "",
         "ORCHEO_HUMAN": "1",
         "NO_COLOR": "1",
     }


### PR DESCRIPTION
## Summary
- Add `credential_env_vars` field to `DenseSearchNode` and `SparseSearchNode` so
  embedding execution can receive API keys from the Orcheo vault, matching the
  existing pattern on `ChunkEmbeddingNode` and `TextEmbeddingNode`
- Update demos 3–6 to pass `[[openai_api_key]]` via `credential_env_vars`
  (embeddings) and `model_kwargs` (generation / LLM judge) so workflows run
  correctly from the uploaded server without a global `OPENAI_API_KEY` env var

## Changes

### Core (`src/orcheo/nodes/conversational_search/retrieval.py`)
- `DenseSearchNode`: added `credential_env_vars` field; `_embed()` now wraps the
  embedding call in `_temporary_env_vars(self.credential_env_vars)`
- `SparseSearchNode`: same treatment

### Demos
- **demo_3** – `DenseSearchNode`, `SparseSearchNode`: added `credential_env_vars`
- **demo_4** – `DenseSearchNode`: added `credential_env_vars`;
  `GroundedGeneratorNode`: added `model_kwargs`
- **demo_5** – `DenseSearchNode`: added `credential_env_vars`;
  `GroundedGeneratorNode`, `StreamingGeneratorNode`: added `model_kwargs`
- **demo_6** – `DenseSearchNode`, `SparseSearchNode`: added `credential_env_vars`;
  `GroundedGeneratorNode`, `LLMJudgeNode`: added `model_kwargs`