### PR TITLE
Refactor MongoDB hybrid search to async Motor execution with shared async client caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "feedparser>=6.0.11",
   "mcp[cli]>=1.12.0",
   "pymongo>=4.13.2",
+  "motor>=3.6.0",
   "dynaconf>=3.2.4",
   "structlog>=24.4.0",
   "cryptography>=43.0.1",

--- a/src/orcheo/nodes/integrations/databases/mongodb/search.py
+++ b/src/orcheo/nodes/integrations/databases/mongodb/search.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 import json
-from collections.abc import Mapping
-from typing import Any, Literal
+from collections.abc import Awaitable, Callable, Mapping
+from threading import Lock
+from typing import Any, ClassVar, Literal
 from langchain_core.runnables import RunnableConfig
-from pydantic import Field, field_validator, model_validator
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pydantic import Field, PrivateAttr, field_validator, model_validator
 from pymongo.command_cursor import CommandCursor
+from pymongo.errors import (
+    AutoReconnect,
+    ConfigurationError,
+    ConnectionFailure,
+    NetworkTimeout,
+    OperationFailure,
+    PyMongoError,
+    ServerSelectionTimeoutError,
+)
 from orcheo.graph.state import State
 from orcheo.nodes.integrations.databases.mongodb.base import MongoDBClientNode
 from orcheo.nodes.registry import NodeMetadata, registry
@@ -349,7 +360,9 @@ class MongoDBEnsureVectorIndexNode(MongoDBClientNode):
 @registry.register(
     NodeMetadata(
         name="MongoDBHybridSearchNode",
-        description="Execute a hybrid search over text and vector indexes.",
+        description=(
+            "Execute a hybrid search over text and vector indexes asynchronously."
+        ),
         category="mongodb",
     )
 )
@@ -392,6 +405,12 @@ class MongoDBHybridSearchNode(MongoDBClientNode):
     filter: dict[str, Any] | None = Field(
         default=None, description="Optional MongoDB filter applied post-search."
     )
+    _async_client_cache: ClassVar[dict[str, AsyncIOMotorClient]] = {}
+    _async_client_ref_counts: ClassVar[dict[str, int]] = {}
+    _async_client_lock: ClassVar[Lock] = Lock()
+    _async_client: AsyncIOMotorClient | None = PrivateAttr(default=None)
+    _async_collection: AsyncIOMotorCollection[Any] | None = PrivateAttr(default=None)
+    _async_client_key: str | None = PrivateAttr(default=None)
 
     @field_validator("vector", mode="before")
     @classmethod
@@ -562,21 +581,113 @@ class MongoDBHybridSearchNode(MongoDBClientNode):
             )
         return normalized
 
