### PR TITLE
Move stack distribution to GHCR images and update CLI setup/startup flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,19 +179,45 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/stack-v')"
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build stack archive
+      - name: Determine stack image metadata
+        id: stack
         run: |
-          tar -czf orcheo-stack.tar.gz -C deploy/stack .
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#stack-v}"
+          if [[ "$version" == "$tag" || -z "$version" ]]; then
+            echo "Invalid stack tag: $tag" >&2
+            exit 1
+          fi
+          image_repo=$(printf '%s' "ghcr.io/${GITHUB_REPOSITORY_OWNER}/orcheo-stack" | tr '[:upper:]' '[:lower:]')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${image_repo}" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          files: orcheo-stack.tar.gz
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push stack image
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/stack
+          file: deploy/stack/Dockerfile.orcheo
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.stack.outputs.image_repo }}:${{ steps.stack.outputs.version }}
+            ${{ steps.stack.outputs.image_repo }}:latest
 
   canvas:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Orcheo is a workflow orchestration platform designed for vibe coding — AI codi
 
 Use the installation path that matches your setup:
 
-> Prerequisite: Docker Desktop/Engine must be installed to run the local stack (`orcheo install --start-local-stack`).
+> Prerequisite: Docker Desktop/Engine must be installed to run the stack (`orcheo install --start-stack`).
 
 <details open>
 <summary>macOS/Linux (bootstrap)</summary>
@@ -35,8 +35,8 @@ curl -fsSL https://ai-colleagues.com/install.sh | sh
 ```
 
 ```bash
