### PR TITLE
Add config --check and orcheo-human CLI alias; update workflow template entrypoint

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 
 [project.scripts]
 orcheo = "orcheo_sdk.cli.main:run"
+orcheo-human = "orcheo_sdk.cli.main:run_human"
 orcheo-mcp = "orcheo_sdk.mcp_server.main:main"
 
 [tool.hatch.build.targets.wheel]

--- a/packages/sdk/src/orcheo_sdk/cli/config_command.py
+++ b/packages/sdk/src/orcheo_sdk/cli/config_command.py
@@ -267,9 +267,7 @@ def _resolve_profiles_with_overrides(
         profile_data = dict(profiles.get(name, {}))
         resolved_api_url = resolved_api_url_override or profile_data.get("api_url")
         if not resolved_api_url:
-            raise CLIError(
-                "Missing ORCHEO_API_URL. Provide --api-url or set ORCHEO_API_URL."
-            )
+            raise CLIError("Missing api_url.")
 
         profile_data["api_url"] = resolved_api_url
         if resolved_service_token:

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -227,3 +227,14 @@ def run() -> None:
     finally:
         if hasattr(app, "rich_markup_mode"):
             app.rich_markup_mode = original_rich_markup
+
+
+def run_human() -> None:
+    """Entry point that defaults to human-readable output."""
+    original_argv = sys.argv.copy()
+    try:
+        if "--human" not in sys.argv:
+            sys.argv = [sys.argv[0], "--human", *sys.argv[1:]]
+        run()
+    finally:
+        sys.argv = original_argv

--- a/packages/sdk/src/orcheo_sdk/services/codegen.py
+++ b/packages/sdk/src/orcheo_sdk/services/codegen.py
@@ -78,7 +78,7 @@ def generate_workflow_template_data() -> dict[str, str]:
     """
     template = '''"""Minimal LangGraph workflow for Orcheo.
 
-Orcheo loads any top-level StateGraph or a `build_graph` function (sync or async)
+Orcheo loads any top-level StateGraph or a `orcheo_workflow` function (sync or async)
 that returns one.
 
 Key points:
@@ -94,7 +94,7 @@ from orcheo.graph.state import State
 from orcheo.nodes.logic import SetVariableNode
 
 
-async def build_graph() -> StateGraph:
+async def orcheo_workflow() -> StateGraph:
     """Build and return the LangGraph workflow."""
     graph = StateGraph(State)
     graph.add_node(

--- a/tests/sdk/test_cli_code_template.py
+++ b/tests/sdk/test_cli_code_template.py
@@ -21,7 +21,7 @@ def test_code_template_creates_workflow_file(
     assert output_file.exists()
     content = output_file.read_text()
     assert "from langgraph.graph import END, START, StateGraph" in content
-    assert "async def build_graph()" in content
+    assert "async def orcheo_workflow()" in content
     assert "Created workflow template" in result.stdout
 
 

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -7,9 +7,12 @@ import pytest
 from typer.testing import CliRunner
 from orcheo_sdk.cli.config import CONFIG_FILENAME, PROFILE_ENV
 from orcheo_sdk.cli.config_command import (
+    _check_profile,
     _format_toml_value,
     _read_env_file,
+    _redact_value,
     _resolve_value,
+    _run_config_check,
 )
 from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.main import app
@@ -343,7 +346,7 @@ def test_config_command_missing_api_url(runner: CliRunner, tmp_path: Path) -> No
 
     assert result.exit_code == 1
     assert isinstance(result.exception, CLIError)
-    assert "ORCHEO_API_URL" in str(result.exception)
+    assert "Missing api_url" in str(result.exception)
 
 
 def test_config_command_invalid_toml(
@@ -543,7 +546,7 @@ def test_config_check_fails_without_api_url(
 
     assert result.exit_code == 1
     assert isinstance(result.exception, CLIError)
-    assert "Missing ORCHEO_API_URL." in str(result.exception)
+    assert "Missing api_url." in str(result.exception)
 
 
 def test_config_check_fails_without_auth_or_service_token(
@@ -676,3 +679,100 @@ def test_config_check_passes_with_redacted_oauth(
     assert "auth-client-id: oa...34" in result.stdout
     assert "https://issuer.example.com" not in result.stdout
     assert "oauth-client-1234" not in result.stdout
+
+
+def test_redact_value_short_string() -> None:
+    """Test that short values (<=4 chars) are fully redacted."""
+    assert _redact_value("ab") == "**"
+    assert _redact_value("abcd") == "****"
+    assert _redact_value("") == ""
+
+
+def test_check_profile_missing_api_url() -> None:
+    """Test _check_profile returns error when api_url is missing."""
+    reason, output = _check_profile({"service_token": "tok"})
+    assert reason == "'api_url' is not configured."
+    assert output is None
+
+
+def test_run_config_check_none_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test _run_config_check raises when output is None."""
+    from unittest.mock import MagicMock
+    import orcheo_sdk.cli.config_command as cc
+
+    state = MagicMock()
+    state.human = True
+
+    profiles: dict[str, dict[str, str]] = {
+        "bad": {"api_url": "http://a.test"},
+    }
+
+    def _fake_check(
+        profile_data: dict[str, object],
+    ) -> tuple[str | None, dict[str, str] | None]:
+        return None, None
+
+    monkeypatch.setattr(cc, "_check_profile", _fake_check)
+
+    with pytest.raises(CLIError, match="failed check"):
+        _run_config_check(
+            state=state,
+            profile_names=["bad"],
+            profiles=profiles,
+        )
+
+
+def test_config_check_oauth_only_no_service_token(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    """Test --check with OAuth auth only covers 206->208, 247->249."""
+    config_path = Path(env["ORCHEO_CONFIG_DIR"]) / CONFIG_FILENAME
+    config_path.write_text(
+        "\n".join(
+            [
+                "[profiles.default]",
+                'api_url = "http://api.test"',
+                'auth_issuer = "https://issuer.example.com"',
+                'auth_client_id = "oauth-client-1234"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    check_env = {**env, "ORCHEO_SERVICE_TOKEN": ""}
+    result = runner.invoke(app, ["config", "--check"], env=check_env)
+
+    assert result.exit_code == 0
+    assert "api-url: http://api.test" in result.stdout
+    assert "service-token" not in result.stdout
+    assert "auth-issuer:" in result.stdout
+    assert "auth-client-id:" in result.stdout
+
+
+def test_config_check_machine_output(runner: CliRunner, env: dict[str, str]) -> None:
+    """Test --check in machine mode outputs JSON."""
+    import json
+
+    config_path = Path(env["ORCHEO_CONFIG_DIR"]) / CONFIG_FILENAME
+    config_path.write_text(
+        "\n".join(
+            [
+                "[profiles.default]",
+                'api_url = "http://api.test"',
+                'service_token = "token-123456"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    machine_env = {**env, "ORCHEO_HUMAN": "", "ORCHEO_SERVICE_TOKEN": ""}
+    result = runner.invoke(app, ["config", "--check"], env=machine_env)
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["status"] == "success"
+    assert "default" in data["profiles"]

--- a/tests/sdk/test_cli_machine_output.py
+++ b/tests/sdk/test_cli_machine_output.py
@@ -182,7 +182,8 @@ class TestConfigMachineMode:
             encoding="utf-8",
         )
 
-        result = runner.invoke(app, ["config", "--check"], env=machine_env)
+        check_env = {**machine_env, "ORCHEO_SERVICE_TOKEN": ""}
+        result = runner.invoke(app, ["config", "--check"], env=check_env)
 
         assert result.exit_code == 0
         data = json.loads(result.stdout)

--- a/tests/sdk/test_cli_machine_output.py
+++ b/tests/sdk/test_cli_machine_output.py
@@ -166,6 +166,31 @@ class TestConfigMachineMode:
         assert "profiles" in data
         assert "config_path" in data
 
+    def test_check_outputs_redacted_json(
+        self, runner: CliRunner, machine_env: dict[str, str]
+    ) -> None:
+        config_path = Path(machine_env["ORCHEO_CONFIG_DIR"]) / "cli.toml"
+        config_path.write_text(
+            "\n".join(
+                [
+                    "[profiles.default]",
+                    'api_url = "http://api.test"',
+                    'service_token = "token-123456"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["config", "--check"], env=machine_env)
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "success"
+        assert "config_path" not in data
+        assert data["profiles"]["default"]["api_url"] == "http://api.test"
+        assert data["profiles"]["default"]["service_token"] == "to...56"
+
 
 class TestEdgeListMachineMode:
     def test_outputs_markdown_table(

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -313,3 +313,32 @@ def test_run_human_injects_human_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured_argv[0] == "orcheo-human"
     assert captured_argv[1] == "--human"
     assert captured_argv[2:] == ["node", "list"]
+
+
+def test_run_human_skips_inject_when_flag_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test run_human does not duplicate --human when already present."""
+    from orcheo_sdk.cli import main as main_mod
+
+    captured_argv: list[str] = []
+
+    def mock_run() -> None:
+        nonlocal captured_argv
+        captured_argv = main_mod.sys.argv.copy()
+
+    monkeypatch.setattr(main_mod, "run", mock_run)
+    monkeypatch.setattr(
+        main_mod.sys,
+        "argv",
+        ["orcheo-human", "--human", "node", "list"],
+    )
+
+    run_human()
+
+    assert captured_argv == [
+        "orcheo-human",
+        "--human",
+        "node",
+        "list",
+    ]

--- a/tests/sdk/test_cli_main.py
+++ b/tests/sdk/test_cli_main.py
@@ -8,7 +8,7 @@ import respx
 import typer
 from typer.testing import CliRunner
 from orcheo_sdk.cli.errors import APICallError, CLIError
-from orcheo_sdk.cli.main import app, run
+from orcheo_sdk.cli.main import app, run, run_human
 
 
 def test_main_config_error_handling(
@@ -294,3 +294,22 @@ def test_run_disables_rich_markup_in_machine_mode(
     assert exc_info.value.code == 1
     assert dummy.called_with_none
     assert dummy.rich_markup_mode == "rich"
+
+
+def test_run_human_injects_human_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orcheo_sdk.cli import main as main_mod
+
+    captured_argv: list[str] = []
+
+    def mock_run() -> None:
+        nonlocal captured_argv
+        captured_argv = main_mod.sys.argv.copy()
+
+    monkeypatch.setattr(main_mod, "run", mock_run)
+    monkeypatch.setattr(main_mod.sys, "argv", ["orcheo-human", "node", "list"])
+
+    run_human()
+
+    assert captured_argv[0] == "orcheo-human"
+    assert captured_argv[1] == "--human"
+    assert captured_argv[2:] == ["node", "list"]


### PR DESCRIPTION
## Summary
This PR improves CLI ergonomics and adds a safe way to validate profile configuration without mutating config files.

## Changes
- Added `orcheo config --check` to validate selected profile(s) without writing changes.
- Added validation rules for config checks:
  - `api_url` must be present.
  - Authentication must include either `service_token` or both `auth_issuer` and `auth_client_id`.
- Added redacted output for sensitive values during checks (human and machine output modes).
- Added `orcheo-human` as a new console entrypoint that injects `--human` by default.
- Updated generated workflow template naming from `build_graph()` to `orcheo_workflow()` (including template docs).

## Test coverage
- Added tests for `config --check` failure paths (missing `api_url`, missing auth config).
- Added tests for successful `config --check` with redacted `service_token` and OAuth fields.
- Added machine-mode test for redacted JSON output from `config --check`.
- Added test verifying `orcheo-human` injects `--human` into argv.