+    @classmethod
+    def _get_shared_async_client(cls, connection_string: str) -> AsyncIOMotorClient:
+        with cls._async_client_lock:
+            client = cls._async_client_cache.get(connection_string)
+            if client is None:
+                client = AsyncIOMotorClient(connection_string)
+                cls._async_client_cache[connection_string] = client
+                cls._async_client_ref_counts[connection_string] = 0
+            cls._async_client_ref_counts[connection_string] = (
+                cls._async_client_ref_counts.get(connection_string, 0) + 1
+            )
+        return client
+
+    @classmethod
+    def _release_shared_async_client(cls, connection_string: str) -> None:
+        client: AsyncIOMotorClient | None = None
+        with cls._async_client_lock:
+            ref_count = cls._async_client_ref_counts.get(connection_string)
+            if ref_count is None:
+                return
+            ref_count -= 1
+            if ref_count <= 0:
+                cls._async_client_ref_counts.pop(connection_string, None)
+                client = cls._async_client_cache.pop(connection_string, None)
+            else:
+                cls._async_client_ref_counts[connection_string] = ref_count
+        if client is not None:
+            client.close()
+
+    def _release_async_client(self) -> None:
+        if self._async_client is None or self._async_client_key is None:
+            return
+        type(self)._release_shared_async_client(self._async_client_key)
+        self._async_client = None
+        self._async_collection = None
+        self._async_client_key = None
+
+    def _ensure_async_collection(self) -> None:
+        """Ensure the async MongoDB collection is initialised."""
+        if self._async_client is None:
+            self._async_client = self._get_shared_async_client(self.connection_string)
+            self._async_client_key = self.connection_string
+        elif (
+            self._async_client_key and self._async_client_key != self.connection_string
+        ):
+            self._release_async_client()
+            self._async_client = self._get_shared_async_client(self.connection_string)
+            self._async_client_key = self.connection_string
+        if self._async_client is None:
+            msg = "MongoDB async client could not be initialized"
+            raise RuntimeError(msg)
+        self._async_collection = self._async_client[self.database][self.collection]
+
+    async def _execute_async_operation(
+        self,
+        *,
+        context: str,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        try:
+            return await operation()
+        except (
+            AutoReconnect,
+            ConnectionFailure,
+            NetworkTimeout,
+            ServerSelectionTimeoutError,
+        ) as exc:
+            msg = f"MongoDB network error during {context}."
+            raise RuntimeError(msg) from exc
+        except OperationFailure as exc:
+            auth_error_codes = {13, 18}
+            if exc.code in auth_error_codes:
+                msg = f"MongoDB authentication/authorization error during {context}."
+            else:
+                msg = f"MongoDB operation error during {context}."
+            raise RuntimeError(msg) from exc
+        except ConfigurationError as exc:
+            msg = f"MongoDB configuration error during {context}."
+            raise RuntimeError(msg) from exc
+        except PyMongoError as exc:
+            msg = f"MongoDB error during {context}."
+            raise RuntimeError(msg) from exc
+
+    def __del__(self) -> None:
+        """Automatic cleanup when object is garbage collected."""
+        self._release_async_client()
+        super().__del__()
+
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
-        """Execute the hybrid search pipeline and normalise results."""
-        self._ensure_collection()
-        assert self._collection is not None
-        collection = self._collection
+        """Execute the hybrid search pipeline asynchronously and normalize results."""
+        self._ensure_async_collection()
+        assert self._async_collection is not None
+        collection = self._async_collection
 
         pipeline = self._build_pipeline()
         context = (
-            f"hybrid search, database={self.database}, collection={self.collection}"
+            f"hybrid search (async), database={self.database}, "
+            f"collection={self.collection}"
         )
 
-        def _operation() -> list[dict[str, Any]]:
-            return list(collection.aggregate(pipeline))
+        async def _operation() -> list[dict[str, Any]]:
+            cursor = collection.aggregate(pipeline)
+            return await cursor.to_list(length=self.top_k)
 
-        results = self._execute_operation(context=context, operation=_operation)
+        results = await self._execute_async_operation(
+            context=context, operation=_operation
+        )
         return {"results": self._normalize_results(results)}
 
 

--- a/tests/nodes/test_mongodb_helpers.py
+++ b/tests/nodes/test_mongodb_helpers.py
@@ -14,7 +14,11 @@ from pymongo.errors import (
     ServerSelectionTimeoutError,
 )
 from orcheo.graph.state import State
-from orcheo.nodes.mongodb import MongoDBNode, MongoDBUpdateManyNode
+from orcheo.nodes.mongodb import (
+    MongoDBHybridSearchNode,
+    MongoDBNode,
+    MongoDBUpdateManyNode,
+)
 
 
 def _build_node(*, operation: str, **overrides: Any) -> MongoDBNode:
@@ -41,6 +45,21 @@ def _build_update_many() -> MongoDBUpdateManyNode:
         filter={"match": True},
         update={"$set": {"match": True}},
     )