-# Unattended full local stack from scratch
-curl -fsSL https://ai-colleagues.com/install.sh | sh -s -- --yes --start-local-stack
+# Unattended full stack from scratch
+curl -fsSL https://ai-colleagues.com/install.sh | sh -s -- --yes --start-stack
 ```
 
 </details>

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -8,6 +8,9 @@ ORCHEO_VAULT_ENCRYPTION_KEY=replace-with-64-hex-chars
 VITE_ORCHEO_CHATKIT_DOMAIN_KEY=domain_pk_replace_me
 ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=change-me
 
+# Optional: pin stack runtime image (backend/worker/celery-beat).
+# ORCHEO_STACK_IMAGE=ghcr.io/shaojiejiang/orcheo-stack:0.1.0
+
 # Optional defaults
 ORCHEO_POSTGRES_USER=orcheo
 ORCHEO_POSTGRES_DB=orcheo

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -33,10 +33,7 @@ services:
       retries: 5
 
   backend:
-    image: orcheo-app:local
-    build:
-      context: .
-      dockerfile: Dockerfile.orcheo
+    image: ${ORCHEO_STACK_IMAGE:-ghcr.io/shaojiejiang/orcheo-stack:latest}
     env_file: .env
     ports:
       - "8000:8000"
@@ -69,10 +66,7 @@ services:
     command: python -m uvicorn orcheo_backend.app:app --host 0.0.0.0 --port 8000
 
   worker:
-    image: orcheo-app:local
-    build:
-      context: .
-      dockerfile: Dockerfile.orcheo
+    image: ${ORCHEO_STACK_IMAGE:-ghcr.io/shaojiejiang/orcheo-stack:latest}
     env_file: .env
     volumes:
       - orcheo_data:/data
@@ -101,10 +95,7 @@ services:
     command: python -m celery -A orcheo_backend.worker.celery_app worker --loglevel=info
 
   celery-beat:
-    image: orcheo-app:local
-    build:
-      context: .
-      dockerfile: Dockerfile.orcheo
+    image: ${ORCHEO_STACK_IMAGE:-ghcr.io/shaojiejiang/orcheo-stack:latest}
     env_file: .env
     volumes:
       - orcheo_data:/data

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -95,11 +95,11 @@ This installs completion for your current shell (bash, zsh, fish, or PowerShell)
 | `orcheo install [--yes] [--mode install\|upgrade] [--stack-version <version>] [--auth-mode api-key\|oauth] [--chatkit-domain-key <key>]` | Guided Docker-stack setup/upgrade (asset sync, `.env` updates, optional compose startup). |
 | `orcheo install upgrade [--yes] [--stack-version <version>] [--auth-mode api-key\|oauth] [--chatkit-domain-key <key>]` | Guided upgrade shortcut command. |
 
-`orcheo install` syncs local stack assets into `~/.orcheo/stack` (or
+`orcheo install` syncs stack assets into `~/.orcheo/stack` (or
 `ORCHEO_STACK_DIR`). Files are refreshed when upstream content differs.
 Use `--stack-version` (or `ORCHEO_STACK_VERSION`) to pin stack assets to a
-specific `stack-v*` release.
-When startup is enabled (`--start-local-stack`), setup then runs Docker Compose
+specific `stack-v*` tag and set `ORCHEO_STACK_IMAGE` accordingly.
+When startup is enabled (`--start-stack`), setup then runs Docker Compose
 (Docker must be installed). Setup also prompts for
 `VITE_ORCHEO_CHATKIT_DOMAIN_KEY`; you can skip and continue, but ChatKit UI
 features stay disabled until the key is set.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -142,7 +142,8 @@ Note: `ORCHEO_REPOSITORY_BACKEND=inmemory` stores runs in-process only and does 
 | `ORCHEO_DISABLE_UPDATE_CHECK` | _unset_ | Boolean (`1/0`, `true/false`, `yes/no`, `on/off`) | Disables startup update reminders in the CLI (`cli/main.py`). |
 | `ORCHEO_STACK_DIR` | `~/.orcheo/stack` | Directory path | Target directory for `orcheo install` stack assets and generated `.env` updates (`cli/setup.py`). |
 | `ORCHEO_STACK_VERSION` | _unset_ | Stack release version string (for example `0.1.0`) | Pins `orcheo install` to a specific `stack-v*` release when `--stack-version` is not provided (`cli/setup.py`). |
-| `ORCHEO_STACK_ASSET_BASE_URL` | _unset_ | HTTP(S) URL | Optional custom mirror base URL for per-file stack asset downloads. When set, it forces per-file sync mode and bypasses release archive downloads (`cli/setup.py`). |
+| `ORCHEO_STACK_IMAGE` | `ghcr.io/shaojiejiang/orcheo-stack:latest` | Container image reference | Runtime image used by `deploy/stack/docker-compose.yml` for backend/worker/celery-beat services. `orcheo install --stack-version` sets this value in `.env` (`cli/setup.py`). |
+| `ORCHEO_STACK_ASSET_BASE_URL` | _unset_ | HTTP(S) URL | Optional custom mirror base URL for per-file stack asset downloads. When set, `orcheo install` skips GitHub tag discovery and downloads stack assets from this mirror (`cli/setup.py`). |
 | `ORCHEO_SETUP_HEALTH_POLL_TIMEOUT_SECONDS` | `60` | Integer ≥ 0 | Timeout window used by `orcheo install` when waiting for `docker compose` backend health checks (`cli/setup.py`). |
 | `ORCHEO_AUTH_ISSUER` | _none_ | OIDC issuer URL | OAuth issuer URL for CLI browser-based login. Can also be set in a `cli.toml` profile via `auth_issuer` (`cli/auth/config.py`). |
 | `ORCHEO_AUTH_CLIENT_ID` | _none_ | String | OAuth client ID for CLI login. Can also be set in a `cli.toml` profile via `auth_client_id` (`cli/auth/config.py`). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Orcheo is a workflow orchestration platform designed for vibe coding — AI codi
 
 Use the installation path that matches your setup:
 
-> Prerequisite: Docker Desktop/Engine must be installed to run the local stack (`orcheo install --start-local-stack`).
+> Prerequisite: Docker Desktop/Engine must be installed to run the stack (`orcheo install --start-stack`).
 
 === "macOS/Linux (bootstrap)"
 
@@ -47,11 +47,11 @@ Use the installation path that matches your setup:
 === "Scripts/CI (non-interactive)"
 
     ```bash
