### PR TITLE
Auth-aware workflow actor/tag resolution plus new loop, RSS, and Telegram parsing nodes

### DIFF
--- a/apps/backend/src/orcheo_backend/app/authentication/jwt_helpers.py
+++ b/apps/backend/src/orcheo_backend/app/authentication/jwt_helpers.py
@@ -87,7 +87,11 @@ def _extract_workspace_ids(claims: Mapping[str, Any]) -> set[str]:
 
     workspaces: set[str] = set()
     for candidate in candidates:
-        workspaces.update(coerce_str_items(candidate))
+        workspaces.update(
+            workspace_id.strip().lower()
+            for workspace_id in coerce_str_items(candidate)
+            if workspace_id.strip()
+        )
     return workspaces
 
 

--- a/apps/canvas/src/features/auth/lib/auth-session.ts
+++ b/apps/canvas/src/features/auth/lib/auth-session.ts
@@ -89,4 +89,43 @@ export const getAccessToken = (): string | null => {
   return tokens.accessToken;
 };
 
+const parseJwtPayload = (token: string): Record<string, unknown> | null => {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  try {
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+    const payload = atob(`${base64}${padding}`);
+    const parsed = JSON.parse(payload) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+};
+
+export const getAccessTokenSubject = (): string | null => {
+  const token = getAccessToken();
+  if (!token) {
+    return null;
+  }
+
+  const payload = parseJwtPayload(token);
+  if (!payload) {
+    return null;
+  }
+
+  const subject = payload.sub;
+  if (typeof subject !== "string") {
+    return null;
+  }
+  const trimmed = subject.trim();
+  return trimmed || null;
+};
+
 export const isAuthenticated = (): boolean => Boolean(getAccessToken());

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.save.integration.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.save.integration.test.ts
@@ -122,7 +122,7 @@ describe("workflow-storage API integration - save workflow", () => {
     );
   });
 