+
+
+def _build_hybrid_search(**overrides: Any) -> MongoDBHybridSearchNode:
+    """Create a MongoDBHybridSearchNode with sane defaults."""
+
+    base_kwargs = {
+        "name": "hybrid",
+        "connection_string": "mongodb://helper",
+        "database": "test_db",
+        "collection": "test_collection",
+        "text_query": "hello",
+        "text_paths": ["body"],
+    }
+    base_kwargs.update(overrides)
+    return MongoDBHybridSearchNode(**base_kwargs)
 
 
 def test_limit_validator_accepts_templates_and_numbers() -> None:
@@ -263,6 +282,39 @@ def test_release_shared_client_ignores_unknown_connection() -> None:
     assert MongoDBNode._client_ref_counts == {}
 
 
+def test_shared_async_client_lifecycle() -> None:
+    MongoDBHybridSearchNode._async_client_cache.clear()
+    MongoDBHybridSearchNode._async_client_ref_counts.clear()
+    client_mock = MagicMock()
+
+    with patch(
+        "orcheo.nodes.integrations.databases.mongodb.base.AsyncIOMotorClient",
+        return_value=client_mock,
+    ):
+        first = MongoDBHybridSearchNode._get_shared_async_client("conn")
+        second = MongoDBHybridSearchNode._get_shared_async_client("conn")
+        assert first is client_mock
+        assert second is client_mock
+        assert MongoDBHybridSearchNode._async_client_ref_counts["conn"] == 2
+
+    MongoDBHybridSearchNode._release_shared_async_client("conn")
+    assert MongoDBHybridSearchNode._async_client_ref_counts["conn"] == 1
+    client_mock.close.assert_not_called()
+
+    MongoDBHybridSearchNode._release_shared_async_client("conn")
+    assert "conn" not in MongoDBHybridSearchNode._async_client_ref_counts
+    client_mock.close.assert_called_once()
+
+
+def test_release_shared_async_client_ignores_unknown_connection() -> None:
+    MongoDBHybridSearchNode._async_client_cache.clear()
+    MongoDBHybridSearchNode._async_client_ref_counts.clear()
+
+    MongoDBHybridSearchNode._release_shared_async_client("missing")
+    assert MongoDBHybridSearchNode._async_client_cache == {}
+    assert MongoDBHybridSearchNode._async_client_ref_counts == {}
+
+
 def test_ensure_collection_raises_when_client_missing() -> None:
     node = _build_node(operation="find")
     with patch.object(MongoDBNode, "_get_shared_client", return_value=None):
@@ -298,6 +350,36 @@ def test_ensure_collection_switches_clients_on_connection_change() -> None:
     assert node._collection is replacement_collection
 
 
+def test_ensure_async_collection_switches_clients_on_connection_change() -> None:
+    node = _build_hybrid_search()
+    node._async_client = MagicMock()
+    node._async_client_key = "old-connection"
+    node.connection_string = "new-connection"
+
+    replacement_db = MagicMock()
+    replacement_collection = MagicMock()
+    replacement_db.__getitem__.return_value = replacement_collection
+
+    replacement_client = MagicMock()
+    replacement_client.__getitem__.return_value = replacement_db
+
+    with patch.object(
+        MongoDBHybridSearchNode,
+        "_get_shared_async_client",
+        return_value=replacement_client,
+    ) as get_client:
+        with patch.object(
+            MongoDBHybridSearchNode, "_release_async_client"
+        ) as release_client:
+            node._ensure_async_collection()
+
+    release_client.assert_called_once()
+    get_client.assert_called_once_with("new-connection")
+    assert node._async_client is replacement_client
+    assert node._async_client_key == "new-connection"
+    assert node._async_collection is replacement_collection
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "exception, message",
@@ -325,6 +407,36 @@ async def test_run_translates_pymongo_errors(
 
     with pytest.raises(RuntimeError, match=message):
         await node.run(state, RunnableConfig())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exception, message",
+    [
+        (AutoReconnect("test"), "MongoDB network error"),
+        (OperationFailure("auth", 13), "MongoDB authentication/authorization error"),
+        (OperationFailure("other", 1), "MongoDB operation error"),
+        (ConfigurationError("bad"), "MongoDB configuration error"),
+        (PyMongoError("generic"), "MongoDB error during"),
+        (
+            ServerSelectionTimeoutError("timeout"),
+            "MongoDB network error",
+        ),
+    ],
+)
+async def test_execute_async_operation_translates_pymongo_errors(
+    exception: Exception,
+    message: str,
+) -> None:
+    node = _build_hybrid_search()
+
+    async def _operation() -> Any:
+        raise exception
+
+    with pytest.raises(RuntimeError, match=message):
+        await node._execute_async_operation(
+            context="hybrid search", operation=_operation
+        )
 
 
 def test_update_many_requires_filter_and_update() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2875,6 +2875,18 @@ wheels = [
 ]
 
 [[package]]