-    orcheo install --yes --start-local-stack
-    orcheo install upgrade --yes --start-local-stack
+    orcheo install --yes --start-stack
+    orcheo install upgrade --yes --start-stack
     ```
 
-`orcheo install` syncs local stack assets into `~/.orcheo/stack` (or
+`orcheo install` syncs stack assets into `~/.orcheo/stack` (or
 `ORCHEO_STACK_DIR`), updates `.env` with setup-selected values, and can start
 the stack with Docker Compose. Setup prompts for
 `VITE_ORCHEO_CHATKIT_DOMAIN_KEY`; you can skip and continue, but ChatKit UI

--- a/docs/manual_setup.md
+++ b/docs/manual_setup.md
@@ -5,7 +5,7 @@ This guide covers manual installation and configuration of Orcheo for users who 
 ## Quick Start
 
 For one-line installation, see the [Quick Start section on the landing page](index.md#quick-start).
-If you already have the SDK installed, run `orcheo install` to set up or upgrade the local stack.
+If you already have the SDK installed, run `orcheo install` to set up or upgrade the stack.
 
 ## Prerequisites
 
@@ -19,9 +19,9 @@ For a complete containerized setup with PostgreSQL, Redis, Celery workers, and C
 
 ### Quick Start
 
-1. **Set up the local stack** using the CLI (this downloads compose files and creates `.env` automatically):
+1. **Set up the stack** using the CLI (this downloads compose files and creates `.env` automatically):
    ```bash
-   orcheo install --start-local-stack
+   orcheo install --start-stack
    ```
 
    The CLI syncs stack assets to `~/.orcheo/stack` (override with `ORCHEO_STACK_DIR`).
@@ -54,8 +54,8 @@ docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DI
 # Stop all services
 docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" down
 
-# Rebuild after changes (--no-cache ensures fresh builds with latest PyPI packages)
-docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" build --no-cache
+# Refresh to the latest published stack image
+docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" pull
 docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" up -d
 ```
 
@@ -128,7 +128,7 @@ For detailed authentication setup including bootstrap tokens, service tokens, an
 If setup/upgrade is interrupted:
 
 1. Re-run `orcheo install` (idempotent reconciliation is the default path).
-2. If local stack services are inconsistent, run:
+2. If stack services are inconsistent, run:
    `STACK_DIR="${ORCHEO_STACK_DIR:-$HOME/.orcheo/stack}"` then
    `docker compose -f "$STACK_DIR/docker-compose.yml" --project-directory "$STACK_DIR" down`
    and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,15 +1,15 @@
 # Releasing Orcheo Packages
 
 This repository now publishes three Python distributions independently, plus a
-versioned local-stack archive release:
+versioned stack container image release:
 
 - `orcheo` – core orchestration engine (`core-v*` tags)
 - `orcheo-sdk` – Python SDK helpers (`sdk-v*` tags)
 - `orcheo-backend` – deployable FastAPI wrapper (`backend-v*` tags)
-- `orcheo-stack.tar.gz` – local stack assets (`stack-v*` tags)
+- `ghcr.io/shaojiejiang/orcheo-stack` – stack runtime image (`stack-v*` tags)
 
 The `build-and-release` and `stack-release` jobs inside
-`.github/workflows/ci.yml` publish the matching package/archive whenever a tag
+`.github/workflows/ci.yml` publish the matching package/image whenever a tag
 with the corresponding prefix is pushed. Follow the steps below to prepare and
 cut a release.
 
@@ -51,11 +51,12 @@ cut a release.
 | `orcheo`         | `core-vX.Y.Z`|
 | `orcheo-backend` | `backend-vX.Y.Z` |
 | `orcheo-sdk`     | `sdk-vX.Y.Z` |
-| local stack archive | `stack-vX.Y.Z` |
+| stack image | `stack-vX.Y.Z` |
 
 CI automatically runs checks, then executes `build-and-release` for Python tags
-or `stack-release` for stack tags. The stack release job publishes a GitHub
-Release asset named `orcheo-stack.tar.gz`.
+or `stack-release` for stack tags. The stack release job publishes
+`ghcr.io/shaojiejiang/orcheo-stack:<version>` and
+`ghcr.io/shaojiejiang/orcheo-stack:latest`.
 
 ## Package-specific Notes
 ### orcheo (core)
@@ -74,7 +75,7 @@ Release asset named `orcheo-stack.tar.gz`.
 2. Update SDK documentation or examples if interfaces changed.
 3. Push the release commit and tag: `git push origin HEAD && git push origin sdk-vX.Y.Z`.
 
