### PR TITLE
Require OAuth audience in CLI config and fix Pinecone BM25 default behavior

### DIFF
--- a/examples/conversational_search/demo_1_hybrid_indexing/config.json
+++ b/examples/conversational_search/demo_1_hybrid_indexing/config.json
@@ -11,7 +11,7 @@
     "chunk_size": 512,
     "chunk_overlap": 64,
     "dense_embed_model": "openai:text-embedding-3-small",
-    "sparse_model": "pinecone:bm25",
+    "sparse_model": "pinecone:bm25-default",
     "vector_store_index_dense": "orcheo-demo-dense",
     "vector_store_index_sparse": "orcheo-demo-sparse",
     "vector_store_namespace": "hybrid_search"

--- a/examples/conversational_search/demo_3_hybrid_search/config.json
+++ b/examples/conversational_search/demo_3_hybrid_search/config.json
@@ -6,7 +6,7 @@
     "sparse_top_k": 10,
     "sparse_score_threshold": 0.0,
     "sparse_vector_store_candidate_k": 50,
-    "sparse_model": "pinecone:bm25",
+    "sparse_model": "pinecone:bm25-default",
     "web_search_provider": "tavily",
     "web_search_max_results": 5,
     "web_search_search_depth": "advanced",

--- a/examples/conversational_search/demo_4_conversational/demo_4.py
+++ b/examples/conversational_search/demo_4_conversational/demo_4.py
@@ -118,7 +118,9 @@ async def orcheo_workflow() -> StateGraph:
     classifier = QueryClassifierNode(name="query_classifier")
     coref = CoreferenceResolverNode(name="coreference_resolver")
     own_query_rewrite = QueryRewriteNode(
-        name="query_rewrite", ai_model="openai:gpt-4o-mini"
+        name="query_rewrite",
+        ai_model="openai:gpt-4o-mini",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     coref_sync = ResultToInputsNode(
         name="coreference_result_to_inputs",
@@ -136,7 +138,7 @@ async def orcheo_workflow() -> StateGraph:
         top_k="{{config.configurable.retrieval.top_k}}",
         score_threshold="{{config.configurable.retrieval.score_threshold}}",
         embed_model="openai:text-embedding-3-small",
-        model_kwargs={"api_key": "[[openai_api_key]]"},
+        model_kwargs={"api_key": "[[openai_api_key]]", "dimensions": 512},
     )
     generator = GroundedGeneratorNode(
         name="generator",

--- a/examples/conversational_search/demo_5_production/demo_5.py
+++ b/examples/conversational_search/demo_5_production/demo_5.py
@@ -163,7 +163,9 @@ def build_demo_nodes(
     )
 
     nodes["query_rewrite"] = QueryRewriteNode(
-        name="query_rewrite", ai_model="openai:gpt-4o-mini"
+        name="query_rewrite",
+        ai_model="openai:gpt-4o-mini",
+        model_kwargs={"api_key": "[[openai_api_key]]"},
     )
     nodes["rewrite_to_search"] = ResultToInputsNode(
         name="rewrite_to_search",
@@ -182,7 +184,7 @@ def build_demo_nodes(
         name="dense_search",
         vector_store=vector_store,
         embed_model=retrieval_cfg.get("embed_model", "openai:text-embedding-3-small"),
-        model_kwargs={"api_key": "[[openai_api_key]]"},
+        model_kwargs={"api_key": "[[openai_api_key]]", "dimensions": 512},
         top_k=retrieval_cfg.get("top_k", 4),
         score_threshold=retrieval_cfg.get("score_threshold", 0.0),
         query_key="search_query",

--- a/examples/conversational_search/demo_6_evaluation/config.json
+++ b/examples/conversational_search/demo_6_evaluation/config.json
@@ -13,7 +13,7 @@
     "retrieval": {
       "top_k": 4,
       "embed_model": "openai:text-embedding-3-small",
-      "sparse_model": "pinecone:bm25",
+      "sparse_model": "pinecone:bm25-default",
       "sparse_top_k": 4,
       "sparse_candidate_k": 50,
       "sparse_score_threshold": 0.0,

--- a/examples/conversational_search/demo_6_evaluation/demo_6.py
+++ b/examples/conversational_search/demo_6_evaluation/demo_6.py
@@ -507,7 +507,7 @@ def build_retrieval_nodes(
         name="dense_search",
         vector_store=vector_store,
         embed_model="{{config.configurable.retrieval.embed_model}}",
-        model_kwargs={"api_key": "[[openai_api_key]]"},
+        model_kwargs={"api_key": "[[openai_api_key]]", "dimensions": 512},
         top_k="{{config.configurable.retrieval.top_k}}",
         query_key="query",
     )

--- a/examples/evaluation/config_md2d.json
+++ b/examples/evaluation/config_md2d.json
@@ -4,7 +4,7 @@
   "configurable": {
     "md2d": {
       "data_path": "https://raw.githubusercontent.com/doc2dial/sharedtask-dialdoc2021/master/data/doc2dial/v1.0.1/doc2dial_dial_validation.json",
-      "max_conversations": 2
+      "max_conversations": null
     },
     "retrieval": {
       "embed_model": "openai:text-embedding-3-small",

--- a/examples/evaluation/config_md2d_indexing.json
+++ b/examples/evaluation/config_md2d_indexing.json
@@ -4,7 +4,7 @@
   "configurable": {
     "corpus": {
       "docs_path": "https://raw.githubusercontent.com/doc2dial/sharedtask-dialdoc2021/master/data/doc2dial/v1.0.1/doc2dial_doc.json",
-      "max_documents": 2,
+      "max_documents": null,
       "chunk_size": 512,
       "chunk_overlap": 64
     },

--- a/examples/evaluation/config_qrecc.json
+++ b/examples/evaluation/config_qrecc.json
@@ -4,7 +4,7 @@
   "configurable": {
     "qrecc": {
       "data_path": "https://huggingface.co/datasets/slupart/qrecc/resolve/main/qrecc_test.json?download=true",
-      "max_conversations": 2
+      "max_conversations": null
     },
     "rewrite": {
       "model": "openai:gpt-4o-mini"

--- a/src/orcheo/nodes/conversational_search/retrieval.py
+++ b/src/orcheo/nodes/conversational_search/retrieval.py
@@ -305,14 +305,17 @@ class SparseSearchNode(TaskNode):
 
     def _validate_sparse_query_configuration(self) -> None:
         """Validate sparse query encoder settings for vector-store retrieval."""
-        if self.sparse_model not in {"pinecone:bm25", "pinecone:bm25-default"}:
+        if self.sparse_model == "pinecone:bm25-default":
+            return
+        if self.sparse_model != "pinecone:bm25":
             return
         if self.sparse_kwargs.get("encoder_state_path"):
             return
         msg = (
             "SparseSearchNode with sparse_model='pinecone:bm25' requires "
             "sparse_kwargs['encoder_state_path'] so query encoding uses a "
-            "pre-fitted BM25 encoder."
+            "pre-fitted BM25 encoder. Use sparse_model='pinecone:bm25-default' "
+            "to use Pinecone default parameters without local state files."
         )
         raise ValueError(msg)
 

--- a/tests/nodes/conversational_search/test_ingestion.py
+++ b/tests/nodes/conversational_search/test_ingestion.py
@@ -1989,6 +1989,22 @@ async def test_chunk_embedding_node_sparse_count_mismatch(
         await node.run(state, {})
 
 
+def test_chunk_embedding_should_fit_sparse_encoder() -> None:
+    assert (
+        ChunkEmbeddingNode._should_fit_sparse_encoder("pinecone:bm25-default", {})
+        is False
+    )
+    assert (
+        ChunkEmbeddingNode._should_fit_sparse_encoder(
+            "pinecone:bm25",
+            {"encoder_state_path": "/tmp/state.json"},
+        )
+        is False
+    )
+    assert ChunkEmbeddingNode._should_fit_sparse_encoder("pinecone:bm25", {}) is True
+    assert ChunkEmbeddingNode._should_fit_sparse_encoder("pinecone:splade", {}) is True
+
+
 @pytest.mark.asyncio
 async def test_text_embedding_node_vector_count_mismatch(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/nodes/conversational_search/test_retrieval.py
+++ b/tests/nodes/conversational_search/test_retrieval.py
@@ -417,6 +417,16 @@ async def test_sparse_search_bm25_requires_encoder_state_path() -> None:
         await node._build_vector_store_query("apple")
 
 
+def test_sparse_search_bm25_default_allows_missing_encoder_state_path() -> None:
+    node = SparseSearchNode(
+        name="sparse-bm25-default",
+        sparse_model="pinecone:bm25-default",
+        sparse_kwargs={},
+    )
+
+    node._validate_sparse_query_configuration()
+
+
 def test_sparse_resolve_chunks_rejects_non_list_payload() -> None:
     node = SparseSearchNode(name="sparse")
     state = State(

--- a/tests/sdk/test_cli_auth_refresh.py
+++ b/tests/sdk/test_cli_auth_refresh.py
@@ -63,6 +63,7 @@ def test_get_valid_access_token_oauth_not_configured(
 ) -> None:
     monkeypatch.delenv("ORCHEO_AUTH_ISSUER", raising=False)
     monkeypatch.delenv("ORCHEO_AUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ORCHEO_AUTH_AUDIENCE", raising=False)
 
     result = get_valid_access_token(profile="default")
     assert result is None
@@ -73,6 +74,7 @@ def test_get_valid_access_token_no_tokens(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     result = get_valid_access_token(profile="default")
     assert result is None
@@ -83,6 +85,7 @@ def test_get_valid_access_token_valid_token(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     future = int(time.time() * 1000) + 3600000
     tokens = AuthTokens(access_token="valid-token", expires_at=future)
@@ -97,6 +100,7 @@ def test_get_valid_access_token_expired_no_refresh(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     past = int(time.time() * 1000) - 3600000
     tokens = AuthTokens(access_token="expired-token", expires_at=past)
@@ -111,6 +115,7 @@ def test_refresh_oauth_tokens_no_refresh_token(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     past = int(time.time() * 1000) - 3600000
     tokens = AuthTokens(
@@ -127,6 +132,7 @@ def test_refresh_oauth_tokens_not_configured(
 ) -> None:
     monkeypatch.delenv("ORCHEO_AUTH_ISSUER", raising=False)
     monkeypatch.delenv("ORCHEO_AUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ORCHEO_AUTH_AUDIENCE", raising=False)
 
     result = refresh_oauth_tokens(profile="default")
     assert result is None
@@ -137,6 +143,7 @@ def test_refresh_oauth_tokens_invalid_discovery_json(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     tokens = AuthTokens(
         access_token="expired-token", expires_at=0, refresh_token="refresh-token"
@@ -163,6 +170,7 @@ def test_refresh_oauth_tokens_http_error(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     tokens = AuthTokens(
         access_token="expired-token", expires_at=0, refresh_token="refresh-token"
@@ -192,6 +200,7 @@ def test_refresh_oauth_tokens_missing_access_token(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     tokens = AuthTokens(
         access_token="expired-token", expires_at=0, refresh_token="refresh-token"
@@ -220,6 +229,7 @@ def test_refresh_oauth_tokens_success_calculates_expiry(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     tokens = AuthTokens(
         access_token="expired-token",
@@ -265,6 +275,7 @@ def test_refresh_oauth_tokens_success_fallback_expiry(
 ) -> None:
     monkeypatch.setenv("ORCHEO_AUTH_ISSUER", "https://auth.example.com")
     monkeypatch.setenv("ORCHEO_AUTH_CLIENT_ID", "client-123")
+    monkeypatch.setenv("ORCHEO_AUTH_AUDIENCE", "https://api.example.com")
 
     tokens = AuthTokens(
         access_token="expired-token", expires_at=456, refresh_token="refresh-token"

--- a/tests/sdk/test_cli_config_command.py
+++ b/tests/sdk/test_cli_config_command.py
@@ -1,6 +1,7 @@
 """Tests for the CLI config command."""
 
 from __future__ import annotations
+import re
 import tomllib
 from pathlib import Path
 import pytest
@@ -80,7 +81,9 @@ def test_config_command_rejects_profile_option(
     result = runner.invoke(app, ["config", "--profile", "remote"], env=env)
 
     assert result.exit_code == 2
-    assert "No such option: --profile" in result.output
+    output = re.sub(r"\x1b\[[0-9;]*m", "", result.output).lower()
+    assert "--profile" in output
+    assert "option" in output
 
 
 def test_config_command_without_auth_or_service_token_fails(


### PR DESCRIPTION
## Summary
This PR tightens OAuth configuration requirements in the SDK CLI and fixes Pinecone BM25 sparse retrieval defaults for conversational search flows. It also updates evaluation/demo configs to run full datasets and use the corrected sparse model defaults.

## What changed

### 1) OAuth CLI configuration hardening
- `auth_audience` is now treated as a required OAuth field alongside `auth_issuer` and `auth_client_id`.
- OAuth config resolution and `is_oauth_configured()` now require all three fields.
- `config --check` now validates and reports OAuth completeness including redacted `auth_audience`.
- `config` now fails when neither `service_token` nor complete OAuth credentials are present.
- Incomplete OAuth combinations now raise clearer errors (including missing `auth_audience`).

### 2) Better profile behavior in `config`
- `config` no longer accepts its own `--profile`; profile selection is taken from root/global profile selection.
- Profile resolution now supports filling missing OAuth fields from existing profile values, enabling incremental fixes to legacy profile entries (e.g., adding only missing audience).
- Tests were updated to reflect root-level profile option ordering and selected-profile-only updates.

### 3) Pinecone BM25 sparse retrieval fixes
- Added compatibility loader for BM25 encoder state across `pinecone-text` API variants (class-style vs instance-style `load`).
- `pinecone:bm25-default` now correctly uses Pinecone default BM25 parameters.
- Ingestion now avoids refitting sparse encoders when using `pinecone:bm25-default` or when loading a prefit `encoder_state_path`.
- Retrieval validation now allows `pinecone:bm25-default` without local encoder state, while still requiring state path for `pinecone:bm25`.

### 4) Example/evaluation config updates
- Conversational search demos now use `pinecone:bm25-default` where appropriate.
- Evaluation sample limits were removed (`max_conversations` / `max_documents` set to `null`) so full datasets run by default.

## Testing
- Updated and expanded SDK CLI auth/config tests for new OAuth requirements and profile-selection behavior.
- Added conversational search tests for BM25 default initialization, loader compatibility, sparse fit logic, and retrieval validation.