-  it("uses JWT subject as actor when no explicit actor is provided", async () => {
+  it("uses default actor when no explicit actor is provided", async () => {
     const mockFetch = getFetchMock();
     const timestamp = new Date().toISOString();
     const subject = "auth0|user-123";
@@ -213,7 +213,7 @@ describe("workflow-storage API integration - save workflow", () => {
     const createPayload = JSON.parse(
       (mockFetch.mock.calls[0]?.[1]?.body ?? "{}") as string,
     ) as { actor?: string };
-    expect(createPayload.actor).toBe(subject);
+    expect(createPayload.actor).toBe("canvas-app");
     window.localStorage.removeItem("orcheo_canvas_auth_tokens");
   });
 });

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.ts
@@ -1,5 +1,4 @@
 import { SAMPLE_WORKFLOWS } from "@features/workflow/data/workflow-data";
-import { getAccessTokenSubject } from "@features/auth/lib/auth-session";
 import { computeWorkflowDiff, type WorkflowSnapshot } from "./workflow-diff";
 import {
   DEFAULT_ACTOR,
@@ -49,7 +48,7 @@ const resolveActor = (actor?: string): string => {
     return explicitActor;
   }
 
-  return getAccessTokenSubject() ?? DEFAULT_ACTOR;
+  return DEFAULT_ACTOR;
 };
 
 const emitUpdate = () => {

--- a/deploy/stack/.env.example
+++ b/deploy/stack/.env.example
@@ -63,7 +63,7 @@ VITE_ORCHEO_AUTH_CLIENT_ID=${ORCHEO_AUTH_CLIENT_ID}
 # Optional explicit callback URL; blank uses `${origin}/auth/callback`.
 VITE_ORCHEO_AUTH_REDIRECT_URI=
 # Space-delimited scopes requested by Canvas during OAuth login.
-VITE_ORCHEO_AUTH_SCOPES=openid profile email
+VITE_ORCHEO_AUTH_SCOPES=openid profile email workflows:read workflows:execute chatkit:session
 # Optional OAuth audience for Canvas token requests.
 VITE_ORCHEO_AUTH_AUDIENCE=${ORCHEO_AUTH_AUDIENCE}
 # Optional organization identifier for multi-tenant IdPs (e.g., Auth0).

--- a/docs/auth0_idp_setup.md
+++ b/docs/auth0_idp_setup.md
@@ -39,6 +39,12 @@ In the same API:
 2. For **User Access**, choose one:
    - `Allow` (simpler for development)
    - `Allow via client-grant` (stricter production option; then explicitly authorize your SPA app and selected permissions)
+3. In **User Access permissions** for your Canvas SPA app, explicitly add:
+   - `workflows:read`
+   - `workflows:execute`
+   - `chatkit:session`
+
+Critical: even when Canvas requests these scopes, Auth0 will not include them in the access token unless API user access/client-grant permissions allow them for that application.
 
 For RBAC:
 
@@ -120,6 +126,7 @@ Update your stack `.env` (derived from `deploy/stack/.env.example`):
 ## Troubleshooting checklist
 
 - `401 Missing required scopes`: requested scopes in Canvas env do not match API permissions or token lacks those scopes.
+- `401 Workflow access denied for caller.`: token scopes are valid, but the caller is not authorized for the specific workflow. For untagged workflows, Orcheo checks workflow owner against the token `sub`. For workspace-tagged workflows (`workspace:<id>`), Orcheo checks workspace claim intersection. Recreate the workflow as the logged-in user, or align workflow tags and workspace claims.
 - `401/403` with org enabled: user is not a member of the specified organization or org/connection setup is incomplete.
 - `invalid_token` issuer/audience: `ORCHEO_AUTH_ISSUER` and `ORCHEO_AUTH_AUDIENCE` mismatch Auth0 token values.
 - ChatKit session issuance errors unrelated to OAuth: missing `ORCHEO_CHATKIT_TOKEN_SIGNING_KEY`.

--- a/docs/auth0_idp_setup.md
+++ b/docs/auth0_idp_setup.md
@@ -1,0 +1,137 @@
+# Auth0 IdP Setup for Orcheo (Docker Stack)
+
+Author: ShaojieJiang
+
+This guide shows how to configure Auth0 as the OAuth/OIDC identity provider for Orcheo Canvas + backend when running the stack from `deploy/stack/docker-compose.yml`.
+
+## Goal
+
+Set `ORCHEO_AUTH_MODE=required` and allow authenticated Canvas users to:
+
+- load workflows
+- start ChatKit workflow sessions
+- use shared ChatKit session flows
+
+## Prerequisites
+
+- An Auth0 tenant with dashboard access.
+- Your Orcheo stack running from `deploy/stack`.
+- A target Canvas URL (for example `http://localhost:5173` in local dev).
+- A target backend URL (for example `http://localhost:8000` in local dev).
+
+## 1. Create the Auth0 API
+
+1. In Auth0, go to `Applications > APIs > Create API`.
+2. Set:
+   - `Name`: `Orcheo API` (or similar)
+   - `Identifier`: your API audience (example: `https://orcheo-api`)
+   - `Signing Algorithm`: `RS256`
+3. Open the API `Permissions` tab and add:
+   - `workflows:read` — `List and view workflow definitions.`
+   - `workflows:execute` — `Trigger workflow executions (including workflow-scoped ChatKit session startup in Canvas).`
+   - `chatkit:session` — `Issue signed ChatKit session tokens for authenticated users.`
+
+## 2. Configure API access policy and RBAC
+
+In the same API:
+
+1. Open `Application Access`.
+2. For **User Access**, choose one:
+   - `Allow` (simpler for development)
+   - `Allow via client-grant` (stricter production option; then explicitly authorize your SPA app and selected permissions)
+
+For RBAC:
+
+- If **RBAC disabled**: requested scopes can be granted directly.
+- If **RBAC enabled**: assign permissions to users via roles; `scope` becomes the intersection of requested scopes and assigned permissions.
+
+## 3. Create the SPA application
+
+1. Go to `Applications > Applications > Create Application`.
+2. Choose `Single Page Web Applications`.
+3. In app settings, set at least:
+   - `Allowed Callback URLs`:
+     - `http://localhost:5173/auth/callback`
+     - `https://<your-canvas-domain>/auth/callback`
+   - `Allowed Logout URLs`:
+     - `http://localhost:5173`
+     - `https://<your-canvas-domain>`
+   - `Allowed Web Origins`:
+     - `http://localhost:5173`
+     - `https://<your-canvas-domain>`
+   - `Allowed Origins (CORS)`:
+     - `http://localhost:5173`
+     - `https://<your-canvas-domain>`
+4. Save, then note:
+   - `Domain` (tenant issuer base, example: `your-tenant.us.auth0.com`)
+   - `Client ID`
+
+## 4. Create an organization (optional but recommended for B2B)
+
+Only required if you will set `VITE_ORCHEO_AUTH_ORGANIZATION`.
+
+1. Go to `Organizations > Create Organization`.
+2. Create an org (for example slug `orcheo-team`).
+3. Enable at least one connection for that org (Database, Google, GitHub, Enterprise, etc.).
+4. Add users/members (or enable auto-membership for supported flows).
+5. In your Orcheo env, set `VITE_ORCHEO_AUTH_ORGANIZATION` to the org identifier you use for Auth0 login (commonly `org_...`).
+
+## 5. Map Auth0 config to Orcheo stack env vars
+
+Update your stack `.env` (derived from `deploy/stack/.env.example`):
+
+### Backend auth validation
+
+- `ORCHEO_AUTH_MODE=required`
+- `ORCHEO_AUTH_JWKS_URL=https://<auth0-domain>/.well-known/jwks.json`
+- `ORCHEO_AUTH_AUDIENCE=<auth0-api-identifier>`
+- `ORCHEO_AUTH_ISSUER=https://<auth0-domain>/`
+- `ORCHEO_AUTH_DEV_LOGIN_ENABLED=false`
+- `ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN=<long-random-secret>`
+
+### Canvas OAuth client settings
+
+- `VITE_ORCHEO_BACKEND_URL=<public-backend-url>`
+- `VITE_ORCHEO_AUTH_ISSUER=https://<auth0-domain>/`
+- `VITE_ORCHEO_AUTH_CLIENT_ID=<auth0-spa-client-id>`
+- `VITE_ORCHEO_AUTH_REDIRECT_URI=` (leave blank to use `${origin}/auth/callback`, or set explicitly)
+- `VITE_ORCHEO_AUTH_SCOPES=openid profile email workflows:read workflows:execute chatkit:session`
+- `VITE_ORCHEO_AUTH_AUDIENCE=<auth0-api-identifier>`
+- `VITE_ORCHEO_AUTH_ORGANIZATION=<org_id>` (optional)
+- `VITE_ORCHEO_AUTH_PROVIDER_PARAM=connection` (optional; for direct provider hints)
+- `VITE_ORCHEO_AUTH_PROVIDER_GOOGLE=google-oauth2` (optional)
+- `VITE_ORCHEO_AUTH_PROVIDER_GITHUB=github` (optional)
+
+### Related runtime settings frequently needed
+
+- `ORCHEO_CORS_ALLOW_ORIGINS=<canvas-origin(s)>`
+- `ORCHEO_CHATKIT_TOKEN_SIGNING_KEY=<long-random-secret>`
+- `VITE_ORCHEO_CHATKIT_DOMAIN_KEY=<chatkit-domain-public-key>`
+
+## 6. Restart and verify
+
+1. Restart stack services (`docker compose up -d` from `deploy/stack`).
+2. Log out of Canvas and log in again (to refresh tokens with new scopes).
+3. Verify access token claims:
+   - `aud` contains your API audience.
+   - `scope` contains `workflows:read workflows:execute chatkit:session`.
+4. Open a workflow ChatKit window in Canvas.
+
+## Troubleshooting checklist
+
+- `401 Missing required scopes`: requested scopes in Canvas env do not match API permissions or token lacks those scopes.
+- `401/403` with org enabled: user is not a member of the specified organization or org/connection setup is incomplete.
+- `invalid_token` issuer/audience: `ORCHEO_AUTH_ISSUER` and `ORCHEO_AUTH_AUDIENCE` mismatch Auth0 token values.
+- ChatKit session issuance errors unrelated to OAuth: missing `ORCHEO_CHATKIT_TOKEN_SIGNING_KEY`.
+
+## Auth0 docs used
+
+- [Register Single-Page Web Applications](https://auth0.com/docs/get-started/auth0-overview/create-applications/single-page-web-apps)
+- [Application Settings](https://auth0.com/docs/get-started/applications/application-settings)
+- [Add API Permissions](https://auth0.com/docs/get-started/apis/add-api-permissions)
+- [Enable Role-Based Access Control for APIs](https://auth0.com/docs/get-started/apis/enable-role-based-access-control-for-apis)
+- [API Access Policies for Applications](https://auth0.com/docs/get-started/apis/api-access-policies-for-applications)
+- [Create Your First Organization](https://auth0.com/docs/organizations/create-first-organization)
+- [Login Flows for Organizations](https://auth0.com/docs/manage-users/organizations/login-flows-for-organizations)
+- [Enable Organization Connections](https://auth0.com/docs/manage-users/organizations/configure-organizations/enable-connections)
+- [Assign Roles to Users](https://auth0.com/docs/users/assign-roles-to-users)

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ That's it! Your agent handles the complexity while you focus on describing what 
 
 - **[Manual Setup Guide](manual_setup.md)** — Installation and configuration
 - **[Canvas](canvas.md)** — Visual workflow designer
+- **[Auth0 IdP Setup](auth0_idp_setup.md)** — Configure Auth0 OAuth/OIDC for the Docker stack
 - **[MCP Integration](mcp_integration.md)** — Connect AI assistants to Orcheo
 - **[Conversational Search](examples/conversational_search.md)** — Step-by-step demos from basic RAG to production-ready search
 - **[Evaluation](examples/evaluation.md)** — QReCC and MultiDoc2Dial benchmark workflows

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - Getting Started:
       - Manual Setup: manual_setup.md
       - Canvas: canvas.md
+      - Auth0 IdP Setup: auth0_idp_setup.md
       - Environment Variables: environment_variables.md
       - Authentication: authentication_guide.md
   - Examples:

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -1,7 +1,7 @@
 """Node registry and metadata definitions for Orcheo."""
 
 from orcheo.nodes.agentensor import AgentensorNode
-from orcheo.nodes.ai import AgentNode, LLMNode
+from orcheo.nodes.ai import AgentNode, AgentReplyExtractorNode, LLMNode
 from orcheo.nodes.communication import DiscordWebhookNode, EmailNode
 from orcheo.nodes.conversational_search import (
     ChunkEmbeddingNode,
@@ -23,6 +23,7 @@ from orcheo.nodes.debug import DebugNode
 from orcheo.nodes.javascript_sandbox import JavaScriptSandboxNode
 from orcheo.nodes.logic import (
     DelayNode,
+    ForLoopNode,
     SetVariableNode,
 )
 from orcheo.nodes.mongodb import (
@@ -39,7 +40,7 @@ from orcheo.nodes.registry import NodeMetadata, NodeRegistry, registry
 from orcheo.nodes.slack import SlackEventsParserNode, SlackNode
 from orcheo.nodes.storage import PostgresNode, SQLiteNode
 from orcheo.nodes.sub_workflow import SubWorkflowNode
-from orcheo.nodes.telegram import MessageTelegram
+from orcheo.nodes.telegram import MessageTelegram, TelegramEventsParserNode
 from orcheo.nodes.triggers import (
     CronTriggerNode,
     HttpPollingTriggerNode,
@@ -58,6 +59,7 @@ __all__ = [
     "NodeRegistry",
     "registry",
     "AgentNode",
+    "AgentReplyExtractorNode",
     "LLMNode",
     "AgentensorNode",
     "HttpRequestNode",
@@ -66,6 +68,7 @@ __all__ = [
     "MergeNode",
     "SetVariableNode",
     "DelayNode",
+    "ForLoopNode",
     "MongoDBNode",
     "MongoDBAggregateNode",
     "MongoDBFindNode",
@@ -81,6 +84,7 @@ __all__ = [
     "EmailNode",
     "DiscordWebhookNode",
     "MessageTelegram",
+    "TelegramEventsParserNode",
     "JavaScriptSandboxNode",
     "DebugNode",
     "SubWorkflowNode",

--- a/src/orcheo/nodes/logic/__init__.py
+++ b/src/orcheo/nodes/logic/__init__.py
@@ -15,6 +15,7 @@ Condition-related utilities have also moved to orcheo.edges.conditions.
 
 from orcheo.nodes.logic.utilities import (
     DelayNode,
+    ForLoopNode,
     SetVariableNode,
     _build_nested,
 )
@@ -23,5 +24,6 @@ from orcheo.nodes.logic.utilities import (
 __all__ = [
     "SetVariableNode",
     "DelayNode",
+    "ForLoopNode",
     "_build_nested",
 ]

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -145,6 +145,7 @@ class RSSNode(TaskNode):
         """Fetch a single source, returning (documents, error_or_None)."""
         try:
             response = await client.get(url, timeout=self.timeout)
+            response.raise_for_status()
             body = response.text
         except httpx.HTTPError as exc:
             return [], {"source": url, "error": str(exc)}

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -1,8 +1,12 @@
-"""RSS node."""
+"""RSS feed fetching and parsing node."""
 
 from __future__ import annotations
-import feedparser
+import datetime
+import re
+from typing import Any
+import httpx
 from langchain_core.runnables import RunnableConfig
+from pydantic import Field
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
@@ -11,21 +15,174 @@ from orcheo.nodes.registry import NodeMetadata, registry
 @registry.register(
     NodeMetadata(
         name="RSSNode",
-        description="RSS node",
+        description="Fetch and parse RSS/Atom feeds from multiple sources",
         category="rss",
     )
 )
 class RSSNode(TaskNode):
-    """RSS node."""
+    """Fetch RSS/Atom feeds via HTTP and parse their entries.
 
-    sources: list[str]
-    """RSS sources to pull from."""
+    Supports both RSS 2.0 ``<item>`` and Atom ``<entry>`` elements.
+    Each source is fetched independently; per-source errors are captured
+    without aborting the remaining feeds.
+    """
 
-    async def run(self, state: State, config: RunnableConfig) -> list[dict]:
-        """Pull the RSS updates."""
-        rss_updates = []
-        for source in self.sources:
-            feed = feedparser.parse(source)
-            rss_updates.extend(feed.entries)
+    sources: list[str] = Field(description="RSS/Atom feed URLs to fetch")
+    timeout: float = Field(
+        default=15.0,
+        ge=0.0,
+        description="HTTP timeout in seconds per feed",
+    )
 
-        return rss_updates
+    # ------------------------------------------------------------------
+    # XML helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_tag_text(xml: str, tag: str) -> str:
+        """Extract text content of the first ``<tag>…</tag>`` occurrence."""
+        open_tag = "<" + tag
+        close_tag = "</" + tag + ">"
+        start = xml.find(open_tag)
+        if start == -1:
+            return ""
+        gt = xml.find(">", start)
+        if gt == -1:
+            return ""
+        end = xml.find(close_tag, gt)
+        if end == -1:
+            return ""
+        content = xml[gt + 1 : end]
+        if content.strip().startswith("<![CDATA["):
+            content = content.strip()[9:]
+            if content.endswith("]]>"):
+                content = content[:-3]
+        return content.strip()
+
+    @staticmethod
+    def _extract_link(xml: str) -> str:
+        """Extract a link from RSS ``<link>`` or Atom ``<link href="…">``."""
+        fallback_href = ""
+        link_start = xml.find("<link")
+        while link_start != -1:
+            tag_end = xml.find(">", link_start)
+            if tag_end == -1:
+                break
+            tag_content = xml[link_start : tag_end + 1]
+
+            attrs = {
+                m.group(1).lower(): m.group(3)
+                for m in re.finditer(
+                    r"([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*(['\"])(.*?)\2",
+                    tag_content,
+                )
+            }
+
+            href = attrs.get("href", "").strip()
+            rel = attrs.get("rel", "").strip().lower()
+            if href:
+                if rel == "alternate":
+                    return href
+                if not fallback_href:
+                    fallback_href = href
+
+            close = xml.find("</link>", tag_end)
+            next_link = xml.find("<link", tag_end)
+            if not href and close != -1 and (next_link == -1 or close < next_link):
+                return xml[tag_end + 1 : close].strip()
+            link_start = next_link
+        return fallback_href
+
+    @classmethod
+    def _parse_items(cls, body: str) -> list[dict[str, str]]:
+        """Parse RSS/Atom items from an XML body using string operations."""
+        items: list[dict[str, str]] = []
+        for item_tag in ("item", "entry"):
+            open_tag = "<" + item_tag
+            close_tag = "</" + item_tag + ">"
+            pos = 0
+            while True:
+                start = body.find(open_tag, pos)
+                if start == -1:
+                    break
+                end = body.find(close_tag, start)
+                if end == -1:
+                    break
+                fragment = body[start : end + len(close_tag)]
+
+                title = cls._extract_tag_text(fragment, "title")
+                link = cls._extract_link(fragment)
+                description = cls._extract_tag_text(
+                    fragment, "description"
+                ) or cls._extract_tag_text(fragment, "summary")
+                pub_date = (
+                    cls._extract_tag_text(fragment, "pubDate")
+                    or cls._extract_tag_text(fragment, "published")
+                    or cls._extract_tag_text(fragment, "updated")
+                )
+
+                items.append(
+                    {
+                        "title": title,
+                        "link": link,
+                        "description": description,
+                        "pubDate": pub_date,
+                    }
+                )
+                pos = end + len(close_tag)
+        return items
+
+    # ------------------------------------------------------------------
+    # Node execution
+    # ------------------------------------------------------------------
+
+    async def _fetch_source(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        now_iso: str,
+    ) -> tuple[list[dict[str, Any]], dict[str, str] | None]:
+        """Fetch a single source, returning (documents, error_or_None)."""
+        try:
+            response = await client.get(url, timeout=self.timeout)
+            body = response.text
+        except httpx.HTTPError as exc:
+            return [], {"source": url, "error": str(exc)}
+
+        if not body:
+            return [], {"source": url, "error": "Empty feed response"}
+
+        documents: list[dict[str, Any]] = []
+        for item in self._parse_items(body):
+            documents.append(
+                {
+                    "title": item.get("title", ""),
+                    "link": item.get("link", ""),
+                    "description": item.get("description", ""),
+                    "pubDate": item.get("pubDate", ""),
+                    "source": url,
+                    "read": False,
+                    "fetched_at": now_iso,
+                }
+            )
+        return documents, None
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fetch all configured RSS sources and return parsed documents."""
+        now_iso = datetime.datetime.now(datetime.UTC).isoformat()
+        documents: list[dict[str, Any]] = []
+        errors: list[dict[str, str]] = []
+
+        async with httpx.AsyncClient() as client:
+            for url in self.sources:
+                docs, error = await self._fetch_source(client, url, now_iso)
+                documents.extend(docs)
+                if error is not None:
+                    errors.append(error)
+
+        return {
+            "documents": documents,
+            "errors": errors,
+            "fetched_count": len(documents),
+            "failed_sources": len(errors),
+        }

--- a/src/orcheo/nodes/telegram.py
+++ b/src/orcheo/nodes/telegram.py
@@ -1,8 +1,10 @@
-"""Telegram messaging node for Orcheo."""
+"""Telegram messaging and event parsing nodes for Orcheo."""
 
 import asyncio
+from collections.abc import Mapping
 from typing import Any
 from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
 from telegram import Bot
 from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
@@ -95,3 +97,173 @@ class MessageTelegram(TaskNode):
             return {"message_id": result.message_id, "status": "sent"}
         except Exception as e:
             raise ValueError(f"Telegram API error: {str(e)}") from e
+
+
+@registry.register(
+    NodeMetadata(
+        name="TelegramEventsParserNode",
+        description="Validate and parse Telegram Bot webhook updates",
+        category="telegram",
+    )
+)
+class TelegramEventsParserNode(TaskNode):
+    """Parse Telegram Bot API webhook updates into a structured event.
+
+    Extracts message metadata (chat ID, username, text) from the
+    ``Update`` JSON payload delivered by the Telegram webhook.
+    Optionally validates the ``X-Telegram-Bot-Api-Secret-Token`` header
+    and filters by allowed update / chat types.
+    """
+
+    secret_token: str | None = Field(
+        default=None,
+        description=(
+            "Expected value of the X-Telegram-Bot-Api-Secret-Token header. "
+            "When set, updates with a missing or mismatched token are rejected."
+        ),
+    )
+    allowed_update_types: list[str] = Field(
+        default_factory=lambda: ["message"],
+        description="Telegram update types allowed to pass through",
+    )
+    allowed_chat_types: list[str] = Field(
+        default_factory=lambda: ["private", "group", "supergroup"],
+        description="Chat types allowed to pass through",
+    )
+    body_key: str = Field(
+        default="body",
+        description="Key in inputs that contains the webhook payload",
+    )
+
+    def _extract_inputs(self, state: State) -> dict[str, Any]:
+        """Extract webhook inputs from state."""
+        if isinstance(state, BaseModel):
+            state_dict = state.model_dump()
+        elif isinstance(state, Mapping):
+            state_dict = dict(state)
+        else:
+            return {}
+        raw_inputs = state_dict.get("inputs")
+        if isinstance(raw_inputs, Mapping):
+            return dict(raw_inputs)
+        return state_dict
+
+    def _verify_secret_token(self, headers: dict[str, str]) -> None:
+        """Verify the secret token header if configured."""
+        if not self.secret_token:
+            return
+        normalized = {k.lower(): v for k, v in headers.items()}
+        token = normalized.get("x-telegram-bot-api-secret-token")
+        if token != self.secret_token:
+            raise ValueError("Telegram secret token verification failed")
+
+    def _detect_update_type(self, payload: dict[str, Any]) -> str | None:
+        """Return the update type present in the payload."""
+        for candidate in (
+            "message",
+            "edited_message",
+            "channel_post",
+            "edited_channel_post",
+            "callback_query",
+            "inline_query",
+            "my_chat_member",
+            "chat_member",
+            "chat_join_request",
+        ):
+            if candidate in payload:
+                return candidate
+        return None
+
+    def _parse_body(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Return the webhook body payload as a dict."""
+        body = inputs.get(self.body_key, {})
+        if isinstance(body, str):
+            import json
+
+            try:
+                body = json.loads(body)
+            except json.JSONDecodeError:
+                return {}
+        if isinstance(body, dict):
+            return body
+        return {}
+
+    def _extract_update_details(
+        self,
+        payload: dict[str, Any],
+        update_type: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], str]:
+        """Extract message, chat, sender, and text for the update."""
+        msg = payload.get(update_type, {})
+        if not isinstance(msg, dict):
+            msg = {}
+
+        if update_type == "callback_query":
+            callback_msg = msg.get("message", {})
+            chat = (
+                callback_msg.get("chat", {}) if isinstance(callback_msg, dict) else {}
+            )
+            sender = msg.get("from", {})
+            text = msg.get("data", "")
+        else:
+            chat = msg.get("chat", {})
+            sender = msg.get("from", {})
+            text = msg.get("text", "")
+
+        if not isinstance(chat, dict):
+            chat = {}
+        if not isinstance(sender, dict):
+            sender = {}
+        if not isinstance(text, str):
+            text = str(text)
+
+        return msg, chat, sender, text
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Parse a Telegram webhook update and return structured event data."""
+        inputs = self._extract_inputs(state)
+        headers = inputs.get("headers", {})
+        if isinstance(headers, dict):
+            self._verify_secret_token(headers)
+
+        body = self._parse_body(inputs)
+
+        update_type = self._detect_update_type(body)
+        if update_type is None or update_type not in self.allowed_update_types:
+            return {
+                "update_type": update_type,
+                "should_process": False,
+                "chat_id": None,
+                "username": None,
+                "text": None,
+            }
+
+        msg, chat, sender, text = self._extract_update_details(body, update_type)
+
+        chat_type = chat.get("type", "")
+        if self.allowed_chat_types and chat_type not in self.allowed_chat_types:
+            return {
+                "update_type": update_type,
+                "should_process": False,
+                "chat_id": str(chat.get("id", "")),
+                "username": None,
+                "text": None,
+            }
+
+        chat_id = str(chat.get("id", ""))
+        username = sender.get("first_name") or sender.get("username") or ""
+        should_process = bool(chat_id and text)
+
+        return {
+            "update_type": update_type,
+            "chat_id": chat_id,
+            "chat_type": chat_type,
+            "username": username,
+            "user_id": str(sender.get("id", "")),
+            "text": text or "",
+            "message_id": msg.get("message_id"),
+            "should_process": should_process,
+        }
+
+
+__all__ = ["MessageTelegram", "TelegramEventsParserNode", "escape_markdown"]

--- a/tests/backend/test_authentication_parsers_claims.py
+++ b/tests/backend/test_authentication_parsers_claims.py
@@ -79,6 +79,14 @@ def test_extract_workspace_ids_from_claims() -> None:
     assert ids == {"ws-3"}
 
 
+def test_extract_workspace_ids_normalizes_case_and_whitespace() -> None:
+    """_extract_workspace_ids normalizes claim values for comparisons."""
+    from orcheo_backend.app.authentication import _extract_workspace_ids
+
+    ids = set(_extract_workspace_ids({"workspace_ids": [" Team-A ", "TEAM-B"]}))
+    assert ids == {"team-a", "team-b"}
+
+
 def test_extract_scopes_with_nested_orcheo_claim() -> None:
     """_extract_scopes finds scopes in nested orcheo.scopes claim."""
     from orcheo_backend.app.authentication import _extract_scopes

--- a/tests/backend/test_workflows_router_actor_and_workspace_tags.py
+++ b/tests/backend/test_workflows_router_actor_and_workspace_tags.py
@@ -1,0 +1,187 @@
+"""Tests for workflow actor and workspace tag resolution in router handlers."""
+
+from __future__ import annotations
+from types import SimpleNamespace
+import pytest
+from orcheo.models.workflow import Workflow
+from orcheo_backend.app.authentication import AuthorizationPolicy, RequestContext
+from orcheo_backend.app.routers import workflows
+from orcheo_backend.app.schemas.workflows import (
+    WorkflowCreateRequest,
+    WorkflowUpdateRequest,
+)
+
+
+class _Repository:
+    def __init__(self) -> None:
+        self.last_actor: str | None = None
+        self.last_tags: list[str] | None = None
+
+    async def create_workflow(
+        self,
+        *,
+        name: str,
+        slug: str | None,
+        description: str | None,
+        tags: list[str] | None,
+        actor: str,
+    ) -> Workflow:
+        self.last_actor = actor
+        self.last_tags = list(tags or [])
+        return Workflow(
+            name=name, slug=slug or "", description=description, tags=tags or []
+        )
+
+    async def update_workflow(
+        self,
+        workflow_id,
+        *,
+        name: str | None,
+        description: str | None,
+        tags: list[str] | None,
+        is_archived: bool | None,
+        actor: str,
+    ) -> Workflow:
+        self.last_actor = actor
+        self.last_tags = list(tags) if tags is not None else None
+        return Workflow(
+            id=workflow_id,
+            name=name or "Workflow",
+            description=description,
+            tags=tags or [],
+            is_archived=bool(is_archived),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_create_workflow_uses_authenticated_subject_and_workspace_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflows,
+        "load_auth_settings",
+        lambda: SimpleNamespace(enforce=True),
+    )
+    repository = _Repository()
+    request = WorkflowCreateRequest(
+        name="CLI uploaded workflow",
+        tags=["langgraph", "cli-upload"],
+        actor="cli",
+    )
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="auth0|user-123",
+            identity_type="user",
+            scopes=frozenset({"workflows:write"}),
+            workspace_ids=frozenset({"team-a"}),
+        )
+    )
+
+    await workflows.create_workflow(request, repository, policy=policy)
+
+    assert repository.last_actor == "auth0|user-123"
+    assert repository.last_tags is not None
+    assert "langgraph" in repository.last_tags
+    assert "cli-upload" in repository.last_tags
+    assert "workspace:team-a" in repository.last_tags
+
+
+@pytest.mark.asyncio()
+async def test_create_workflow_keeps_request_actor_when_context_unavailable() -> None:
+    repository = _Repository()
+    request = WorkflowCreateRequest(
+        name="Legacy workflow",
+        tags=["legacy"],
+        actor="cli",
+    )
+
+    await workflows.create_workflow(request, repository)
+
+    assert repository.last_actor == "cli"
+    assert repository.last_tags == ["legacy"]
+
+
+@pytest.mark.asyncio()
+async def test_create_workflow_adds_workspace_tags_when_tags_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflows,
+        "load_auth_settings",
+        lambda: SimpleNamespace(enforce=True),
+    )
+    repository = _Repository()
+    request = WorkflowCreateRequest(
+        name="Tagless workflow",
+        actor="cli",
+    )
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="service-token-2",
+            identity_type="service",
+            scopes=frozenset({"workflows:write"}),
+            workspace_ids=frozenset({"team-x"}),
+        )
+    )
+
+    await workflows.create_workflow(request, repository, policy=policy)
+
+    assert repository.last_actor == "service-token-2"
+    assert repository.last_tags == ["workspace:team-x"]
+
+
+@pytest.mark.asyncio()
+async def test_update_workflow_appends_workspace_tags_when_auth_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflows,
+        "load_auth_settings",
+        lambda: SimpleNamespace(enforce=True),
+    )
+    repository = _Repository()
+    workflow = Workflow(name="Workflow")
+    request = WorkflowUpdateRequest(tags=["cli-upload"], actor="cli")
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="service-token-1",
+            identity_type="service",
+            scopes=frozenset({"workflows:write"}),
+            workspace_ids=frozenset({"ws-1", "ws-2"}),
+        )
+    )
+
+    await workflows.update_workflow(workflow.id, request, repository, policy=policy)
+
+    assert repository.last_actor == "service-token-1"
+    assert repository.last_tags is not None
+    assert "cli-upload" in repository.last_tags
+    assert "workspace:ws-1" in repository.last_tags
+    assert "workspace:ws-2" in repository.last_tags
+
+
+@pytest.mark.asyncio()
+async def test_update_workflow_preserves_none_tags_when_request_omits_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflows,
+        "load_auth_settings",
+        lambda: SimpleNamespace(enforce=True),
+    )
+    repository = _Repository()
+    workflow = Workflow(name="Workflow")
+    request = WorkflowUpdateRequest(actor="cli")
+    policy = AuthorizationPolicy(
+        RequestContext(
+            subject="service-token-3",
+            identity_type="service",
+            scopes=frozenset({"workflows:write"}),
+            workspace_ids=frozenset({"ws-1"}),
+        )
+    )
+
+    await workflows.update_workflow(workflow.id, request, repository, policy=policy)
+
+    assert repository.last_actor == "service-token-3"
+    assert repository.last_tags is None

--- a/tests/backend/test_workflows_router_actor_and_workspace_tags.py
+++ b/tests/backend/test_workflows_router_actor_and_workspace_tags.py
@@ -189,6 +189,33 @@ async def test_update_workflow_appends_workspace_tags_when_auth_enforced(
     assert "workspace:ws-2" in repository.last_tags
 
 
+def test_append_workspace_tags_returns_list_when_tags_none() -> None:
+    """_append_workspace_tags returns workspace tag list when tags is None.
+
+    Covers line 507.
+    """
+    context = RequestContext(
+        subject="user-1",
+        identity_type="user",
+        scopes=frozenset({"workflows:write"}),
+        workspace_ids=frozenset({"ws-a"}),
+    )
+    result = workflows._append_workspace_tags(None, context)
+    assert result == ["workspace:ws-a"]
+
+
+def test_append_workspace_tags_skips_duplicate_workspace_tag() -> None:
+    """Workspace tag already present is not added again (branch 516->514)."""
+    context = RequestContext(
+        subject="user-1",
+        identity_type="user",
+        scopes=frozenset({"workflows:write"}),
+        workspace_ids=frozenset({"ws-a"}),
+    )
+    result = workflows._append_workspace_tags(["workspace:ws-a"], context)
+    assert result == ["workspace:ws-a"]
+
+
 @pytest.mark.asyncio()
 async def test_update_workflow_preserves_none_tags_when_request_omits_tags(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/nodes/test_ai_agent_node_messages.py
+++ b/tests/nodes/test_ai_agent_node_messages.py
@@ -265,3 +265,21 @@ def test_build_messages_keeps_existing_messages_without_checkpointer() -> None:
     )
     assert len(messages) == 1
     assert messages[0].content == "Previous answer"
+
+
+def test_build_messages_checkpointer_with_no_new_inputs() -> None:
+    """Checkpointer present but inputs produce no new messages – branch 352->355."""
+    node = AgentNode(name="agent", ai_model="test-model")
+    state = State(
+        messages=[{"role": "assistant", "content": "Previous answer"}],
+        inputs={},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+    messages = node._build_messages(
+        state,
+        config={"configurable": {"thread_id": "thread-1", "__pregel_checkpointer": {}}},
+    )
+    assert len(messages) == 1
+    assert messages[0].content == "Previous answer"

--- a/tests/nodes/test_ai_agent_reply_extractor.py
+++ b/tests/nodes/test_ai_agent_reply_extractor.py
@@ -1,0 +1,118 @@
+"""Tests for AgentReplyExtractorNode (lines 417-429 of ai.py)."""
+
+from __future__ import annotations
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentReplyExtractorNode
+
+
+@pytest.mark.asyncio
+async def test_extractor_returns_dict_assistant_content() -> None:
+    """Dict-style assistant message: returns its content string (lines 419-423)."""
+    node = AgentReplyExtractorNode(name="extractor")
+    state: State = {
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": "Hi there!"}
+
+
+@pytest.mark.asyncio
+async def test_extractor_skips_dict_assistant_with_empty_content() -> None:
+    """Dict assistant message with empty content is skipped; fallback is
+    returned (line 422 false branch).
+    """
+    node = AgentReplyExtractorNode(name="extractor")
+    state: State = {
+        "messages": [{"role": "assistant", "content": ""}],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": node.fallback_message}
+
+
+@pytest.mark.asyncio
+async def test_extractor_skips_dict_non_assistant_role() -> None:
+    """Dict message with non-assistant role is not extracted (line 420 false branch)."""
+    node = AgentReplyExtractorNode(name="extractor")
+    state: State = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": node.fallback_message}
+
+
+@pytest.mark.asyncio
+async def test_extractor_returns_ai_message_string_content() -> None:
+    """AIMessage with string content is returned directly (lines 424-428,
+    isinstance str True).
+    """
+    node = AgentReplyExtractorNode(name="extractor")
+    state: State = {
+        "messages": [HumanMessage(content="Q"), AIMessage(content="Answer")],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": "Answer"}
+
+
+@pytest.mark.asyncio
+async def test_extractor_stringifies_ai_message_non_string_content() -> None:
+    """AIMessage with non-string content is converted via str() (line 427
+    str() branch).
+    """
+    node = AgentReplyExtractorNode(name="extractor")
+    content = [{"type": "text", "text": "structured"}]
+    state: State = {
+        "messages": [AIMessage(content=content)],  # type: ignore[list-item]
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": str(content)}
+
+
+@pytest.mark.asyncio
+async def test_extractor_returns_fallback_when_no_assistant_message() -> None:
+    """Fallback message returned when messages list has no assistant turn (line 429)."""
+    node = AgentReplyExtractorNode(
+        name="extractor", fallback_message="No reply available"
+    )
+    state: State = {
+        "messages": [HumanMessage(content="Question")],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result == {"agent_reply": "No reply available"}
+
+
+@pytest.mark.asyncio
+async def test_extractor_returns_fallback_for_empty_messages() -> None:
+    """Fallback returned when messages list is empty (line 417-418, 429)."""
+    node = AgentReplyExtractorNode(name="extractor")
+    state: State = {
+        "messages": [],
+        "inputs": {},
+        "results": {},
+        "structured_response": None,
+    }
+    result = await node.run(state, RunnableConfig())
+    assert result["agent_reply"] == node.fallback_message

--- a/tests/nodes/test_ai_llm_node.py
+++ b/tests/nodes/test_ai_llm_node.py
@@ -56,3 +56,77 @@ def test_llmnode_build_messages_skips_empty_input() -> None:
     node = LLMNode(name="llm", ai_model="test-model", input_text="  ")
     state = State(inputs={}, results={}, structured_response=None)
     assert node._build_messages(state) == []
+
+
+def test_llmnode_build_messages_no_user_message_no_instruction() -> None:
+    """input_text without user_message or instruction hits the else
+    branches (lines 493, 499).
+    """
+    node = LLMNode(name="llm", ai_model="test-model", input_text="plain text")
+    state = State(inputs={}, results={}, structured_response=None)
+    messages = node._build_messages(state)
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "plain text"
+
+
+@pytest.mark.asyncio
+async def test_llmnode_run_returns_empty_when_no_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMNode.run returns early with empty messages when _build_messages
+    yields [] (line 455).
+    """
+
+    async def fake_prepare_tools(self: LLMNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr(LLMNode, "_prepare_tools", fake_prepare_tools)
+
+    node = LLMNode(name="llm", ai_model="test-model")
+    state = State(inputs={}, results={}, structured_response=None)
+    result = await node.run(state, {})
+    assert result == {"messages": []}
+
+
+@pytest.mark.asyncio
+async def test_llmnode_run_with_response_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMNode.run sets response_format_strategy when response_format is
+    provided (line 461).
+    """
+    from pydantic import BaseModel
+
+    class Schema(BaseModel):
+        answer: str
+
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: LLMNode):  # type: ignore[unused-argument]
+        return []
+
+    def fake_init_chat_model(*args, **kwargs):
+        return "model"
+
+    captured: dict = {}
+
+    def fake_create_agent(model, tools, system_prompt=None, response_format=None):
+        captured["response_format"] = response_format
+        return fake_agent
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", fake_init_chat_model)
+    monkeypatch.setattr("orcheo.nodes.ai.create_agent", fake_create_agent)
+    monkeypatch.setattr(LLMNode, "_prepare_tools", fake_prepare_tools)
+
+    node = LLMNode(
+        name="llm",
+        ai_model="test-model",
+        input_text="hello",
+        response_format=Schema,
+    )
+    state = State(inputs={}, results={}, structured_response=None)
+    result = await node.run(state, {})
+    assert result == {"messages": [AIMessage(content="done")]}
+    assert captured["response_format"] is not None

--- a/tests/nodes/test_logic_set_variable_node.py
+++ b/tests/nodes/test_logic_set_variable_node.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import pytest
 from langchain_core.runnables import RunnableConfig
 from orcheo.graph.state import State
-from orcheo.nodes.logic import SetVariableNode
+from orcheo.nodes.logic import DelayNode, ForLoopNode, SetVariableNode, _build_nested
 
 
 @pytest.mark.asyncio
@@ -98,3 +98,112 @@ async def test_set_variable_node_empty_variables() -> None:
     payload = result["results"]["assign"]
 
     assert payload == {}
+
+
+@pytest.mark.asyncio
+async def test_delay_node_runs() -> None:
+    state = State({"results": {}})
+    node = DelayNode(name="wait", duration_seconds=0.0)
+
+    result = await node(state, RunnableConfig())
+
+    assert result["results"]["wait"]["duration_seconds"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_non_list_items() -> None:
+    """Non-list items returns done immediately without iterating."""
+    node = ForLoopNode(name="loop", items="not_a_list")
+
+    result = await node.run({"results": {}}, RunnableConfig())
+
+    assert result == {"done": True, "index": 0, "total": 0, "current_item": None}
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_first_iteration() -> None:
+    """First invocation yields the item at index 0 and advances index to 1."""
+    state = State({"results": {}})
+    node = ForLoopNode(name="loop", items=["a", "b", "c"])
+
+    result = await node(state, RunnableConfig())
+    payload = result["results"]["loop"]
+
+    assert payload["done"] is False
+    assert payload["current_item"] == "a"
+    assert payload["index"] == 1
+    assert payload["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_subsequent_iteration() -> None:
+    """Reads the previous index from state and advances through the list."""
+    state = State({"results": {"loop": {"index": 1}}})
+    node = ForLoopNode(name="loop", items=["a", "b", "c"])
+
+    result = await node(state, RunnableConfig())
+    payload = result["results"]["loop"]
+
+    assert payload["done"] is False
+    assert payload["current_item"] == "b"
+    assert payload["index"] == 2
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_exhausted() -> None:
+    """Returns done=True when the stored index has reached or passed the end."""
+    state = State({"results": {"loop": {"index": 3}}})
+    node = ForLoopNode(name="loop", items=["a", "b", "c"])
+
+    result = await node(state, RunnableConfig())
+    payload = result["results"]["loop"]
+
+    assert payload["done"] is True
+    assert payload["current_item"] is None
+    assert payload["index"] == 3
+    assert payload["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_prev_results_not_mapping() -> None:
+    """When results is not a Mapping the index defaults to 0."""
+    node = ForLoopNode(name="loop", items=["x", "y"])
+
+    result = await node.run({"results": "not_a_dict"}, RunnableConfig())
+
+    assert result["current_item"] == "x"
+    assert result["index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_loop_state_not_mapping() -> None:
+    """When the node's own previous state is not a Mapping the index defaults to 0."""
+    node = ForLoopNode(name="loop", items=["x", "y"])
+
+    result = await node.run({"results": {"loop": "not_a_dict"}}, RunnableConfig())
+
+    assert result["current_item"] == "x"
+    assert result["index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_for_loop_node_raw_index_none() -> None:
+    """When the stored index value is None it defaults to 0."""
+    node = ForLoopNode(name="loop", items=["x", "y"])
+
+    result = await node.run({"results": {"loop": {"index": None}}}, RunnableConfig())
+
+    assert result["current_item"] == "x"
+    assert result["index"] == 1
+
+
+def test_build_nested_empty_path_raises() -> None:
+    """An empty path string raises ValueError."""
+    with pytest.raises(ValueError, match="non-empty string"):
+        _build_nested("", 42)
+
+
+def test_build_nested_whitespace_only_path_raises() -> None:
+    """A path containing only dots/whitespace (no real segments) raises ValueError."""
+    with pytest.raises(ValueError, match="at least one segment"):
+        _build_nested("...", 42)

--- a/tests/nodes/test_telegram.py
+++ b/tests/nodes/test_telegram.py
@@ -1,10 +1,16 @@
 """Tests for Telegram node."""
 
+import json
 from unittest.mock import AsyncMock, patch
 import pytest
+from pydantic import BaseModel
 from telegram import Message
 from orcheo.graph.state import State
-from orcheo.nodes.telegram import MessageTelegram, escape_markdown
+from orcheo.nodes.telegram import (
+    MessageTelegram,
+    TelegramEventsParserNode,
+    escape_markdown,
+)
 
 
 def test_escape_markdown():
@@ -105,3 +111,391 @@ async def test_telegram_node_tool_run(telegram_node):
             mock_bot.send_message.assert_called_once_with(
                 chat_id="123456", text="Test message!", parse_mode=None
             )
+
+
+# ---------------------------------------------------------------------------
+# TelegramEventsParserNode helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parser(**kwargs) -> TelegramEventsParserNode:
+    return TelegramEventsParserNode(name="parser", **kwargs)
+
+
+def _message_state(body: object, headers: dict | None = None) -> State:
+    return State({"inputs": {"headers": headers or {}, "body": body}, "results": {}})
+
+
+# ---------------------------------------------------------------------------
+# _extract_inputs
+# ---------------------------------------------------------------------------
+
+
+def test_parser_extract_inputs_basemodel_state() -> None:
+    """BaseModel state uses model_dump() and returns the inputs mapping."""
+
+    class FakeState(BaseModel):
+        inputs: dict = {}
+
+    node = _make_parser()
+    result = node._extract_inputs(FakeState(inputs={"body": {}, "x": 1}))  # type: ignore[arg-type]
+    assert result == {"body": {}, "x": 1}
+
+
+def test_parser_extract_inputs_non_mapping_state() -> None:
+    """A non-Mapping, non-BaseModel state returns an empty dict."""
+    node = _make_parser()
+    assert node._extract_inputs(42) == {}  # type: ignore[arg-type]
+
+
+def test_parser_extract_inputs_non_mapping_inputs() -> None:
+    """When the inputs value is not a Mapping the whole state dict is returned."""
+    node = _make_parser()
+    state = {"inputs": "flat_string", "other": 1}
+    result = node._extract_inputs(state)  # type: ignore[arg-type]
+    assert result == {"inputs": "flat_string", "other": 1}
+
+
+# ---------------------------------------------------------------------------
+# _verify_secret_token
+# ---------------------------------------------------------------------------
+
+
+def test_parser_verify_secret_token_no_secret() -> None:
+    """No secret configured – any headers pass without raising."""
+    node = _make_parser()
+    node._verify_secret_token({"X-Telegram-Bot-Api-Secret-Token": "anything"})
+
+
+def test_parser_verify_secret_token_matching() -> None:
+    """Correct token in headers does not raise."""
+    node = _make_parser(secret_token="s3cr3t")
+    node._verify_secret_token({"x-telegram-bot-api-secret-token": "s3cr3t"})
+
+
+def test_parser_verify_secret_token_mismatch() -> None:
+    """Wrong token raises ValueError."""
+    node = _make_parser(secret_token="s3cr3t")
+    with pytest.raises(ValueError, match="secret token verification failed"):
+        node._verify_secret_token({"x-telegram-bot-api-secret-token": "wrong"})
+
+
+# ---------------------------------------------------------------------------
+# _detect_update_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "update_type",
+    [
+        "message",
+        "edited_message",
+        "channel_post",
+        "edited_channel_post",
+        "callback_query",
+        "inline_query",
+        "my_chat_member",
+        "chat_member",
+        "chat_join_request",
+    ],
+)
+def test_parser_detect_update_type_known(update_type: str) -> None:
+    node = _make_parser()
+    assert node._detect_update_type({update_type: {}}) == update_type
+
+
+def test_parser_detect_update_type_unknown() -> None:
+    node = _make_parser()
+    assert node._detect_update_type({"unknown_key": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_body
+# ---------------------------------------------------------------------------
+
+
+def test_parser_parse_body_dict() -> None:
+    node = _make_parser()
+    body = {"update_id": 1}
+    assert node._parse_body({"body": body}) == body
+
+
+def test_parser_parse_body_valid_json_string() -> None:
+    node = _make_parser()
+    assert node._parse_body({"body": '{"update_id": 1}'}) == {"update_id": 1}
+
+
+def test_parser_parse_body_invalid_json_string() -> None:
+    node = _make_parser()
+    assert node._parse_body({"body": "not json {"}) == {}
+
+
+def test_parser_parse_body_non_dict_non_string() -> None:
+    """A list body (valid JSON type but not a dict) returns {}."""
+    node = _make_parser()
+    assert node._parse_body({"body": [1, 2, 3]}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _extract_update_details
+# ---------------------------------------------------------------------------
+
+
+def test_parser_extract_update_details_non_dict_msg() -> None:
+    """When the update value is not a dict, msg/chat/sender default to {}."""
+    node = _make_parser()
+    msg, chat, sender, text = node._extract_update_details(
+        {"message": "not_a_dict"}, "message"
+    )
+    assert msg == {}
+    assert chat == {}
+    assert sender == {}
+    assert text == ""
+
+
+def test_parser_extract_update_details_non_dict_fields() -> None:
+    """Non-dict chat/sender and non-str text are coerced to safe defaults."""
+    node = _make_parser()
+    payload: dict = {"message": {"chat": "bad_chat", "from": 99, "text": 42}}
+    msg, chat, sender, text = node._extract_update_details(payload, "message")
+    assert chat == {}
+    assert sender == {}
+    assert text == "42"
+
+
+def test_parser_extract_update_details_callback_query() -> None:
+    """callback_query extracts chat from nested message and text from data."""
+    node = _make_parser()
+    payload: dict = {
+        "callback_query": {
+            "message": {"chat": {"id": 7, "type": "private"}},
+            "from": {"id": 1, "first_name": "Alice"},
+            "data": "btn_click",
+        }
+    }
+    msg, chat, sender, text = node._extract_update_details(payload, "callback_query")
+    assert chat == {"id": 7, "type": "private"}
+    assert text == "btn_click"
+
+
+def test_parser_extract_update_details_callback_non_dict_callback_msg() -> None:
+    """When the callback_query's nested message is not a dict, chat defaults to {}."""
+    node = _make_parser()
+    payload: dict = {
+        "callback_query": {
+            "message": "not_a_dict",
+            "from": {"id": 1},
+            "data": "click",
+        }
+    }
+    msg, chat, sender, text = node._extract_update_details(payload, "callback_query")
+    assert chat == {}
+    assert text == "click"
+
+
+# ---------------------------------------------------------------------------
+# run() integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parser_run_valid_message() -> None:
+    """Happy path: a private message is fully parsed and should_process=True."""
+    state = _message_state(
+        body={
+            "update_id": 1,
+            "message": {
+                "message_id": 10,
+                "from": {"id": 100, "first_name": "Alice"},
+                "chat": {"id": -1, "type": "private"},
+                "text": "Hello",
+            },
+        }
+    )
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is True
+    assert payload["update_type"] == "message"
+    assert payload["chat_id"] == "-1"
+    assert payload["username"] == "Alice"
+    assert payload["text"] == "Hello"
+    assert payload["message_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_parser_run_no_update_type() -> None:
+    """Empty body produces should_process=False with update_type=None."""
+    state = _message_state(body={})
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["update_type"] is None
+    assert payload["chat_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_parser_run_disallowed_update_type() -> None:
+    """Update type present but not in allowed list → should_process=False."""
+    state = _message_state(body={"channel_post": {"text": "news"}})
+    node = _make_parser(allowed_update_types=["message"])
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["update_type"] == "channel_post"
+
+
+@pytest.mark.asyncio
+async def test_parser_run_disallowed_chat_type() -> None:
+    """Chat type not in allowed list → should_process=False with chat_id set."""
+    state = _message_state(
+        body={
+            "message": {
+                "message_id": 5,
+                "from": {"id": 1},
+                "chat": {"id": 99, "type": "channel"},
+                "text": "hi",
+            }
+        }
+    )
+    node = _make_parser(allowed_chat_types=["private"])
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["chat_id"] == "99"
+    assert payload["username"] is None
+
+
+@pytest.mark.asyncio
+async def test_parser_run_callback_query() -> None:
+    """callback_query update is parsed correctly."""
+    state = _message_state(
+        body={
+            "callback_query": {
+                "message": {"chat": {"id": 5, "type": "private"}},
+                "from": {"id": 2, "first_name": "Bob"},
+                "data": "btn",
+            }
+        },
+    )
+    node = _make_parser(allowed_update_types=["callback_query"])
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is True
+    assert payload["update_type"] == "callback_query"
+    assert payload["text"] == "btn"
+    assert payload["username"] == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_parser_run_secret_token_mismatch() -> None:
+    """Mismatching secret token raises ValueError during run()."""
+    state = _message_state(
+        body={},
+        headers={"x-telegram-bot-api-secret-token": "wrong"},
+    )
+    node = _make_parser(secret_token="correct")
+    with pytest.raises(ValueError, match="secret token verification failed"):
+        await node(state, None)
+
+
+@pytest.mark.asyncio
+async def test_parser_run_body_as_json_string() -> None:
+    """Body delivered as a JSON string is parsed transparently."""
+    body = {
+        "update_id": 2,
+        "message": {
+            "message_id": 3,
+            "from": {"id": 1, "first_name": "Eve"},
+            "chat": {"id": 10, "type": "private"},
+            "text": "Hi",
+        },
+    }
+    state = _message_state(body=json.dumps(body))
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is True
+    assert payload["text"] == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_parser_run_invalid_json_body() -> None:
+    """An invalid JSON body string results in an empty body → should_process=False."""
+    state = _message_state(body="not json {")
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["update_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_parser_run_body_non_dict_non_string() -> None:
+    """A list body (non-dict, non-string) is treated as an empty payload."""
+    state = _message_state(body=[1, 2, 3])
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["update_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_parser_run_non_dict_headers() -> None:
+    """Non-dict headers value skips secret-token verification entirely."""
+    state = State({"inputs": {"headers": "not_a_dict", "body": {}}, "results": {}})
+    node = _make_parser(secret_token="s3cr3t")
+    # No ValueError raised despite secret_token being set
+    result = await node(state, None)
+    assert result["results"]["parser"]["should_process"] is False
+
+
+@pytest.mark.asyncio
+async def test_parser_run_should_process_false_when_no_text() -> None:
+    """should_process is False when message text is empty."""
+    state = _message_state(
+        body={
+            "message": {
+                "message_id": 1,
+                "from": {"id": 1, "first_name": "Alice"},
+                "chat": {"id": 5, "type": "private"},
+                "text": "",
+            }
+        }
+    )
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["should_process"] is False
+    assert payload["text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_parser_run_username_fallback_to_username_field() -> None:
+    """Falls back to sender.username when first_name is absent."""
+    state = _message_state(
+        body={
+            "message": {
+                "message_id": 1,
+                "from": {"id": 9, "username": "alice_bot"},
+                "chat": {"id": 3, "type": "private"},
+                "text": "hello",
+            }
+        }
+    )
+    node = _make_parser()
+    result = await node(state, None)
+    payload = result["results"]["parser"]
+
+    assert payload["username"] == "alice_bot"


### PR DESCRIPTION
## Summary

This branch adds auth-aware workflow ownership behavior across backend and Canvas, introduces new utility/integration nodes, and expands Auth0 setup documentation.

## Main Changes

- Backend workflow router now resolves `actor` from authenticated context (when auth enforcement is enabled) instead of trusting client-provided actor values.
- Backend workflow create/update now appends `workspace:<id>` tags from auth context claims, while preserving `tags=None` semantics on update.
- Workflow archive/publish/revoke routes now also use resolved authenticated actor values for auditing and logging.
- Canvas now derives default actor from JWT `sub` (access token subject) when no explicit actor is provided, for both save and delete workflow operations.
- Added Canvas integration coverage to verify JWT-subject actor propagation.
- Added `ForLoopNode` to iterate list items through stateful index progression (`done`, `index`, `iteration`, `current_item`).
- Updated `While` edge behavior to read iteration state (from loop state) but stop mutating/storing iteration internally.
- Added `AgentReplyExtractorNode` to extract the latest assistant reply from mixed agent message history.
- Reworked `RSSNode` from `feedparser`-style entry passthrough to HTTP fetch + RSS/Atom parsing with structured output:
  - returns `documents`, `errors`, `fetched_count`, `failed_sources`
  - includes per-document metadata like `source`, `read`, and `fetched_at`
- Added `TelegramEventsParserNode` to parse/validate Telegram webhook updates, including optional secret-token verification and update/chat-type filtering.
- Updated node exports/registry to expose new nodes.
- Added Auth0 IdP setup documentation and linked it into MkDocs navigation.
- Updated stack env example to request workflow/chatkit scopes by default:
  - `workflows:read workflows:execute chatkit:session`

## Test Updates

- Added backend tests for actor/workspace-tag resolution in workflow routes.
- Added/updated tests for `While` edge iteration semantics.
- Added tests for agent message handling in checkpointed flows.
- Updated RSS tests to validate the new HTTP fetch + structured response behavior.