-### local stack archive
+### stack image
 1. Run `(cd deploy/stack && bump2version <part>)` to create `stack-vX.Y.Z`.
 2. Ensure `deploy/stack/` contains the intended compose and widget assets.
 3. Push the release commit and tag: `git push origin HEAD && git push origin stack-vX.Y.Z`.

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -220,7 +220,7 @@ def _run_install_flow(
     auth_mode: str | None,
     api_key: str | None,
     chatkit_domain_key: str | None,
-    start_local_stack: bool | None,
+    start_stack: bool | None,
     install_docker: bool | None,
     manual_secrets: bool,
     forced_mode: SetupMode | None = None,
@@ -234,7 +234,7 @@ def _run_install_flow(
         auth_mode=auth_value,
         api_key=api_key,
         chatkit_domain_key=chatkit_domain_key,
-        start_local_stack=start_local_stack,
+        start_stack=start_stack,
         install_docker=install_docker,
         yes=yes,
         manual_secrets=manual_secrets,
@@ -291,10 +291,10 @@ def install_command(
             ),
         ),
     ] = None,
-    start_local_stack: Annotated[
+    start_stack: Annotated[
         bool | None,
         typer.Option(
-            "--start-local-stack/--skip-local-stack",
+            "--start-stack/--skip-stack",
             help="Start or skip docker compose stack startup after syncing assets.",
         ),
     ] = None,
@@ -325,7 +325,7 @@ def install_command(
         auth_mode=auth_mode,
         api_key=api_key,
         chatkit_domain_key=chatkit_domain_key,
-        start_local_stack=start_local_stack,
+        start_stack=start_stack,
         install_docker=install_docker,
         manual_secrets=manual_secrets,
     )
@@ -369,10 +369,10 @@ def install_upgrade_command(
             ),
         ),
     ] = None,
