### PR TITLE
Add orcheo stack CLI command for common Docker Compose actions with tests

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -276,11 +276,19 @@ def _stack_compose_base_args() -> list[str]:
     ]
 
 
-def _run_stack_command(command: list[str], *, console: Console) -> None:
+def _run_stack_command(
+    command: list[str],
+    *,
+    console: Console,
+    expected_exit_codes: set[int] | None = None,
+) -> None:
+    if expected_exit_codes is None:
+        expected_exit_codes = {0}
+
     command_text = " ".join(command)
     console.print(f"[cyan]$ {command_text}[/cyan]")
     result = subprocess.run(command, check=False)
-    if result.returncode != 0:
+    if result.returncode not in expected_exit_codes:
         raise typer.BadParameter(
             f"Command failed with exit code {result.returncode}: {command_text}"
         )
@@ -520,6 +528,7 @@ def stack_command(
     _run_stack_command(
         command_by_action[action],
         console=_resolve_install_console(ctx),
+        expected_exit_codes={0, 130} if action == "logs" else {0},
     )
 
 

--- a/tests/sdk/test_cli_stack.py
+++ b/tests/sdk/test_cli_stack.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from typing import Any
-from orcheo_sdk.cli.main import app
+import pytest
+import typer
+from rich.console import Console
+from orcheo_sdk.cli.main import (
+    _resolve_stack_project_dir,
+    _run_stack_command,
+    app,
+)
 
 
 def _stack_env(base_env: dict[str, str], stack_dir: Path) -> dict[str, str]:
@@ -217,3 +224,68 @@ def test_stack_requires_docker_binary(
 
     assert result.exit_code == 2
     assert called["value"] is False
+
+
+# ------------------------------------------------------------------
+# Coverage for previously-uncovered lines
+# ------------------------------------------------------------------
+
+
+def test_resolve_stack_project_dir_defaults_to_home(
+    monkeypatch: Any,
+) -> None:
+    """When ORCHEO_STACK_DIR is unset, fall back to ~/.orcheo/stack."""
+    monkeypatch.delenv("ORCHEO_STACK_DIR", raising=False)
+    result = _resolve_stack_project_dir()
+    assert result == Path.home() / ".orcheo" / "stack"
+
+
+def test_run_stack_command_defaults_expected_exit_codes(
+    monkeypatch: Any,
+) -> None:
+    """expected_exit_codes defaults to {0} when not provided."""
+    executed: list[str] = []
+
+    def _run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        executed[:] = command
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.subprocess.run", _run)
+    _run_stack_command(["echo", "hello"], console=Console())
+    assert executed == ["echo", "hello"]
+
+
+def test_run_stack_command_raises_on_unexpected_exit_code(
+    monkeypatch: Any,
+) -> None:
+    """Non-zero exit code not in expected set raises BadParameter."""
+
+    def _run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        return subprocess.CompletedProcess(command, 42)
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.subprocess.run", _run)
+    with pytest.raises(typer.BadParameter, match="exit code 42"):
+        _run_stack_command(["false"], console=Console())
+
+
+def test_stack_no_action_raises_error(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Invoking stack without any action flag shows an error."""
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 2

--- a/tests/sdk/test_cli_stack.py
+++ b/tests/sdk/test_cli_stack.py
@@ -1,0 +1,179 @@
+"""Tests for ``orcheo stack`` shortcuts."""
+
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from typing import Any
+from orcheo_sdk.cli.main import app
+
+
+def _stack_env(base_env: dict[str, str], stack_dir: Path) -> dict[str, str]:
+    env = dict(base_env)
+    env["ORCHEO_STACK_DIR"] = str(stack_dir)
+    return env
+
+
+def test_stack_logs_shortcut_runs_compose_logs_follow(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    executed: list[str] = []
+
+    def _run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        executed[:] = command
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.subprocess.run", _run)
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack", "--logs"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 0
+    assert executed == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+        "logs",
+        "-f",
+    ]
+
+
+def test_stack_start_shortcut_runs_compose_up_detached(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    executed: list[str] = []
+
+    def _run(command: list[str], *, check: bool) -> subprocess.CompletedProcess[str]:
+        del check
+        executed[:] = command
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("orcheo_sdk.cli.main.subprocess.run", _run)
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack", "--start"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 0
+    assert executed == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+        "up",
+        "-d",
+    ]
+
+
+def test_stack_rejects_multiple_actions(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
+    called = {"value": False}
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.main.subprocess.run",
+        lambda *args, **kwargs: (
+            called.__setitem__("value", True),
+            subprocess.CompletedProcess(args, 0),
+        )[1],
+    )
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack", "--logs", "--ps"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 2
+    assert called["value"] is False
+
+
+def test_stack_requires_existing_compose_file(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
+    called = {"value": False}
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.main.subprocess.run",
+        lambda *args, **kwargs: (
+            called.__setitem__("value", True),
+            subprocess.CompletedProcess(args, 0),
+        )[1],
+    )
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack", "--ps"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 2
+    assert called["value"] is False
+
+
+def test_stack_requires_docker_binary(
+    runner: Any,
+    env: dict[str, str],
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: None)
+    called = {"value": False}
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.main.subprocess.run",
+        lambda *args, **kwargs: (
+            called.__setitem__("value", True),
+            subprocess.CompletedProcess(args, 0),
+        )[1],
+    )
+
+    result = runner.invoke(
+        app,
+        ["--no-update-check", "stack", "--ps"],
+        env=_stack_env(env, stack_dir),
+    )
+
+    assert result.exit_code == 2
+    assert called["value"] is False


### PR DESCRIPTION
## Summary
This PR adds a new top-level CLI command, `orcheo stack`, to run common Docker Compose operations for the local Orcheo stack through simple flags.

### What changed
- Added `stack` command in `packages/sdk/src/orcheo_sdk/cli/main.py`
- Added stack directory resolution:
  - Uses `ORCHEO_STACK_DIR` if set
  - Falls back to `~/.orcheo/stack`
- Added compose command builder that:
  - Verifies `docker-compose.yml` exists
  - Uses `docker compose -f <compose-file> --project-directory <stack-dir> ...`
- Added command runner wrapper that:
  - Prints the exact command to the console
  - Raises a CLI error when the subprocess exits non-zero
- Added action flags (exactly one required):
  - `--logs` (`docker compose logs -f`)
  - `--start` (`docker compose up -d`)
  - `--stop` (`docker compose stop`)
  - `--restart` (`docker compose restart`)
  - `--ps` (`docker compose ps`)
  - `--pull` (`docker compose pull`)
  - `--down` (`docker compose down`)
- Added validation:
  - Docker binary must exist in `PATH`
  - Exactly one action flag must be provided
  - Compose file must exist before executing

## Tests
Added `tests/sdk/test_cli_stack.py` with coverage for:
- `--logs` invoking `docker compose logs -f`
- `--start` invoking `docker compose up -d`
- Rejecting multiple actions in one command
- Requiring an existing `docker-compose.yml`
- Requiring Docker binary availability

## Behavior impact
- Introduces a user-facing CLI shortcut for stack lifecycle and inspection tasks.
- Provides clearer preflight errors when stack prerequisites are missing.