### PR TITLE
Preserve existing backend URL values by default in orcheo install upgrade

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -161,6 +161,27 @@ def _normalize_optional_value(value: str | None) -> str | None:
     return normalized or None
 
 
+def _normalize_dotenv_value(value: str | None) -> str | None:
+    """Normalize a value read from a dotenv line.
+
+    This strips whitespace and unwraps matching single or double quotes.
+    """
+    normalized = _normalize_optional_value(value)
+    if normalized is None:
+        return None
+    if (
+        len(normalized) >= 2
+        and normalized[0] == normalized[-1]
+        and normalized[0]
+        in {
+            '"',
+            "'",
+        }
+    ):
+        normalized = normalized[1:-1].strip()
+    return normalized or None
+
+
 def _resolve_chatkit_domain_key(
     chatkit_domain_key: str | None,
     *,
@@ -378,8 +399,7 @@ def _read_env_value(env_file: Path, key: str) -> str | None:
         if not match or match.group(1) != key:
             continue
         _, _, value = line.partition("=")
-        stripped = value.strip()
-        return stripped or None
+        return _normalize_dotenv_value(value)
     return None
 
 

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -50,6 +50,7 @@ class SetupConfig:
     chatkit_domain_key: str | None
     start_stack: bool
     install_docker_if_missing: bool
+    preserve_existing_backend_url: bool = False
     stack_project_dir: str | None = None
     stack_env_file: str | None = None
 
@@ -77,12 +78,31 @@ def _resolve_mode(mode: SetupMode | None, *, yes: bool) -> SetupMode:
     return "upgrade" if selected == "upgrade" else "install"
 
 
-def _resolve_backend_url(backend_url: str | None, *, yes: bool) -> str:
+def _resolve_backend_url(
+    backend_url: str | None,
+    *,
+    mode: SetupMode,
+    yes: bool,
+) -> tuple[str, bool]:
+    default_backend_url = "http://localhost:8000"
     if backend_url:
-        return backend_url
+        return backend_url, False
+    if mode == "upgrade":
+        if yes:
+            return default_backend_url, True
+        selected = _normalize_optional_value(
+            typer.prompt(
+                "Backend URL (Enter to keep existing)",
+                default="",
+                show_default=False,
+            )
+        )
+        if selected is None:
+            return default_backend_url, True
+        return selected, False
     if yes:
-        return "http://localhost:8000"
-    return typer.prompt("Backend URL", default="http://localhost:8000")
+        return default_backend_url, False
+    return typer.prompt("Backend URL", default=default_backend_url), False
 
 
 def _resolve_auth_mode(auth_mode: AuthMode | None, *, yes: bool) -> AuthMode:
@@ -456,6 +476,19 @@ def _ensure_stack_assets(
         config,
         requested_stack_version=requested_stack_version,
     )
+    if (
+        config.mode == "upgrade"
+        and config.preserve_existing_backend_url
+        and not env_created
+    ):
+        preserved_orcheo_api_url = _read_env_value(env_file, "ORCHEO_API_URL")
+        if preserved_orcheo_api_url is not None:
+            updates.pop("ORCHEO_API_URL", None)
+            config.backend_url = preserved_orcheo_api_url
+
+        if _read_env_value(env_file, "VITE_ORCHEO_BACKEND_URL") is not None:
+            updates.pop("VITE_ORCHEO_BACKEND_URL", None)
+
     if env_created:
         # Fresh install: overwrite template placeholders with generated secrets.
         _upsert_env_values(env_file, updates, defaults=defaults, console=console)
@@ -487,7 +520,11 @@ def run_setup(
 ) -> SetupConfig:
     """Collect interactive/non-interactive setup options."""
     resolved_mode = _resolve_mode(mode, yes=yes)
-    resolved_backend_url = _resolve_backend_url(backend_url, yes=yes)
+    resolved_backend_url, preserve_existing_backend_url = _resolve_backend_url(
+        backend_url,
+        mode=resolved_mode,
+        yes=yes,
+    )
     resolved_auth_mode = _resolve_auth_mode(auth_mode, yes=yes)
     resolved_start_stack = _resolve_bool(
         start_stack,
@@ -523,6 +560,11 @@ def run_setup(
             "[cyan]Keeping existing API bootstrap token. "
             "Pass --api-key to rotate it.[/cyan]"
         )
+    if resolved_mode == "upgrade" and preserve_existing_backend_url:
+        console.print(
+            "[cyan]Keeping existing backend URL. "
+            "Pass --backend-url to update it.[/cyan]"
+        )
     if resolved_auth_mode == "oauth":
         console.print(
             "[yellow]OAuth mode selected. Configure ORCHEO_AUTH_ISSUER, "
@@ -538,6 +580,7 @@ def run_setup(
         chatkit_domain_key=resolved_chatkit_domain_key,
         start_stack=resolved_start_stack,
         install_docker_if_missing=resolved_install_docker,
+        preserve_existing_backend_url=preserve_existing_backend_url,
     )
 
 

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -278,6 +278,7 @@ def test_run_setup_upgrade_preserves_existing_api_key_by_default() -> None:
     assert config.mode == "upgrade"
     assert config.auth_mode == "api-key"
     assert config.api_key is None
+    assert config.preserve_existing_backend_url is True
 
 
 def test_run_setup_upgrade_honors_explicit_api_key() -> None:
@@ -327,6 +328,32 @@ def test_execute_setup_preserves_secrets_on_upgrade(
     assert "ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=my-signing-key" in env_content
     # Config updates still applied.
     assert "ORCHEO_API_URL=http://localhost:8000" in env_content
+
+
+def test_execute_setup_preserves_backend_urls_on_upgrade_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upgrade defaults should preserve existing backend URL values."""
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir(parents=True)
+    (stack_dir / ".env").write_text(
+        "ORCHEO_API_URL=http://existing-api.test\n"
+        "VITE_ORCHEO_BACKEND_URL=http://existing-vite.test\n",
+        encoding="utf-8",
+    )
+    _patch_common(monkeypatch, stack_dir=stack_dir, has_docker=False)
+
+    config = _setup_config()
+    config.mode = "upgrade"
+    config.start_stack = False
+    config.preserve_existing_backend_url = True
+    execute_setup(config, console=Console(record=True))
+
+    env_content = (stack_dir / ".env").read_text(encoding="utf-8")
+    assert "ORCHEO_API_URL=http://existing-api.test" in env_content
+    assert "VITE_ORCHEO_BACKEND_URL=http://existing-vite.test" in env_content
+    assert config.backend_url == "http://existing-api.test"
 
 
 def test_execute_setup_raises_when_asset_download_fails(
@@ -544,7 +571,20 @@ def test_setup_low_level_resolvers_and_command_errors(
     monkeypatch.setattr(setup_mod.typer, "prompt", lambda _p, default: "upgrade")
     assert setup_mod._resolve_mode(None, yes=False) == "upgrade"
     monkeypatch.setattr(setup_mod.typer, "prompt", lambda _p, default: "http://x")
-    assert setup_mod._resolve_backend_url(None, yes=False) == "http://x"
+    assert setup_mod._resolve_backend_url(None, mode="install", yes=False) == (
+        "http://x",
+        False,
+    )
+    monkeypatch.setattr(setup_mod.typer, "prompt", lambda *args, **kwargs: " ")
+    assert setup_mod._resolve_backend_url(None, mode="upgrade", yes=False) == (
+        "http://localhost:8000",
+        True,
+    )
+    monkeypatch.setattr(setup_mod.typer, "prompt", lambda *args, **kwargs: "http://u")
+    assert setup_mod._resolve_backend_url(None, mode="upgrade", yes=False) == (
+        "http://u",
+        False,
+    )
     monkeypatch.setattr(setup_mod.typer, "prompt", lambda _p, default: "oauth")
     assert setup_mod._resolve_auth_mode(None, yes=False) == "oauth"
     monkeypatch.setattr(setup_mod.typer, "confirm", lambda _p, default: False)

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -356,6 +356,29 @@ def test_execute_setup_preserves_backend_urls_on_upgrade_by_default(
     assert config.backend_url == "http://existing-api.test"
 
 
+def test_execute_setup_normalizes_quoted_backend_url_on_upgrade_preserve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserved backend URL should be unquoted before health checks and summary."""
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir(parents=True)
+    (stack_dir / ".env").write_text(
+        'ORCHEO_API_URL="https://api.example.com"\n'
+        'VITE_ORCHEO_BACKEND_URL="https://api.example.com"\n',
+        encoding="utf-8",
+    )
+    _patch_common(monkeypatch, stack_dir=stack_dir, has_docker=False)
+
+    config = _setup_config()
+    config.mode = "upgrade"
+    config.start_stack = False
+    config.preserve_existing_backend_url = True
+    execute_setup(config, console=Console(record=True))
+
+    assert config.backend_url == "https://api.example.com"
+
+
 def test_execute_setup_raises_when_asset_download_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
This PR changes `orcheo install upgrade` so that existing backend URL values in the stack `.env` are preserved when the user does not explicitly provide a new backend URL (including `--yes` runs).

## What Changed
- Updated upgrade backend URL resolution:
  - Interactive upgrade prompt now supports “Enter to keep existing”.
  - `--yes` + upgrade now preserves existing backend URL values unless `--backend-url` is explicitly passed.
- Added `preserve_existing_backend_url` to setup config to carry this intent through setup execution.
- Updated env upsert behavior during upgrade:
  - Do not overwrite `ORCHEO_API_URL` if preserving existing values and key already exists.
  - Do not overwrite `VITE_ORCHEO_BACKEND_URL` if preserving existing values and key already exists.
  - Reuse preserved `ORCHEO_API_URL` for health checks and summary output.
- Added/updated tests for:
  - Default upgrade preserving backend URL intent.
  - Execution path preserving existing backend URL keys.
  - Resolver behavior for install vs upgrade backend URL input handling.

## Why
Previously, upgrade flows could overwrite existing backend URL values with defaults (for example `http://localhost:8000`) when no explicit backend URL was provided. This was unexpected and could break existing non-local setups.

## Validation
- `make format`
- `make lint`
- `uv run pytest tests/sdk/test_cli_setup_stack_assets.py -q`
- `uv run pytest tests/sdk/test_cli_setup.py -q`

All checks passed.