-    start_local_stack: Annotated[
+    start_stack: Annotated[
         bool | None,
         typer.Option(
-            "--start-local-stack/--skip-local-stack",
+            "--start-stack/--skip-stack",
             help="Start or skip docker compose stack startup after syncing assets.",
         ),
     ] = None,
@@ -401,7 +401,7 @@ def install_upgrade_command(
         auth_mode=auth_mode,
         api_key=api_key,
         chatkit_domain_key=chatkit_domain_key,
-        start_local_stack=start_local_stack,
+        start_stack=start_stack,
         install_docker=install_docker,
         manual_secrets=manual_secrets,
         forced_mode="upgrade",

--- a/project/initiatives/stack_installation/1_requirements.md
+++ b/project/initiatives/stack_installation/1_requirements.md
@@ -39,7 +39,7 @@ Ship a single guided setup/upgrade command so users can install or upgrade Orche
 | CLI user | receive update reminders on CLI use, at most once per 24 hours | I stay up to date without noisy output | P0 | Update checks run only when CLI commands are invoked, and at most once every 24h |
 
 ### Context, Problems, Opportunities
-Current setup historically relied on manual steps and guide-following. The current canonical bootstrap path and guided CLI flow improve this, but documentation and implementation need to stay aligned around one source of truth for local-stack assets and startup behavior. Canvas currently does not expose its own version and connected backend version side-by-side, and CLI has no periodic update reminder flow. This creates avoidable support load and version skew between `orcheo-sdk`, `orcheo-backend`, and `orcheo-canvas`.
+Current setup historically relied on manual steps and guide-following. The current canonical bootstrap path and guided CLI flow improve this, but documentation and implementation need to stay aligned around one source of truth for stack assets and startup behavior. Canvas currently does not expose its own version and connected backend version side-by-side, and CLI has no periodic update reminder flow. This creates avoidable support load and version skew between `orcheo-sdk`, `orcheo-backend`, and `orcheo-canvas`.
 
 ### Product goals and Non-goals
 Goals:
@@ -61,13 +61,13 @@ P0 installation flow:
 - Keep install/upgrade orchestration logic in a single CLI implementation (bootstrap only handles environment detection, prerequisite setup, and handoff).
 - Windows support is P1 for full validation/hardening; a PowerShell bootstrap entrypoint exists and follows the same thin handoff pattern.
 - Support two primary modes: fresh install and in-place upgrade.
-- Prompt for key inputs with defaults (backend URL, auth mode, optional local stack start). Supported auth modes (e.g., API key, OAuth) and credential handling during setup should be defined in the design doc.
-- For secrets that can be safely generated on the local machine (for example, local stack `SECRET_KEY` values), setup should default to generating them for the user. Prompt for manual entry only when required by explicit user choice or external integration constraints.
+- Prompt for key inputs with defaults (backend URL, auth mode, optional stack start). Supported auth modes (e.g., API key, OAuth) and credential handling during setup should be defined in the design doc.
+- For secrets that can be safely generated on the local machine (for example, stack `SECRET_KEY` values), setup should default to generating them for the user. Prompt for manual entry only when required by explicit user choice or external integration constraints.
 - Support non-interactive mode (`--yes` + flags) for CI/scripts.
 - Validate prerequisites and print actionable remediation (Docker for stack startup).
 - If `uv` is missing, bootstrap should install it (or provide exact install commands) and continue.
 - If Docker is missing, prompt users to either install Docker (default choice) or skip Docker-dependent steps when they plan to use a remote backend. Without Docker, users can still install and use the CLI and SDK against a remote backend; local full-stack mode (backend + Canvas + Redis + worker) requires Docker.
-- For local full-stack startup, provision required compose assets from a canonical source (`deploy/stack/`) into a user-local stack directory (default `~/.orcheo/stack`) before running Docker Compose.
+- For local full-stack startup, provision required compose assets from a canonical source (`deploy/stack/`) into a user-managed stack directory (default `~/.orcheo/stack`) before running Docker Compose.
 - Allow stack asset source and target overrides via environment variables (`ORCHEO_STACK_ASSET_BASE_URL`, `ORCHEO_STACK_DIR`) for mirrors and custom environments.
 - Be idempotent: rerunning should reconcile state safely rather than duplicate/conflict.
 - End with a summary that includes synced stack location, `.env` path, and next commands.
@@ -115,7 +115,7 @@ Use a shared version metadata contract exposed by backend and consumed by Canvas
   - Unix shell bootstrap (`sh`) as the only P0 bootstrap entrypoint.
   - Windows PowerShell bootstrap is P1.
   - Bootstrap remains thin and delegates install/upgrade decisions to CLI flow.
-- Local stack assets:
+- Stack assets:
   - Source-of-truth assets are stored in-repo under `deploy/stack/`.
   - Setup downloads missing assets from a configurable raw content base URL into
     `ORCHEO_STACK_DIR` (default `~/.orcheo/stack`) before compose startup.
@@ -177,4 +177,4 @@ Risk Mitigation:
 
 ## APPENDIX
 - Canonical bootstrap entrypoint: `https://ai-colleagues.com/install.sh`
-- Canonical local-stack asset path: `deploy/stack/`
+- Canonical stack asset path: `deploy/stack/`

--- a/project/initiatives/stack_installation/2_design.md
+++ b/project/initiatives/stack_installation/2_design.md
@@ -33,10 +33,10 @@ The implementation uses a shared backend metadata contract for installed/latest 
   - Handles prerequisite checks, prompt collection, install/upgrade execution, and summary output.
   - Key dependencies: existing CLI config/state modules, shell command runner, package managers (uv/npm).
 
-- **Local Stack Asset Bundle (`deploy/stack/`)**
+- **Stack Asset Bundle (`deploy/stack/`)**
   - Stores source-of-truth compose assets (`docker-compose.yml`, `Dockerfile.orcheo`,
     `.env.example`, `chatkit_widgets/*`).
-  - Consumed by setup flow via raw-content download into a user-local stack directory
+  - Consumed by setup flow via raw-content download into a user-managed stack directory
     (`ORCHEO_STACK_DIR`, default `~/.orcheo/stack`).
   - Key dependencies: GitHub raw delivery (or mirror override via `ORCHEO_STACK_ASSET_BASE_URL`).
 
@@ -62,18 +62,18 @@ The implementation uses a shared backend metadata contract for installed/latest 
 1. User runs `orcheo install` (or bootstrap equivalent).
 2. Bootstrap (if used) ensures `uv` exists; if missing, it installs `uv` or prints exact
    install commands and retries handoff.
-3. CLI checks prerequisites (Docker for local stack startup).
+3. CLI checks prerequisites (Docker for stack startup).
 4. CLI prompts for mode and key inputs, defaulting sensible values on Enter.
    - Mode: fresh install or in-place upgrade.
    - Backend URL.
    - Auth mode.
-   - Optional local stack startup.
+   - Optional stack startup.
    - If Docker is missing: default prompt is to install Docker, with explicit skip option for
      remote-backend-only usage.
 4. CLI performs install or upgrade steps:
-   - Local-stack asset bootstrap/sync (`deploy/stack` -> `ORCHEO_STACK_DIR`)
+   - Stack asset bootstrap/sync (`deploy/stack` -> `ORCHEO_STACK_DIR`)
    - `.env` reconciliation with setup-selected values
-   - Optional `docker compose ... up -d --build` against the provisioned stack directory
+   - Optional `docker compose ... pull` then `docker compose ... up -d` against the provisioned stack directory
 5. In upgrade mode, CLI reconciles state idempotently and preserves existing configuration.
 6. CLI validates resulting versions and backend reachability (if configured).
 7. CLI prints summary and next steps.
@@ -229,7 +229,7 @@ Behavior:
 Feature flags/config:
 - `ORCHEO_DISABLE_UPDATE_CHECK=1` disables CLI update reminders.
 - `ORCHEO_UPDATE_CHECK_TTL_HOURS` controls backend cache/check windows.
-- `ORCHEO_STACK_DIR` controls local stack project directory for compose assets.
+- `ORCHEO_STACK_DIR` controls stack project directory for compose assets.
 - `ORCHEO_STACK_ASSET_BASE_URL` controls raw asset source for stack provisioning.
 
 ## P1 Extensions

--- a/project/initiatives/stack_installation/3_plan.md
+++ b/project/initiatives/stack_installation/3_plan.md
@@ -33,7 +33,7 @@ Deliver a guided single-command setup/upgrade experience, plus version awareness
   - Dependencies: Task 1.1
 - [x] Task 1.3: Implement prerequisite checks and actionable error messaging
   - Dependencies: Task 1.1
-- [x] Task 1.4: Implement guided prompts (install/upgrade mode, backend URL, auth mode, optional local stack start)
+- [x] Task 1.4: Implement guided prompts (install/upgrade mode, backend URL, auth mode, optional stack start)
   - Dependencies: Task 1.1
 - [x] Task 1.4a: Implement secret prompt behavior defaults (auto-generate locally for eligible secrets, explicit manual-entry opt-out)
   - Dependencies: Task 1.4
@@ -45,7 +45,7 @@ Deliver a guided single-command setup/upgrade experience, plus version awareness
   - Dependencies: Task 1.4
 - [x] Task 1.8: Add summary output with installed versions and next steps
   - Dependencies: Task 1.6
-- [x] Task 1.9: Provision local-stack compose assets from canonical repo path (`deploy/stack`) before Docker startup
+- [x] Task 1.9: Provision stack compose assets from canonical repo path (`deploy/stack`) before Docker startup
   - Dependencies: Tasks 1.2, 1.6
 
 ---
@@ -125,7 +125,7 @@ Deliver a guided single-command setup/upgrade experience, plus version awareness
   - Dependencies: Milestones 1, 2, 4
 - [x] Task 5.5: Update Canvas and CLI docs/screenshots for version/reminder UX
   - Dependencies: Milestones 3, 4
-- [x] Task 5.5a: Align setup docs and env-var docs with canonical local-stack asset source (`deploy/stack`) and override knobs
+- [x] Task 5.5a: Align setup docs and env-var docs with canonical stack asset source (`deploy/stack`) and override knobs
   - Dependencies: Milestone 1
 - [ ] Task 5.6: Run end-to-end QA matrix (fresh install, upgrade, stale version reminders)
   - Dependencies: Milestones 1, 3, 4

--- a/scripts/ubuntu-setup.sh
+++ b/scripts/ubuntu-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Purpose: Bootstrap an Ubuntu machine for Orcheo by installing required packages
 # (Docker, cloudflared), enabling Docker, installing cloudflared as a service,
-# running Orcheo setup for a local stack, and configuring Bash history/search ergonomics.
+# running Orcheo setup for a stack, and configuring Bash history/search ergonomics.
 # Requirement: Set CLOUDFLARED_TOKEN in the environment before running.
 
 set -euo pipefail
@@ -82,22 +82,22 @@ install_uv_and_orcheo_sdk() {
   uv tool install -U orcheo-sdk
 }
 
-setup_local_stack() {
+setup_stack() {
   if [[ -n "${ORCHEO_STACK_ASSET_BASE_URL:-}" ]]; then
     export ORCHEO_STACK_ASSET_BASE_URL
   fi
   if id -nG "$USER" | grep -qw docker; then
-    sg docker -c "orcheo install --yes --start-local-stack"
+    sg docker -c "orcheo install --yes --start-stack"
     return
   fi
-  orcheo install --yes --start-local-stack
+  orcheo install --yes --start-stack
 }
 
 main() {
   install_dependencies
   install_cloudflared
   install_uv_and_orcheo_sdk
-  setup_local_stack
+  setup_stack
   configure_bash_history
 }
 

--- a/tests/sdk/test_cli_setup.py
+++ b/tests/sdk/test_cli_setup.py
@@ -22,7 +22,7 @@ def test_install_command_non_interactive_defaults(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key=None,
-            start_local_stack=True,
+            start_stack=True,
             install_docker_if_missing=True,
         )
 
@@ -66,7 +66,7 @@ def test_install_command_respects_no_update_check(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key=None,
-            start_local_stack=True,
+            start_stack=True,
             install_docker_if_missing=True,
         ),
     )
@@ -99,7 +99,7 @@ def test_install_upgrade_subcommand_forces_upgrade(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key=None,
-            start_local_stack=True,
+            start_stack=True,
             install_docker_if_missing=True,
         )
 
@@ -132,7 +132,7 @@ def test_install_command_passes_chatkit_domain_key(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key="domain_pk_test",
-            start_local_stack=False,
+            start_stack=False,
             install_docker_if_missing=True,
         )
 
@@ -176,7 +176,7 @@ def test_install_command_passes_stack_version(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key=None,
-            start_local_stack=False,
+            start_stack=False,
             install_docker_if_missing=True,
         ),
     )
@@ -214,7 +214,7 @@ def test_install_upgrade_command_passes_stack_version(
             auth_mode="api-key",
             api_key="generated",
             chatkit_domain_key=None,
-            start_local_stack=False,
+            start_stack=False,
             install_docker_if_missing=True,
         ),
     )