+name = "motor"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymongo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ae/96b88362d6a84cb372f7977750ac2a8aed7b2053eed260615df08d5c84f4/motor-3.7.1.tar.gz", hash = "sha256:27b4d46625c87928f331a6ca9d7c51c2f518ba0e270939d395bc1ddc89d64526", size = 280997 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/9a/35e053d4f442addf751ed20e0e922476508ee580786546d699b0567c4c67/motor-3.7.1-py3-none-any.whl", hash = "sha256:8a63b9049e38eeeb56b4fdd57c3312a6d1f25d01db717fe7d82222393c410298", size = 74996 },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3463,6 +3475,7 @@ dependencies = [
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "mcp", extra = ["cli"] },
+    { name = "motor" },
     { name = "openai" },
     { name = "openai-chatkit" },
     { name = "opentelemetry-api" },
@@ -3535,6 +3548,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
+    { name = "motor", specifier = ">=3.6.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "openai-chatkit", specifier = ">=1.4.0" },
     { name = "opentelemetry-api", specifier = ">=1.26.0" },


### PR DESCRIPTION
## Summary
This PR refactors MongoDB hybrid search execution to use async Motor clients/cursors, adds shared async client lifecycle management, and expands tests for async behavior and error handling.

## Main Changes
- Added `motor>=3.6.0` dependency and lockfile updates:
  - `/Users/shaojiejiang/Development/orcheo/pyproject.toml`
  - `/Users/shaojiejiang/Development/orcheo/uv.lock`
- Extended MongoDB base client node with async client support:
  - shared async client cache + reference counting
  - async collection initialization and connection-switch handling
  - async operation wrapper with MongoDB error translation parity
  - async client cleanup in destructor and `atexit` hook
  - file: `/Users/shaojiejiang/Development/orcheo/src/orcheo/nodes/integrations/databases/mongodb/base.py`
- Updated `MongoDBHybridSearchNode` to run fully asynchronously:
  - switched from sync collection usage to async collection
  - replaced `list(collection.aggregate(...))` with `await cursor.to_list(length=top_k)`
  - updated node metadata/description to reflect async behavior
  - file: `/Users/shaojiejiang/Development/orcheo/src/orcheo/nodes/integrations/databases/mongodb/search.py`
- Expanded test coverage for async client and async hybrid search paths:
  - async shared-client lifecycle tests
  - async collection reinitialization tests
  - async operation error translation tests
  - hybrid search async execution/pipeline assertions
  - files:
    - `/Users/shaojiejiang/Development/orcheo/tests/nodes/test_mongodb_helpers.py`
    - `/Users/shaojiejiang/Development/orcheo/tests/nodes/test_mongodb_search_nodes.py`

## Impact
- Aligns hybrid search execution with async runtime patterns.
- Improves connection reuse and cleanup for async MongoDB clients.
- Hardens reliability through broader tests around async error handling and execution flow.
