### PR TITLE
Fix canvas npm ci failure by syncing lockfile package versions

### DIFF
--- a/apps/canvas/package-lock.json
+++ b/apps/canvas/package-lock.json
@@ -8962,7 +8962,7 @@
       }
     },
     "node_modules/esbuild-plugin-globals": {
-      "version": "0.3.0",
+      "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/esbuild-plugin-globals/-/esbuild-plugin-globals-0.2.0.tgz",
       "integrity": "sha512-y+6utQVWrETQWs0J8EGLV5gEOP59mmjX+fKWoQHn4TYwFMaj0FxQYflc566tHuokBCzl+uNW2iIlM1o1jfNy6w==",
       "license": "MIT",
@@ -16894,7 +16894,7 @@
       }
     },
     "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.3.0",
+      "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,


### PR DESCRIPTION
### Motivation
- CI `npm ci` failed for the Canvas app because `package-lock.json` contained `version` fields that did not match the resolved tarballs, causing strict lockfile validation to error with EUSAGE.

### Description
- Updated `apps/canvas/package-lock.json` to correct two mismatched `version` fields: `node_modules/esbuild-plugin-globals` changed from `0.3.0` to `0.2.0` and `node_modules/tough-cookie/node_modules/universalify` changed from `0.3.0` to `0.2.0` to match their resolved artifacts.
- No changes were made to `apps/canvas/package.json` or source code; this is a lockfile fix to restore install determinism for CI.

### Testing
- Ran `npm ci` in `apps/canvas` and the install now completes successfully (previous `npm ci` showed EUSAGE due to the mismatch). 
- Ran `make canvas-format` which completed without error. 
- Ran `make canvas-lint` which completed without error. 
- Ran `npm --prefix apps/canvas run test -- --run src/App.test.tsx` and the targeted test suite passed (1 test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699953ef670483278334e68ad6a73b18)