### PR DESCRIPTION
## Summary
This PR migrates Orcheo stack delivery from release tarballs to published GHCR images, updates the SDK setup flow to consume stack-tagged assets directly, and aligns CLI/docs/scripts around the new stack startup semantics.

## What Changed
- Reworked stack release CI to build and push multi-arch container images to GHCR (`<version>` and `latest`) instead of publishing `orcheo-stack.tar.gz`.
- Updated stack compose services (`backend`, `worker`, `celery-beat`) to use `ORCHEO_STACK_IMAGE` (defaulting to `ghcr.io/shaojiejiang/orcheo-stack:latest`) rather than local image builds.
- Renamed CLI stack startup flags from:
  - `--start-local-stack/--skip-local-stack`
  to:
  - `--start-stack/--skip-stack`
- Refactored setup internals:
  - Removed archive download/extraction path.
  - Switched to per-file asset sync from `deploy/stack` raw URLs.
  - Added tag-based asset source resolution for `stack-v*` versions.
  - Switched latest-version discovery from GitHub Releases API to GitHub Tags API.
  - Skips prerelease-like versions when auto-discovering latest.
- Added/updated `.env` behavior:
  - `--stack-version` now sets `ORCHEO_STACK_IMAGE=ghcr.io/shaojiejiang/orcheo-stack:<version>`.
  - Added `ORCHEO_STACK_IMAGE` documentation and `.env.example` comments.
- Changed startup behavior from local rebuilds to image refresh:
  - `docker compose pull`
  - `docker compose up -d`
- Updated install docs, release docs, quickstart examples, ubuntu bootstrap script, and initiative docs to use “stack” terminology and new flags/flow.
- Updated SDK tests to reflect:
  - new flag names,
  - tag-based stack asset resolution,
  - `ORCHEO_STACK_IMAGE` env updates,
  - `pull + up` startup behavior,
  - removal of archive-extraction paths/tests.

## Why
This unifies stack distribution around versioned container images, removes archive extraction complexity, improves reproducibility across architectures, and aligns user-facing setup commands/docs with the current deployment model.

## Impact
- **User-facing CLI change:** `--start-local-stack` is replaced by `--start-stack`.
- **Operational change:** stack runtime now defaults to pulling GHCR images instead of building local backend/worker images during setup.
