### PR TITLE
Improve batch evaluation scalability and MD2D indexing configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Orcheo is a workflow orchestration platform designed for vibe coding — AI codi
 
 > **Note:** This project is currently in Beta. Expect breaking changes as we iterate rapidly towards 1.0.
 
-> **SIGIR Reviewers:** See the **[Conversational Search Examples](https://orcheo.readthedocs.io/en/latest/conversational_search_examples/)** for step-by-step demos from basic RAG to production-ready search.
+> **SIGIR Reviewers:** See the **[Conversational Search Examples](https://orcheo.readthedocs.io/en/latest/examples/conversational_search/)** for step-by-step demos from basic RAG to production-ready search.
 
 ## Why Orcheo?
 
@@ -56,7 +56,7 @@ That's it! Your agent handles the complexity while you focus on describing what 
 ## Guides
 
 - **[Manual Setup Guide](https://orcheo.readthedocs.io/en/latest/manual_setup/)** — Installation, CLI reference, authentication, and Canvas setup
-- **[Conversational Search Examples](https://orcheo.readthedocs.io/en/latest/conversational_search_examples/)** — Step-by-step demos from basic RAG to production-ready search
+- **[Conversational Search Examples](https://orcheo.readthedocs.io/en/latest/examples/conversational_search/)** — Step-by-step demos from basic RAG to production-ready search
 
 ```bash
 # Quick start: Run Demo 1 (no external services required)

--- a/examples/conversational_search/demo_3_hybrid_search/demo_3.py
+++ b/examples/conversational_search/demo_3_hybrid_search/demo_3.py
@@ -88,7 +88,7 @@ async def orcheo_workflow() -> StateGraph:
         name="dense_search",
         vector_store=dense_store,
         embed_model="{{config.configurable.dense_embed_model}}",
-        model_kwargs={"api_key": "[[openai_api_key]]"},
+        model_kwargs={"api_key": "[[openai_api_key]]", "dimensions": 512},
         top_k="{{config.configurable.dense_top_k}}",
         score_threshold="{{config.configurable.dense_similarity_threshold}}",
     )

--- a/examples/evaluation/README.md
+++ b/examples/evaluation/README.md
@@ -151,7 +151,7 @@ Each dataset has a single config file that controls data paths, model selections
 |--------|----------------|
 | `config_qrecc.json` | `data_path`, `max_conversations`, similarity `embed_model` and `dimensions` |
 | `config_md2d.json` | `data_path`, `max_conversations`, retrieval `embed_model`/`dimensions`/`top_k`, generation `model` |
-| `config_md2d_indexing.json` | `docs_path`, `max_documents`, `chunk_size`, `chunk_overlap`, retrieval `embed_model`/`dimensions` |
+| `config_md2d_indexing.json` | `docs_path`, `max_documents`, `chunk_size`, `chunk_overlap`, retrieval `embed_model`/`dimensions`, indexing `batch_size`/`max_retries`/`backoff_seconds` |
 
 Users can create custom configs with different model or retrieval parameters to compare pipeline configurations against the established baselines.
 

--- a/examples/evaluation/config_md2d.json
+++ b/examples/evaluation/config_md2d.json
@@ -4,7 +4,9 @@
   "configurable": {
     "md2d": {
       "data_path": "https://raw.githubusercontent.com/doc2dial/sharedtask-dialdoc2021/master/data/doc2dial/v1.0.1/doc2dial_dial_validation.json",
-      "max_conversations": null
+      "max_conversations": null,
+      "max_concurrency": 4,
+      "history_window_size": 3
     },
     "retrieval": {
       "embed_model": "openai:text-embedding-3-small",

--- a/examples/evaluation/config_md2d_indexing.json
+++ b/examples/evaluation/config_md2d_indexing.json
@@ -12,6 +12,12 @@
       "embed_model": "openai:text-embedding-3-small",
       "dimensions": 512
     },
+    "indexing": {
+      "batch_size": 32,
+      "max_retries": 2,
+      "backoff_seconds": 0.05,
+      "skip_unchanged": false
+    },
     "vector_store": {
       "type": "pinecone",
       "pinecone": {

--- a/examples/evaluation/config_qrecc.json
+++ b/examples/evaluation/config_qrecc.json
@@ -4,7 +4,9 @@
   "configurable": {
     "qrecc": {
       "data_path": "https://huggingface.co/datasets/slupart/qrecc/resolve/main/qrecc_test.json?download=true",
-      "max_conversations": null
+      "max_conversations": null,
+      "max_concurrency": 8,
+      "history_window_size": 3
     },
     "rewrite": {
       "model": "openai:gpt-4o-mini"

--- a/examples/evaluation/md2d_eval.py
+++ b/examples/evaluation/md2d_eval.py
@@ -100,6 +100,9 @@ def build_nodes() -> dict[str, Any]:
         prediction_field="reply",
         gold_field="gold_response",
         max_conversations="{{config.configurable.md2d.max_conversations}}",
+        max_concurrency="{{config.configurable.md2d.max_concurrency}}",
+        history_window_size="{{config.configurable.md2d.history_window_size}}",
+        include_per_conversation_details=False,
         pipeline=build_generation_pipeline_graph(),
     )
 

--- a/examples/evaluation/qrecc_eval.py
+++ b/examples/evaluation/qrecc_eval.py
@@ -56,6 +56,9 @@ def build_nodes() -> dict[str, Any]:
         prediction_field="query",
         gold_field="gold_rewrite",
         max_conversations="{{config.configurable.qrecc.max_conversations}}",
+        max_concurrency="{{config.configurable.qrecc.max_concurrency}}",
+        history_window_size="{{config.configurable.qrecc.history_window_size}}",
+        include_per_conversation_details=False,
         pipeline=build_rewrite_pipeline_graph(),
     )
 


### PR DESCRIPTION
## Summary
This PR improves evaluation throughput/memory controls and modernizes the MD2D indexing example pipeline.

## What changed
- Enhanced `ConversationalBatchEvalNode` with:
  - `max_concurrency` for concurrent conversation processing
  - `history_window_size` for bounded turn history passed to pipeline nodes
  - `include_per_conversation_details` to optionally omit per-conversation predictions/references and reduce memory use
- Refactored batch evaluation execution to support async concurrency (with semaphore limits) while preserving output ordering.
- Added template-aware validation/resolution for new numeric config fields.

## Example/config updates
- Updated evaluation configs to expose concurrency/history settings:
  - QRECC: `max_concurrency`, `history_window_size`
  - MD2D eval: `max_concurrency`, `history_window_size`
- Updated evaluation examples to disable per-conversation detail payloads for lighter outputs.
- Switched MD2D indexing flow from `ChunkEmbeddingNode + VectorStoreUpsertNode` to `IncrementalIndexerNode`.
- Added indexing config options for incremental indexing behavior:
  - `batch_size`, `max_retries`, `backoff_seconds`, `skip_unchanged`
- Updated evaluation README config table to document new indexing knobs.