### PR TITLE
Add graph-store-backed AgentNode chat history and wire store support across runtime execution

### DIFF
--- a/apps/backend/src/orcheo_backend/app/_core_exports.py
+++ b/apps/backend/src/orcheo_backend/app/_core_exports.py
@@ -5,7 +5,7 @@ from pydantic import TypeAdapter as _PydanticTypeAdapter
 import orcheo_backend.app.workflow_execution as _workflow_execution_module
 from orcheo.config import get_settings
 from orcheo.graph.builder import build_graph
-from orcheo.persistence import create_checkpointer
+from orcheo.persistence import create_checkpointer, create_graph_store
 from orcheo_backend.app.authentication import (
     authenticate_request,
     authenticate_websocket,
@@ -124,6 +124,7 @@ __all__ = [
     "build_graph",
     "create_app",
     "create_checkpointer",
+    "create_graph_store",
     "execute_workflow",
     "execute_workflow_evaluation",
     "execute_workflow_training",

--- a/apps/backend/src/orcheo_backend/app/chatkit/message_utils.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/message_utils.py
@@ -28,7 +28,7 @@ with warnings.catch_warnings():
         WidgetRoot,
     )
 from langchain_core.messages import BaseMessage
-from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+from orcheo.runtime.state_builder import build_initial_state as build_runtime_state
 
 
 def collect_text_from_user_content(content: list[UserMessageContent]) -> str:
@@ -77,19 +77,10 @@ def stringify_langchain_message(message: Any) -> str:
 def build_initial_state(
     graph_config: Mapping[str, Any],
     inputs: Mapping[str, Any],
+    runtime_config: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any]:
     """Create the initial workflow state for the configured format."""
-    if graph_config.get("format") == LANGGRAPH_SCRIPT_FORMAT:
-        state = dict(inputs)
-        state.setdefault("inputs", dict(inputs))
-        state.setdefault("results", {})
-        state.setdefault("messages", [])
-        return state
-    return {
-        "messages": [],
-        "results": {},
-        "inputs": dict(inputs),
-    }
+    return build_runtime_state(graph_config, inputs, runtime_config)
 
 
 def extract_reply_from_state(state: Mapping[str, Any]) -> str | None:

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.ts
@@ -1,4 +1,5 @@
 import { SAMPLE_WORKFLOWS } from "@features/workflow/data/workflow-data";
+import { getAccessTokenSubject } from "@features/auth/lib/auth-session";
 import { computeWorkflowDiff, type WorkflowSnapshot } from "./workflow-diff";
 import {
   DEFAULT_ACTOR,

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.ts
@@ -1,5 +1,4 @@
 import { SAMPLE_WORKFLOWS } from "@features/workflow/data/workflow-data";
-import { getAccessTokenSubject } from "@features/auth/lib/auth-session";
 import { computeWorkflowDiff, type WorkflowSnapshot } from "./workflow-diff";
 import {
   DEFAULT_ACTOR,

--- a/project/initiatives/agent_chat_history/1_requirements.md
+++ b/project/initiatives/agent_chat_history/1_requirements.md
@@ -1,0 +1,147 @@
+# Requirements Document
+
+## METADATA
+- **Authors:** Codex
+- **Project/Feature Name:** Agent Chat History via LangGraph Store
+- **Type:** Enhancement
+- **Summary:** Add a LangGraph store backend (SQLite/Postgres) and let `AgentNode` optionally read/write keyed chat history from that store to improve threaded bot behavior.
+- **Owner (if different than authors):** Shaojie Jiang
+- **Date Started:** 2026-02-26
+
+## RELEVANT LINKS & STAKEHOLDERS
+
+| Documents | Link | Owner | Name |
+|-----------|------|-------|------|
+| LangGraph persistence guide | https://docs.langchain.com/oss/python/langgraph/persistence | LangChain | Store + persistence reference |
+| Existing checkpointer factory | `src/orcheo/persistence.py` | Orcheo Eng | `create_checkpointer` |
+| Agent node implementation | `src/orcheo/nodes/ai.py` | Orcheo Eng | `AgentNode` message handling |
+| Backend graph compilation paths | `apps/backend/src/orcheo_backend/app/workflow_execution.py` | Orcheo Eng | Workflow execution compile points |
+| Initiative requirements | `./1_requirements.md` | Shaojie Jiang | This document |
+| Initiative design | `./2_design.md` | Shaojie Jiang | Technical design |
+| Initiative plan | `./3_plan.md` | Shaojie Jiang | Milestones and tasks |
+
+## PROBLEM DEFINITION
+### Objectives
+Add a first-class graph store backend, matching the checkpointer backend strategy, with SQLite and Postgres support and wiring to all backend graph compilations. Extend `AgentNode` with an opt-in toggle to load keyed chat history from graph store, merge it with current thread messages, and trim to `max_messages`.
+
+### Target users
+Workflow authors building threaded bot backends (for example, WeCom CS bots, Telegram bots) and backend operators managing Orcheo runtime persistence.
+
+### User Stories
+| As a... | I want to... | So that... | Priority | Acceptance Criteria |
+|---------|--------------|------------|----------|---------------------|
+| Workflow author | Enable graph-store-backed history in `AgentNode` | My bot can continue conversations across webhook runs for the same chat/session | P0 | When toggle is enabled and a stable conversation key is resolved, node loads prior messages, merges with current thread messages, and limits to `max_messages` |
+| Workflow author | Keep this feature optional | Existing workflows stay unchanged | P0 | Default behavior remains unchanged when toggle is disabled |
+| Backend operator | Configure graph store with SQLite or Postgres | Persistence behavior matches deployment backend | P0 | Settings validation supports both backends and graph compilation receives a store instance |
+| Backend operator | Observe history-store failures without run crashes | I can troubleshoot safely | P1 | Store read/write failures are logged and node falls back to in-memory message assembly |
+
+### Context, Problems, Opportunities
+Current backend wiring compiles graphs with checkpointer only. `AgentNode` currently derives messages from state/input and truncates locally, but does not read/write a shared keyed chat history store. For messaging channels with repeated callbacks per chat, this can lose continuity unless external state assembly is done manually. Webhook runs currently bind `thread_id` to per-run execution IDs, so `thread_id` alone is not a stable chat key for WeCom CS/Telegram callbacks. LangGraph store support provides a natural place to persist lightweight conversation context keyed by a stable conversation identity.
+
+### Product goals and Non-goals
+Goals:
+- Add graph store backend creation with SQLite/Postgres parity to checkpointer handling.
+- Pass store into all backend `graph.compile(...)` paths.
+- Add configurable, opt-in chat-history loading in `AgentNode`.
+- Keep only latest `max_messages` for inference after merge; store full history append-only.
+
+Non-goals:
+- Replacing checkpointer state semantics.
+- Building long-term memory retrieval/ranking.
+- Introducing summarization/compression in this iteration.
+- Cross-thread identity resolution.
+
+## PRODUCT DEFINITION
+### Requirements
+P0:
+- Add `create_graph_store(settings)` in persistence utilities, similar lifecycle to `create_checkpointer(settings)`.
+- Support `sqlite` and `postgres` graph store backends.
+- Add settings for graph store backend/path with environment validation.
+- Update all backend graph compilation entry points to pass both `checkpointer` and `store`.
+- Add `AgentNode` toggle (for example `use_graph_chat_history: bool = False`).
+- When toggle is `True`:
+  - Resolve a stable conversation key with this precedence:
+    - Explicit override from a previous node result, config, or input (for example `{{results.resolve_history_key.session_key}}`, `{{configurable.history_key}}`, or `{{inputs.history_key}}`).
+    - Channel-derived key from parsed payload fields:
+      - Telegram: `telegram:{{results.telegram_events_parser.chat_id}}`
+      - WeCom Customer Service: `wecom_cs:{{results.wecom_cs_sync.open_kf_id}}:{{results.wecom_cs_sync.external_userid}}`
+      - WeCom AI bot: `wecom_aibot:{{results.wecom_ai_bot_events_parser.chat_type}}:{{results.wecom_ai_bot_events_parser.user}}`
+      - WeCom internal direct message: `wecom_dm:{{results.wecom_events_parser.user}}`
+    - Fallback: `{{thread_id}}` for non-webhook/manual flows.
+  - Key fields (`history_key_template`, `history_key_candidates`) must support both:
+    - Literal values (for example `support-room-1`)
+    - Orcheo template strings `{{...}}` (including previous node outputs via `results.*`)
+  - Read stored history before agent run (tail window up to `max_messages`).
+  - Merge stored history tail with current thread messages for this invocation.
+  - Keep latest `max_messages` for inference.
+  - Append newly observed user/assistant turns to full history in graph store after run (full history grows append-only; `max_messages` cap applies only to the inference payload).
+- When toggle is `False`, preserve current behavior.
+
+P1:
+- Add configurable keying fields (`history_namespace`, `history_key_template`, `history_key_candidates`, `history_value_field`).
+- Add best-effort error handling and structured logs for store operations.
+
+Out of scope:
+- Automatic redaction and PII classification.
+- Semantic retrieval over historic messages.
+
+### Designs (if applicable)
+See `./2_design.md`.
+
+### [Optional] Other Teams Impacted
+- **Backend Runtime:** configuration and compile wiring updates.
+- **Workflow Authors:** optional new node fields and expectations around stable conversation-key inputs.
+
+## TECHNICAL CONSIDERATIONS
+### Architecture Overview
+Introduce a dedicated graph store factory in `src/orcheo/persistence.py`, add configuration surface in `orcheo.config`, and wire store instances into backend compile paths that already inject checkpointer. `AgentNode` consumes the runtime store via LangGraph context and performs keyed history load/merge/trim/persist around agent invocation.
+
+### Technical Requirements
+- Store backend validation and defaults must be deterministic and backward compatible.
+- Postgres mode requires DSN and compatible pool options.
+- Store setup/migrations (`store.setup()`) must run during startup/first use similarly to checkpointer setup.
+- Agent history merge should normalize stored entries into `BaseMessage` equivalents.
+- History retrieval requires a resolved conversation key; if unavailable, skip store logic safely.
+- Key resolution must support literal values and Orcheo `{{...}}` templates for both `history_key_template` and `history_key_candidates`.
+- Keep message ordering stable (oldest to newest before trimming tail).
+
+### AI/ML Considerations (if applicable)
+Not applicable.
+
+## MARKET DEFINITION
+Internal enhancement for Orcheo runtime and bot workflow authors.
+
+## LAUNCH/ROLLOUT PLAN
+### Success metrics
+| KPIs | Target & Rationale |
+|------|--------------------|
+| Graph compile compatibility | 100% backend compile paths continue to execute with store enabled/disabled |
+| Agent history continuity | For repeated callbacks with the same conversation key, prior turns are present in payload when toggle is enabled |
+| Regression guardrail | No behavior change in existing workflows with toggle disabled |
+
+### Rollout Strategy
+- Implement behind opt-in node field (default `False`).
+- Validate SQLite first in local/staging, then Postgres staging.
+- Enable feature in selected bot workflows before wider use.
+
+### Experiment Plan (if applicable)
+No formal A/B test; use staged workflow validation with replayed thread samples.
+
+### Estimated Launch Phases (if applicable)
+| Phase | Target | Description |
+|-------|--------|-------------|
+| **Phase 1** | Dev/staging (SQLite) | Validate store factory, compile wiring, and node history behavior |
+| **Phase 2** | Staging (Postgres) | Validate DSN/pool setup and end-to-end chat continuity |
+| **Phase 3** | Production opt-in | Enable for selected WeCom/Telegram workflows |
+
+## HYPOTHESIS & RISKS
+- **Hypothesis:** Persisting bounded thread history in graph store improves multi-turn response quality for channel bots without forcing external session assembly.
+- **Risk:** Duplicate or conflicting memory sources (checkpointer state vs graph store) can cause confusion.
+  - **Mitigation:** Keep graph-store history explicitly opt-in and documented as chat history source for `AgentNode` only.
+- **Risk:** Storage growth and sensitive data retention.
+  - **Mitigation:** Keep bounded window (`max_messages`), add retention/TTL follow-up, and avoid storing unnecessary payload fields.
+- **Risk:** Missing/unstable conversation keys lead to fragmented history.
+  - **Mitigation:** Prefer explicit/channel-derived keys, keep `thread_id` only as fallback, and log key-resolution failures.
+
+## APPENDIX
+None.

--- a/project/initiatives/agent_chat_history/2_design.md
+++ b/project/initiatives/agent_chat_history/2_design.md
@@ -6,7 +6,7 @@
 - **Author:** Codex
 - **Owner:** Shaojie Jiang
 - **Date:** 2026-02-26
-- **Status:** Draft
+- **Status:** Approved
 
 ---
 
@@ -31,6 +31,7 @@ On top of that, `AgentNode` gains an opt-in mode to consume chat history from gr
 - **Backend Execution Wiring (`apps/backend/...`)**
   - Extends compile call sites to `graph.compile(checkpointer=..., store=...)`.
   - Applies to workflow execution, triggers, worker tasks, and ChatKit workflow executor.
+  - Uses a shared runtime initial-state builder so `state["config"]` is assembled consistently across entrypoints for mapping-based payloads.
 
 - **AgentNode (`src/orcheo/nodes/ai.py`)**
   - Adds opt-in fields controlling graph-store chat history behavior and keying.
@@ -49,8 +50,8 @@ On top of that, `AgentNode` gains an opt-in mode to consume chat history from gr
 ### Flow 2: AgentNode run with graph-store history enabled
 
 1. `AgentNode.run(...)` receives state and runtime config.
-2. Node resolves message candidates from state/input and gathers key candidates from config and parsed payload fields (literal values or Orcheo templates like `{{results.some_node.some_field}}`).
-3. Node resolves namespace/key using precedence (explicit key override, channel-derived stable key, then `thread_id` fallback).
+2. Node resolves message candidates from state/input and evaluates configured key candidates from workflow state (literal values or Orcheo templates such as `{{results.some_node.some_field}}`).
+3. Node resolves namespace/key using configured candidate order (channel-derived defaults; workflow-specific overrides only when authors add candidates explicitly).
 4. Node loads conversation metadata and fetches only the latest history tail required for inference.
 5. Node normalizes and merges `history_tail + current_thread_messages`.
 6. Node trims to latest `max_messages` and invokes agent.
@@ -88,18 +89,11 @@ history_namespace: list[str] = ["agent_chat_history"]
 # Supports literal values (for example "shared-room") or Orcheo templates.
 history_key_template: str = "{{conversation_key}}"
 history_key_candidates: list[str] = [
-    "{{results.resolve_history_key.session_key}}",
-    "{{configurable.history_key}}",
-    "{{inputs.history_key}}",
     "telegram:{{results.telegram_events_parser.chat_id}}",
     "wecom_cs:{{results.wecom_cs_sync.open_kf_id}}:{{results.wecom_cs_sync.external_userid}}",
     "wecom_aibot:{{results.wecom_ai_bot_events_parser.chat_type}}:{{results.wecom_ai_bot_events_parser.user}}",
     "wecom_dm:{{results.wecom_events_parser.user}}",
-    "{{thread_id}}",
 ]
-history_meta_key_suffix: str = "__meta__"
-# Chunk size tuned to balance write amplification and tail-read latency.
-history_chunk_size: int = 200
 history_value_field: str = "content"
 ```
 
@@ -158,7 +152,7 @@ history_value_field: str = "content"
 - Candidate/template syntax:
   - Literal string is allowed (for example `support-room-1`)
   - Orcheo template syntax `{{...}}` is allowed (for example `telegram:{{results.telegram_events_parser.chat_id}}`)
-  - Templates may reference runtime state such as `inputs`, `results`, `configurable`, and `thread_id`
+  - Templates resolve against workflow state paths (for example `inputs.*`, `results.*`, `config.*`, including `config.configurable.*`)
 - Key: resolved from `history_key_template` (literal or template) with `conversation_key` available in scope
 - Validation/canonicalization rules:
   - Evaluate candidates in declared order after template render.
@@ -181,7 +175,6 @@ history_value_field: str = "content"
 - Full history can grow unbounded for analytics/audit use cases without slowing inference path.
 - Use optimistic concurrency for metadata/chunk updates to avoid lost writes under concurrent callbacks.
 - For Postgres backend, reuse pooled connections via store factory config.
-- `history_chunk_size=200` is chosen to keep per-item payload size moderate while reducing metadata churn from overly small chunks.
 
 ## Error Handling
 
@@ -222,8 +215,7 @@ history_value_field: str = "content"
   - Reproducible key-resolution scenarios with fixed fixtures:
     - `telegram:{{results.telegram_events_parser.chat_id}}`
     - `wecom_cs:{{results.wecom_cs_sync.open_kf_id}}:{{results.wecom_cs_sync.external_userid}}`
-    - Explicit override candidate outranking channel-derived candidates.
-    - Fallback to `{{thread_id}}` in non-webhook/manual runs only.
+    - Explicit custom override candidate (for example `{{results.resolve_history_key.session_key}}`) outranking channel-derived candidates when included by workflow authors.
 
 - **Manual QA checklist**
   - Simulate WeCom/Telegram callbacks with stable payload IDs (same `chat_id` / same `open_kf_id + external_userid`).
@@ -251,5 +243,6 @@ history_value_field: str = "content"
 
 | Date | Author | Changes |
 |------|--------|---------|
+| 2026-02-27 | Codex | Updated key-candidate defaults, removed `thread_id` fallback references, and clarified state-based `{{config.*}}` resolution contract |
 | 2026-02-27 | Codex | Added key validation, retry/backoff limits, explicit fallback behavior, observability, rollback and migration details |
 | 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/2_design.md
+++ b/project/initiatives/agent_chat_history/2_design.md
@@ -1,0 +1,204 @@
+# Design Document
+
+## For Agent Chat History via LangGraph Store
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Owner:** Shaojie Jiang
+- **Date:** 2026-02-26
+- **Status:** Draft
+
+---
+
+## Overview
+
+This design adds a dedicated LangGraph store backend to Orcheo runtime and wires it into graph compilation alongside the existing checkpointer. The store supports SQLite and Postgres, mirroring current persistence backend options used in backend execution paths.
+
+On top of that, `AgentNode` gains an opt-in mode to consume chat history from graph store. When enabled, the node resolves a keyed conversation identity, reads only the latest window required for inference (`max_messages`), and appends new user/assistant turns to persisted full history. This is intended for bot backends where each callback may not include full prior context.
+
+## Components
+
+- **Config Layer (`orcheo.config`)**
+  - Adds graph store backend and path fields (plus validation) parallel to checkpoint backend.
+  - Ensures Postgres DSN requirements are enforced when graph store backend is `postgres`.
+
+- **Persistence Factory (`src/orcheo/persistence.py`)**
+  - Adds `create_graph_store(settings)` async context manager.
+  - Uses LangGraph `AsyncSqliteStore` or `AsyncPostgresStore`.
+  - Calls `store.setup()` before use.
+
+- **Backend Execution Wiring (`apps/backend/...`)**
+  - Extends compile call sites to `graph.compile(checkpointer=..., store=...)`.
+  - Applies to workflow execution, triggers, worker tasks, and ChatKit workflow executor.
+
+- **AgentNode (`src/orcheo/nodes/ai.py`)**
+  - Adds opt-in fields controlling graph-store chat history behavior and keying.
+  - Reads only a recent tail window before run, merges with current messages, trims to `max_messages` for inference, then appends newly observed turns to full history.
+
+## Request Flows
+
+### Flow 1: Compile graph with checkpointer + store
+
+1. Backend loads runtime settings.
+2. Backend opens checkpointer context (`create_checkpointer(settings)`).
+3. Backend opens graph store context (`create_graph_store(settings)`).
+4. Backend compiles with both: `graph.compile(checkpointer=checkpointer, store=store)`.
+5. Compiled graph execution proceeds unchanged for nodes not using store.
+
+### Flow 2: AgentNode run with graph-store history enabled
+
+1. `AgentNode.run(...)` receives state and runtime config.
+2. Node resolves message candidates from state/input and gathers key candidates from config and parsed payload fields (literal values or Orcheo templates like `{{results.some_node.some_field}}`).
+3. Node resolves namespace/key using precedence (explicit key override, channel-derived stable key, then `thread_id` fallback).
+4. Node loads conversation metadata and fetches only the latest history tail required for inference.
+5. Node normalizes and merges `history_tail + current_thread_messages`.
+6. Node trims to latest `max_messages` and invokes agent.
+7. Node appends newly observed user/assistant messages to full history and updates metadata (best effort with retry on version conflict).
+
+### Flow 3: AgentNode run with history disabled or unavailable
+
+1. Toggle is `False`, or no conversation key can be resolved, or store unavailable.
+2. Node executes current in-memory message path only.
+3. No graph store read/write performed.
+
+## API Contracts
+
+### Runtime settings (proposed)
+
+```env
+ORCHEO_GRAPH_STORE_BACKEND=sqlite|postgres
+ORCHEO_GRAPH_STORE_SQLITE_PATH=~/.orcheo/graph_store.sqlite
+# Uses ORCHEO_POSTGRES_DSN and shared pool settings when backend=postgres
+```
+
+### Internal persistence API
+
+```python
+@asynccontextmanager
+async def create_graph_store(settings: Dynaconf) -> AsyncIterator[Any]:
+    ...
+```
+
+### AgentNode fields (proposed)
+
+```python
+use_graph_chat_history: bool = False
+history_namespace: list[str] = ["agent_chat_history"]
+# Supports literal values (for example "shared-room") or Orcheo templates.
+history_key_template: str = "{{conversation_key}}"
+history_key_candidates: list[str] = [
+    "{{results.resolve_history_key.session_key}}",
+    "{{configurable.history_key}}",
+    "{{inputs.history_key}}",
+    "telegram:{{results.telegram_events_parser.chat_id}}",
+    "wecom_cs:{{results.wecom_cs_sync.open_kf_id}}:{{results.wecom_cs_sync.external_userid}}",
+    "wecom_aibot:{{results.wecom_ai_bot_events_parser.chat_type}}:{{results.wecom_ai_bot_events_parser.user}}",
+    "wecom_dm:{{results.wecom_events_parser.user}}",
+    "{{thread_id}}",
+]
+history_meta_key_suffix: str = "__meta__"
+history_chunk_size: int = 200
+history_value_field: str = "content"
+```
+
+## Data Models / Schemas
+
+### Graph store metadata item
+
+```json
+{
+  "conversation_key": "telegram:123456789",
+  "last_seq": 4231,
+  "chunk_size": 200,
+  "latest_chunk_key": "chunk:000021",
+  "updated_at": "2026-02-26T20:30:00Z",
+  "version": 17
+}
+```
+
+### Graph store chunk item (append-only history segments)
+
+```json
+{
+  "conversation_key": "telegram:123456789",
+  "chunk_key": "chunk:000021",
+  "start_seq": 4201,
+  "end_seq": 4231,
+  "messages": [
+    {"seq": 4228, "role": "user", "content": "Hi"},
+    {"seq": 4229, "role": "assistant", "content": "Hello"},
+    {"seq": 4230, "role": "user", "content": "Need help"},
+    {"seq": 4231, "role": "assistant", "content": "Sure"}
+  ],
+  "updated_at": "2026-02-26T20:30:00Z"
+}
+```
+
+### Read/write behavior
+
+- **Tail read for inference**
+  - Read metadata by conversation key.
+  - Fetch latest chunk(s) backward until collecting at least `max_messages`.
+  - Return only newest `max_messages` in chronological order for prompt assembly.
+- **Append for persistence**
+  - Assign new monotonically increasing `seq` values from metadata `last_seq`.
+  - Append only newly observed user and assistant turns to the latest chunk (or create next chunk if full).
+  - Update metadata (`last_seq`, `latest_chunk_key`, `updated_at`, `version`) with optimistic concurrency and retry.
+
+### Key resolution
+
+- Namespace: tuple from `history_namespace` (for example `("agent_chat_history",)`)
+- Conversation key: first non-empty key resolved from `history_key_candidates`
+- Candidate/template syntax:
+  - Literal string is allowed (for example `support-room-1`)
+  - Orcheo template syntax `{{...}}` is allowed (for example `telegram:{{results.telegram_events_parser.chat_id}}`)
+  - Templates may reference runtime state such as `inputs`, `results`, `configurable`, and `thread_id`
+- Key: resolved from `history_key_template` (literal or template) with `conversation_key` available in scope
+
+## Security Considerations
+
+- Chat history may contain sensitive content; storing only required fields (`role`, `content`) reduces exposure.
+- Keep store usage explicit (`use_graph_chat_history=False` by default).
+- Ensure DSN and credentials stay in env/vault and are never logged.
+- Add warning-level logs on store failures without dumping message bodies.
+
+## Performance Considerations
+
+- Inference path is bounded by `max_messages`: metadata read + latest chunk reads only (not full transcript scan).
+- Persistence path appends only deltas; it does not rewrite the full history blob on each turn.
+- Full history can grow unbounded for analytics/audit use cases without slowing inference path.
+- Use optimistic concurrency for metadata/chunk updates to avoid lost writes under concurrent callbacks.
+- For Postgres backend, reuse pooled connections via store factory config.
+
+## Testing Strategy
+
+- **Unit tests**
+  - `create_graph_store` for SQLite and Postgres paths, setup call, and invalid backend handling.
+  - Config validation/default tests for graph store env vars.
+  - `AgentNode` history logic: toggle on/off, key resolution, tail read to `max_messages`, append-only writes, chunk rollover, reset command interaction.
+
+- **Integration tests**
+  - Backend compile paths include `store` argument in addition to checkpointer.
+  - Repeated callbacks with the same resolved conversation key recover recent context while full history keeps growing append-only.
+  - Concurrent callbacks on the same conversation key do not lose appended turns (retry/version path).
+
+- **Manual QA checklist**
+  - Simulate WeCom/Telegram callbacks with stable payload IDs (same `chat_id` / same `open_kf_id + external_userid`).
+  - Verify context continuity across separate runs.
+  - Verify latest `max_messages` retrieval latency remains stable after very long sessions.
+  - Verify full transcript remains complete and ordered by `seq`.
+  - Verify disabling toggle restores old behavior.
+
+## Rollout Plan
+
+1. Phase 1 (Dev/staging — SQLite): Implement store factory/config and compile wiring; validate with SQLite backend in dev/staging.
+2. Phase 2 (Staging — Postgres): Implement `AgentNode` toggle + history behavior; validate DSN/pool setup and end-to-end chat continuity with Postgres backend in staging.
+3. Phase 3 (Production opt-in): Enable for selected WeCom/Telegram bot workflows with monitoring.
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/3_plan.md
+++ b/project/initiatives/agent_chat_history/3_plan.md
@@ -6,7 +6,7 @@
 - **Author:** Codex
 - **Owner:** Shaojie Jiang
 - **Date:** 2026-02-26
-- **Status:** Draft
+- **Status:** Approved
 
 ---
 
@@ -28,13 +28,13 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 1.1: Add config types/defaults in `src/orcheo/config/app_settings.py` (`AppSettings`) for graph store backend and sqlite path.
+- [x] Task 1.1: Add config types/defaults in `src/orcheo/config/app_settings.py` (`AppSettings`) for graph store backend and sqlite path.
   - Dependencies: None
-- [ ] Task 1.2: Add validation rules in `AppSettings` and loader normalization (absolute SQLite path; reject `~` and relative values).
+- [x] Task 1.2: Add validation rules in `AppSettings` and loader normalization (absolute SQLite path; reject `~` and relative values).
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
+- [x] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
   - Dependencies: Task 1.2
-- [ ] Task 1.4: Add persistence tests for graph store factory (sqlite/postgres/error paths).
+- [x] Task 1.4: Add persistence tests for graph store factory (sqlite/postgres/error paths).
   - Dependencies: Task 1.3
 
 ---
@@ -45,11 +45,11 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 2.1: Update workflow execution compile paths to include `store`.
+- [x] Task 2.1: Update workflow execution compile paths to include `store`.
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Update trigger/worker/ChatKit executor compile paths to include `store`.
+- [x] Task 2.2: Update trigger/worker/ChatKit executor compile paths to include `store`.
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Add/adjust backend unit tests that patch compile calls to assert `store` wiring.
+- [x] Task 2.3: Add/adjust backend unit tests that patch compile calls to assert `store` wiring.
   - Dependencies: Task 2.2
 
 ---
@@ -60,16 +60,16 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable conversation-key precedence (explicit/channel-derived before `thread_id` fallback).
-  - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) including `results.*` references.
+- [x] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable channel-derived default key candidates.
+  - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) resolved from workflow state (for example `results.*`, `inputs.*`, `config.*`).
   - Dependencies: Milestone 1
-- [ ] Task 3.2: Implement deterministic key validation (empty/unresolved-template/invalid-char/length checks) before store read/write.
+- [x] Task 3.2: Implement deterministic key validation (empty/unresolved-template/invalid-char/length checks) before store read/write.
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Implement store read and message normalization path before agent invoke.
+- [x] Task 3.3: Implement store read and message normalization path before agent invoke.
   - Dependencies: Task 3.1
-- [ ] Task 3.4: Implement merge + `max_messages` trimming + post-run store update with bounded optimistic-concurrency retry policy.
+- [x] Task 3.4: Implement merge + `max_messages` trimming + post-run store update with bounded optimistic-concurrency retry policy.
   - Dependencies: Task 3.3
-- [ ] Task 3.5: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
+- [x] Task 3.5: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
   - Acceptance note: include test cases for literal keys and `{{...}}` template keys resolved from previous node results.
   - Acceptance note: include explicit Telegram and WeCom CS fixture cases and persistent-conflict fallback behavior.
   - Dependencies: Task 3.4
@@ -82,7 +82,7 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 4.1: Run targeted test suites for config, persistence, backend workflow execution, and AI node message handling.
+- [x] Task 4.1: Run targeted test suites for config, persistence, backend workflow execution, and AI node message handling.
   - Dependencies: Milestones 2 and 3
 - [ ] Task 4.2: SQLite staging verification — validate store factory, compile wiring, and node history behavior with SQLite backend using repeated callbacks with stable conversation IDs (WeCom/Telegram-like payloads).
   - Dependencies: Task 4.1
@@ -90,9 +90,9 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
   - Dependencies: Task 4.2
 - [ ] Task 4.4: Add observability signals (metrics/log fields) and verify dashboards/alerts for read/write failures, key-resolution failures, and truncation events.
   - Dependencies: Task 4.3
-- [ ] Task 4.5: Document rollback playbook per rollout phase (SQLite staging, Postgres staging, production opt-in).
+- [x] Task 4.5: Document rollback playbook per rollout phase (SQLite staging, Postgres staging, production opt-in).
   - Dependencies: Task 4.4
-- [ ] Task 4.6: Publish migration + user-facing guidance for workflows moving from manual session assembly to graph-store chat history.
+- [x] Task 4.6: Publish migration + user-facing guidance for workflows moving from manual session assembly to graph-store chat history.
   - Dependencies: Task 4.5
 
 ---
@@ -101,5 +101,6 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 | Date | Author | Changes |
 |------|--------|---------|
+| 2026-02-27 | Codex | Updated Milestone 3 notes to reflect channel-derived default candidates and state-based template resolution |
 | 2026-02-27 | Codex | Clarified config module targets, added key-validation/retry tasks, observability, rollback, and migration documentation tasks |
 | 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/3_plan.md
+++ b/project/initiatives/agent_chat_history/3_plan.md
@@ -1,0 +1,97 @@
+# Project Plan
+
+## For Agent Chat History via LangGraph Store
+
+- **Version:** 0.1
+- **Author:** Codex
+- **Owner:** Shaojie Jiang
+- **Date:** 2026-02-26
+- **Status:** Draft
+
+---
+
+## Overview
+
+Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-history behavior for threaded bot backends, while preserving backward compatibility for existing workflows.
+
+**Related Documents:**
+- Requirements: `./1_requirements.md`
+- Design: `./2_design.md`
+
+---
+
+## Milestones
+
+### Milestone 1: Graph Store Foundation
+
+**Description:** Add store backend configuration and persistence factory, parallel to checkpointer behavior.
+
+#### Task Checklist
+
+- [ ] Task 1.1: Add config types/defaults for graph store backend and sqlite path.
+  - Dependencies: None
+- [ ] Task 1.2: Add validation rules in `AppSettings` and loader normalization.
+  - Dependencies: Task 1.1
+- [ ] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
+  - Dependencies: Task 1.2
+- [ ] Task 1.4: Add persistence tests for graph store factory (sqlite/postgres/error paths).
+  - Dependencies: Task 1.3
+
+---
+
+### Milestone 2: Backend Compile Wiring
+
+**Description:** Ensure all runtime compilation paths receive both checkpointer and store.
+
+#### Task Checklist
+
+- [ ] Task 2.1: Update workflow execution compile paths to include `store`.
+  - Dependencies: Milestone 1
+- [ ] Task 2.2: Update trigger/worker/ChatKit executor compile paths to include `store`.
+  - Dependencies: Task 2.1
+- [ ] Task 2.3: Add/adjust backend unit tests that patch compile calls to assert `store` wiring.
+  - Dependencies: Task 2.2
+
+---
+
+### Milestone 3: AgentNode Graph Chat History
+
+**Description:** Add opt-in node behavior to load/merge/trim/persist chat history from graph store.
+
+#### Task Checklist
+
+- [ ] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable conversation-key precedence (explicit/channel-derived before `thread_id` fallback).
+  - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) including `results.*` references.
+  - Dependencies: Milestone 1
+- [ ] Task 3.2: Implement store read and message normalization path before agent invoke.
+  - Dependencies: Task 3.1
+- [ ] Task 3.3: Implement merge + `max_messages` trimming + post-run store update.
+  - Dependencies: Task 3.2
+- [ ] Task 3.4: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
+  - Acceptance note: include test cases for literal keys and `{{...}}` template keys resolved from previous node results.
+  - Dependencies: Task 3.3
+
+---
+
+### Milestone 4: Hardening, Validation, and Reflection
+
+**Description:** Validate behavior in bot-like scenarios and document operational guidance.
+
+#### Task Checklist
+
+- [ ] Task 4.1: Run targeted test suites for config, persistence, backend workflow execution, and AI node message handling.
+  - Dependencies: Milestones 2 and 3
+- [ ] Task 4.2: SQLite staging verification — validate store factory, compile wiring, and node history behavior with SQLite backend using repeated callbacks with stable conversation IDs (WeCom/Telegram-like payloads).
+  - Dependencies: Task 4.1
+- [ ] Task 4.3: Postgres staging verification — validate DSN/pool setup and end-to-end chat continuity with Postgres backend using the same callback scenarios.
+  - Dependencies: Task 4.2
+- [ ] Task 4.4: Document guidance on when to use graph-store chat history and known risks (retention, duplication, key quality).
+  - Dependencies: Task 4.3
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/3_plan.md
+++ b/project/initiatives/agent_chat_history/3_plan.md
@@ -2,7 +2,7 @@
 
 ## For Agent Chat History via LangGraph Store
 
-- **Version:** 0.1
+- **Version:** 0.2
 - **Author:** Codex
 - **Owner:** Shaojie Jiang
 - **Date:** 2026-02-26
@@ -28,9 +28,9 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 1.1: Add config types/defaults for graph store backend and sqlite path.
+- [ ] Task 1.1: Add config types/defaults in `src/orcheo/config/app_settings.py` (`AppSettings`) for graph store backend and sqlite path.
   - Dependencies: None
-- [ ] Task 1.2: Add validation rules in `AppSettings` and loader normalization.
+- [ ] Task 1.2: Add validation rules in `AppSettings` and loader normalization (absolute SQLite path; reject `~` and relative values).
   - Dependencies: Task 1.1
 - [ ] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
   - Dependencies: Task 1.2
@@ -63,13 +63,16 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 - [ ] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable conversation-key precedence (explicit/channel-derived before `thread_id` fallback).
   - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) including `results.*` references.
   - Dependencies: Milestone 1
-- [ ] Task 3.2: Implement store read and message normalization path before agent invoke.
+- [ ] Task 3.2: Implement deterministic key validation (empty/unresolved-template/invalid-char/length checks) before store read/write.
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Implement merge + `max_messages` trimming + post-run store update.
-  - Dependencies: Task 3.2
-- [ ] Task 3.4: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
-  - Acceptance note: include test cases for literal keys and `{{...}}` template keys resolved from previous node results.
+- [ ] Task 3.3: Implement store read and message normalization path before agent invoke.
+  - Dependencies: Task 3.1
+- [ ] Task 3.4: Implement merge + `max_messages` trimming + post-run store update with bounded optimistic-concurrency retry policy.
   - Dependencies: Task 3.3
+- [ ] Task 3.5: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
+  - Acceptance note: include test cases for literal keys and `{{...}}` template keys resolved from previous node results.
+  - Acceptance note: include explicit Telegram and WeCom CS fixture cases and persistent-conflict fallback behavior.
+  - Dependencies: Task 3.4
 
 ---
 
@@ -85,8 +88,12 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
   - Dependencies: Task 4.1
 - [ ] Task 4.3: Postgres staging verification — validate DSN/pool setup and end-to-end chat continuity with Postgres backend using the same callback scenarios.
   - Dependencies: Task 4.2
-- [ ] Task 4.4: Document guidance on when to use graph-store chat history and known risks (retention, duplication, key quality).
+- [ ] Task 4.4: Add observability signals (metrics/log fields) and verify dashboards/alerts for read/write failures, key-resolution failures, and truncation events.
   - Dependencies: Task 4.3
+- [ ] Task 4.5: Document rollback playbook per rollout phase (SQLite staging, Postgres staging, production opt-in).
+  - Dependencies: Task 4.4
+- [ ] Task 4.6: Publish migration + user-facing guidance for workflows moving from manual session assembly to graph-store chat history.
+  - Dependencies: Task 4.5
 
 ---
 
@@ -94,4 +101,5 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 | Date | Author | Changes |
 |------|--------|---------|
+| 2026-02-27 | Codex | Clarified config module targets, added key-validation/retry tasks, observability, rollback, and migration documentation tasks |
 | 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/4_rollout_playbook.md
+++ b/project/initiatives/agent_chat_history/4_rollout_playbook.md
@@ -1,0 +1,82 @@
+# Rollout Playbook
+
+- **Version:** 0.2
+- **Author:** Codex
+- **Owner:** Shaojie Jiang
+- **Date:** 2026-02-27
+
+## Scope
+
+Operational rollback and migration guidance for graph-store-backed `AgentNode` chat history.
+
+## Rollback Playbook
+
+### Phase 1: SQLite Staging
+
+Trigger conditions:
+- Graph compilation fails after store wiring changes.
+- SQLite store setup/read/write errors regress staging stability.
+
+Rollback:
+1. Set `ORCHEO_GRAPH_STORE_BACKEND=sqlite` and keep `ORCHEO_GRAPH_STORE_SQLITE_PATH` pointed at a valid absolute path for diagnostics.
+2. Disable workflow-level history usage by setting `use_graph_chat_history=false` for affected `AgentNode` definitions.
+3. Redeploy backend/worker services.
+4. Validate that workflow runs still succeed with checkpointer-only behavior.
+
+### Phase 2: Postgres Staging
+
+Trigger conditions:
+- DSN/pool configuration errors.
+- Persistent store write conflicts or latency regressions.
+
+Rollback:
+1. Switch `ORCHEO_GRAPH_STORE_BACKEND=sqlite` for staging workloads.
+2. Keep `use_graph_chat_history=false` on unstable workflows until Postgres configuration is corrected.
+3. Redeploy services and rerun callback replay validation.
+
+### Phase 3: Production Opt-In
+
+Trigger conditions:
+- Channel-specific key resolution failures.
+- Elevated graph-history read/write failures.
+
+Rollback:
+1. Disable `use_graph_chat_history` on affected production workflows first (fastest and lowest-risk rollback).
+2. If backend-wide issues persist, switch to `ORCHEO_GRAPH_STORE_BACKEND=sqlite` with a known-good path.
+3. If required, roll back backend image to previous release and keep the feature toggle disabled.
+
+## Migration Guidance
+
+### Prerequisites
+
+1. Configure graph store:
+  - `ORCHEO_GRAPH_STORE_BACKEND=sqlite|postgres`
+  - `ORCHEO_GRAPH_STORE_SQLITE_PATH` must be absolute when backend is `sqlite`
+  - `ORCHEO_POSTGRES_DSN` required when backend is `postgres`
+2. Ensure workflows compile with both checkpointer and store wiring (covered by backend unit tests).
+
+### Node Configuration Migration
+
+1. Enable feature per `AgentNode`:
+  - `use_graph_chat_history: true`
+2. Keep defaults unless customization is needed:
+  - `history_namespace: ["agent_chat_history"]`
+  - `history_key_template: "{{conversation_key}}"`
+3. Keep default channel-derived `history_key_candidates`; add custom candidates only when workflow-specific keys are required (for example `{{results.resolve_history_key.session_key}}` or `{{config.configurable.history_key}}`).
+
+### Validation Checklist
+
+1. Replay repeated callbacks for the same Telegram/WeCom identities and verify context continuity.
+2. Confirm unresolved or invalid keys do not crash runs (node should degrade to in-memory behavior).
+3. Verify truncation behavior: inference payload keeps latest `max_messages`, while store history keeps appended turns.
+4. Monitor warning logs for:
+  - key-resolution failures
+  - store read failures
+  - store write conflicts/failures
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-02-27 | Codex | Updated migration guidance to remove `thread_id` fallback dependency and align custom key examples with state-based `{{config.*}}` templates |
+| 2026-02-27 | Codex | Initial draft |

--- a/src/orcheo/config/__init__.py
+++ b/src/orcheo/config/__init__.py
@@ -12,6 +12,7 @@ from orcheo.config.loader import (
 from orcheo.config.types import (
     ChatKitBackend,
     CheckpointBackend,
+    GraphStoreBackend,
     RepositoryBackend,
     VaultBackend,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "VaultSettings",
     "ChatKitBackend",
     "CheckpointBackend",
+    "GraphStoreBackend",
     "RepositoryBackend",
     "VaultBackend",
     "_DEFAULTS",

--- a/src/orcheo/config/defaults.py
+++ b/src/orcheo/config/defaults.py
@@ -1,8 +1,13 @@
 """Default values shared across configuration models."""
 
+from pathlib import Path
+
+
 _DEFAULTS: dict[str, object] = {
     "CHECKPOINT_BACKEND": "sqlite",
     "SQLITE_PATH": "~/.orcheo/checkpoints.sqlite",
+    "GRAPH_STORE_BACKEND": "sqlite",
+    "GRAPH_STORE_SQLITE_PATH": str(Path.home() / ".orcheo" / "graph_store.sqlite"),
     "REPOSITORY_BACKEND": "sqlite",
     "REPOSITORY_SQLITE_PATH": "~/.orcheo/workflows.sqlite",
     "CHATKIT_BACKEND": "sqlite",

--- a/src/orcheo/config/loader.py
+++ b/src/orcheo/config/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from functools import lru_cache
+from pathlib import Path
 from dynaconf import Dynaconf
 from pydantic import ValidationError
 from orcheo.config.app_settings import AppSettings
@@ -27,6 +28,12 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
         settings = AppSettings(
             checkpoint_backend=source.get("CHECKPOINT_BACKEND"),
             sqlite_path=source.get("SQLITE_PATH", _DEFAULTS["SQLITE_PATH"]),
+            graph_store_backend=source.get(
+                "GRAPH_STORE_BACKEND", _DEFAULTS["GRAPH_STORE_BACKEND"]
+            ),
+            graph_store_sqlite_path=source.get(
+                "GRAPH_STORE_SQLITE_PATH", _DEFAULTS["GRAPH_STORE_SQLITE_PATH"]
+            ),
             repository_backend=source.get(
                 "REPOSITORY_BACKEND", _DEFAULTS["REPOSITORY_BACKEND"]
             ),
@@ -106,6 +113,11 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
     )
     normalized.set("CHECKPOINT_BACKEND", settings.checkpoint_backend)
     normalized.set("SQLITE_PATH", settings.sqlite_path)
+    normalized.set("GRAPH_STORE_BACKEND", settings.graph_store_backend)
+    normalized.set(
+        "GRAPH_STORE_SQLITE_PATH",
+        str(Path(settings.graph_store_sqlite_path).resolve(strict=False)),
+    )
     normalized.set("REPOSITORY_BACKEND", settings.repository_backend)
     normalized.set("REPOSITORY_SQLITE_PATH", settings.repository_sqlite_path)
     normalized.set("CHATKIT_BACKEND", settings.chatkit_backend)

--- a/src/orcheo/config/types.py
+++ b/src/orcheo/config/types.py
@@ -4,8 +4,15 @@ from typing import Literal
 
 
 CheckpointBackend = Literal["sqlite", "postgres"]
+GraphStoreBackend = Literal["sqlite", "postgres"]
 ChatKitBackend = Literal["sqlite", "postgres"]
 RepositoryBackend = Literal["inmemory", "sqlite", "postgres"]
 VaultBackend = Literal["inmemory", "file", "aws_kms", "postgres"]
 
-__all__ = ["ChatKitBackend", "CheckpointBackend", "RepositoryBackend", "VaultBackend"]
+__all__ = [
+    "ChatKitBackend",
+    "CheckpointBackend",
+    "GraphStoreBackend",
+    "RepositoryBackend",
+    "VaultBackend",
+]

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -1,4 +1,4 @@
-"""Persistence helpers that create LangGraph checkpoint savers."""
+"""Persistence helpers that create LangGraph checkpoint savers and stores."""
 
 from __future__ import annotations
 import importlib
@@ -9,21 +9,27 @@ from typing import Any, cast
 import aiosqlite
 from dynaconf import Dynaconf
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-from orcheo.config import CheckpointBackend
+from langgraph.store.sqlite.aio import AsyncSqliteStore
+from orcheo.config import CheckpointBackend, GraphStoreBackend
 
 
 AsyncPostgresSaver: Any | None
 AsyncConnectionPool: Any | None
 DictRowFactory: Any | None
+AsyncPostgresStore: Any | None
 
 try:  # pragma: no cover - optional dependency
     AsyncPostgresSaver = importlib.import_module(
         "langgraph.checkpoint.postgres.aio"
     ).AsyncPostgresSaver
+    AsyncPostgresStore = importlib.import_module(
+        "langgraph.store.postgres.aio"
+    ).AsyncPostgresStore
     AsyncConnectionPool = importlib.import_module("psycopg_pool").AsyncConnectionPool
     DictRowFactory = importlib.import_module("psycopg.rows").dict_row
 except Exception:  # pragma: no cover - fallback when dependency missing
     AsyncPostgresSaver = None
+    AsyncPostgresStore = None
     AsyncConnectionPool = None
     DictRowFactory = None
 
@@ -97,4 +103,46 @@ async def create_checkpointer(settings: Dynaconf) -> AsyncIterator[Any]:
         return
 
     msg = "Unsupported checkpoint backend configured."
+    raise ValueError(msg)
+
+
+@asynccontextmanager
+async def create_graph_store(settings: Dynaconf) -> AsyncIterator[Any]:
+    """Create a LangGraph store based on the configured backend."""
+    backend = cast(GraphStoreBackend, settings.graph_store_backend)
+
+    if backend == "sqlite":
+        sqlite_path = Path(str(settings.graph_store_sqlite_path))
+        sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async with AsyncSqliteStore.from_conn_string(str(sqlite_path)) as store:
+            await store.setup()
+            yield store
+        return
+
+    if backend == "postgres":
+        if AsyncPostgresStore is None:  # pragma: no cover
+            msg = "Postgres graph store requires langgraph postgres extras."
+            raise RuntimeError(msg)
+
+        dsn = settings.postgres_dsn
+        if dsn is None:  # pragma: no cover - defensive, validated earlier
+            msg = "Postgres backend requires ORCHEO_POSTGRES_DSN to be set."
+            raise RuntimeError(msg)
+
+        pool_config = {
+            "min_size": int(settings.postgres_pool_min_size),
+            "max_size": int(settings.postgres_pool_max_size),
+            "timeout": float(settings.postgres_pool_timeout),
+            "max_idle": float(settings.postgres_pool_max_idle),
+        }
+        async with AsyncPostgresStore.from_conn_string(
+            dsn,
+            pool_config=pool_config,
+        ) as store:
+            await store.setup()
+            yield store
+        return
+
+    msg = "Unsupported graph store backend configured."
     raise ValueError(msg)

--- a/src/orcheo/runtime/__init__.py
+++ b/src/orcheo/runtime/__init__.py
@@ -13,6 +13,7 @@ from .credentials import (
     get_active_credential_resolver,
     parse_credential_reference,
 )
+from .state_builder import build_initial_state
 
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "credential_resolution",
     "get_active_credential_resolver",
     "parse_credential_reference",
+    "build_initial_state",
 ]

--- a/src/orcheo/runtime/state_builder.py
+++ b/src/orcheo/runtime/state_builder.py
@@ -1,0 +1,38 @@
+"""Shared runtime state assembly helpers."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+
+
+def build_initial_state(
+    graph_config: Mapping[str, Any],
+    inputs: Any,
+    runtime_config: Mapping[str, Any] | None = None,
+) -> Any:
+    """Return the initial workflow state used by runtime entrypoints."""
+    runtime_state_config = (
+        dict(runtime_config) if isinstance(runtime_config, Mapping) else {}
+    )
+
+    if graph_config.get("format") == LANGGRAPH_SCRIPT_FORMAT:
+        if not isinstance(inputs, Mapping):
+            return inputs
+        state = dict(inputs)
+        state.setdefault("inputs", dict(inputs))
+        state.setdefault("results", {})
+        state.setdefault("messages", [])
+        state["config"] = runtime_state_config
+        return state
+
+    normalized_inputs = dict(inputs) if isinstance(inputs, Mapping) else inputs
+    return {
+        "messages": [],
+        "results": {},
+        "inputs": normalized_inputs,
+        "config": runtime_state_config,
+    }
+
+
+__all__ = ["build_initial_state"]

--- a/tests/backend/test_chatkit_helpers.py
+++ b/tests/backend/test_chatkit_helpers.py
@@ -117,6 +117,7 @@ def testbuild_initial_state_langgraph_script() -> None:
     assert result["inputs"] == inputs
     assert result["messages"] == []
     assert result["results"] == {}
+    assert result["config"] == {}
 
 
 def testbuild_initial_state_default() -> None:
@@ -127,6 +128,7 @@ def testbuild_initial_state_default() -> None:
     assert result["messages"] == []
     assert result["results"] == {}
     assert result["inputs"] == {"message": "test"}
+    assert result["config"] == {}
 
 
 def testextract_reply_from_state_direct_reply() -> None:

--- a/tests/backend/test_chatkit_server_helpers.py
+++ b/tests/backend/test_chatkit_server_helpers.py
@@ -90,6 +90,7 @@ def test_build_initial_state_langgraph_format() -> None:
     assert result["metadata"] == {"key": "value"}
     assert result["messages"] == []
     assert result["results"] == {}
+    assert result["config"] == {}
 
 
 def test_build_initial_state_standard_format() -> None:
@@ -100,6 +101,7 @@ def test_build_initial_state_standard_format() -> None:
     assert "messages" in result
     assert "results" in result
     assert "inputs" in result
+    assert "config" in result
     assert result["inputs"] == inputs
 
 

--- a/tests/backend/worker/test_tasks_workflow_execution.py
+++ b/tests/backend/worker/test_tasks_workflow_execution.py
@@ -228,36 +228,46 @@ class TestExecuteWorkflow:
                             return_value=mock_checkpointer,
                         ):
                             with patch(
-                                "orcheo_backend.app.workflow_execution._build_initial_state",
-                                return_value={},
+                                "orcheo.persistence.create_graph_store",
+                                return_value=mock_checkpointer,
                             ):
-                                with patch("orcheo.config.get_settings"):
-                                    with patch(
-                                        "orcheo.runtime.runnable_config.merge_runnable_configs"
-                                    ) as mock_merge:
-                                        mock_config = MagicMock()
-                                        mock_config.to_runnable_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.to_state_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.to_json_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.tags = []
-                                        mock_config.callbacks = []
-                                        mock_config.metadata = {}
-                                        mock_config.run_name = None
-                                        mock_merge.return_value = mock_config
-
+                                with patch(
+                                    "orcheo_backend.app.workflow_execution._build_initial_state",
+                                    return_value={},
+                                ):
+                                    with patch("orcheo.config.get_settings"):
                                         with patch(
-                                            "orcheo.runtime.credentials.credential_resolution"
-                                        ):
-                                            result = await _execute_workflow(mock_run)
+                                            "orcheo.runtime.runnable_config.merge_runnable_configs"
+                                        ) as mock_merge:
+                                            mock_config = MagicMock()
+                                            mock_config.to_runnable_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.to_state_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.to_json_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.tags = []
+                                            mock_config.callbacks = []
+                                            mock_config.metadata = {}
+                                            mock_config.run_name = None
+                                            mock_merge.return_value = mock_config
+
+                                            with patch(
+                                                "orcheo.runtime.credentials.credential_resolution"
+                                            ):
+                                                result = await _execute_workflow(
+                                                    mock_run
+                                                )
 
         assert result["status"] == "succeeded"
         mock_repo.mark_run_succeeded.assert_called_once()
+        mock_graph.compile.assert_called_once_with(
+            checkpointer=mock_checkpointer,
+            store=mock_checkpointer,
+        )
         mock_history.start_run.assert_awaited_once()
         mock_history.append_step.assert_awaited()
         mock_history.mark_completed.assert_awaited_once()

--- a/tests/config/test_app_settings.py
+++ b/tests/config/test_app_settings.py
@@ -60,3 +60,10 @@ def test_coerce_postgres_pool_float_defaults_and_valid_values() -> None:
     assert AppSettings._coerce_postgres_pool_float(45.5) == 45.5
     # String numbers are converted
     assert AppSettings._coerce_postgres_pool_float("120.5") == 120.5
+
+
+def test_coerce_graph_store_backend_defaults_and_valid_values() -> None:
+    """Graph store backend coercion should mirror checkpoint backend behavior."""
+
+    assert AppSettings._coerce_graph_store_backend(None) == "sqlite"
+    assert AppSettings._coerce_graph_store_backend("POSTGRES") == "postgres"

--- a/tests/nodes/conversational_search/test_web_search.py
+++ b/tests/nodes/conversational_search/test_web_search.py
@@ -7,9 +7,12 @@ import httpx
 import pytest
 import respx
 from langchain_core.runnables import RunnableConfig
+import orcheo.nodes.conversational_search.retrieval as retrieval_mod
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search import WebSearchNode
 from orcheo.nodes.conversational_search.models import SearchResult
+from orcheo.runtime.credentials import CredentialResolver, credential_resolution
+from tests.runtime.credential_test_helpers import create_vault_with_secret
 
 
 @pytest.mark.asyncio
@@ -123,11 +126,8 @@ async def test_web_search_node_requires_query_when_not_suppressed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_web_search_node_requires_api_key_when_not_suppressed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """WebSearchNode should require api_key or env var when suppression disabled."""
-    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+async def test_web_search_node_requires_api_key_when_not_suppressed() -> None:
+    """WebSearchNode should require api_key when suppression disabled."""
     node = WebSearchNode(name="web", suppress_errors=False)
     state = State(
         inputs={"query": "hello"},
@@ -136,9 +136,82 @@ async def test_web_search_node_requires_api_key_when_not_suppressed(
     )
 
     with pytest.raises(
-        ValueError, match="WebSearchNode requires an api_key or TAVILY_API_KEY env var"
+        ValueError, match="WebSearchNode requires api_key to be configured"
     ):
         await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_web_search_node_rejects_whitespace_api_key_when_not_suppressed() -> None:
+    """WebSearchNode should treat whitespace api_key as missing."""
+    node = WebSearchNode(name="web", api_key="   ", suppress_errors=False)
+    state = State(
+        inputs={"query": "hello"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(
+        ValueError, match="WebSearchNode requires api_key to be configured"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
+async def test_web_search_node_resolves_api_key_from_credential_vault() -> None:
+    """WebSearchNode should resolve api_key placeholders via active resolver."""
+    state = State(
+        inputs={"query": "latest ai news"},
+        results={},
+        structured_response=None,
+    )
+    node = WebSearchNode(name="web", api_key="[[telegram_bot]]", suppress_errors=False)
+    resolver = CredentialResolver(create_vault_with_secret(secret="vault-key"))
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["json"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"results": []})
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("https://api.tavily.com/search").mock(side_effect=handler)
+        with credential_resolution(resolver):
+            await node.run(state, {})
+
+    assert captured["json"]["api_key"] == "vault-key"
+
+
+def test_web_search_node_raises_for_placeholder_without_active_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential placeholders require an active credential resolver."""
+    node = WebSearchNode(name="web", api_key="[[telegram_bot]]")
+    monkeypatch.setattr(retrieval_mod, "get_active_credential_resolver", lambda: None)
+
+    with pytest.raises(ValueError, match="no active credential resolver is available"):
+        node._resolve_api_key()
+
+
+def test_web_search_node_raises_when_resolved_credential_is_not_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolved credential values must be strings."""
+
+    class _BadResolver:
+        def resolve(self, reference: object) -> int:
+            del reference
+            return 123
+
+    node = WebSearchNode(name="web", api_key="[[telegram_bot]]")
+    monkeypatch.setattr(
+        retrieval_mod, "get_active_credential_resolver", lambda: _BadResolver()
+    )
+
+    with pytest.raises(
+        ValueError, match="Resolved WebSearchNode api_key credential must be a string"
+    ):
+        node._resolve_api_key()
 
 
 @pytest.mark.asyncio

--- a/tests/nodes/evaluation/test_batch.py
+++ b/tests/nodes/evaluation/test_batch.py
@@ -159,11 +159,11 @@ async def test_batch_eval_resolves_templated_max_conversations() -> None:
         name="batch",
         max_conversations="{{config.configurable.qrecc.max_conversations}}",
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"qrecc": {"max_conversations": 1}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 1
     assert result["total_turns"] == 2
@@ -460,33 +460,6 @@ def test_batch_eval_validate_max_conversations_none() -> None:
     assert node.max_conversations is None
 
 
-def test_batch_eval_validate_max_conversations_invalid_string() -> None:
-    """Non-integer, non-template string raises ValueError."""
-    with pytest.raises(ValueError, match="must be an integer"):
-        ConversationalBatchEvalNode(name="batch", max_conversations="bad")
-
-
-@pytest.mark.asyncio
-async def test_batch_eval_resolve_max_conversations_invalid_string() -> None:
-    """String that can't resolve to int raises ValueError at runtime."""
-    node = ConversationalBatchEvalNode(
-        name="batch",
-        max_conversations="{{config.configurable.max}}",
-    )
-    # Simulate template not resolved (stays as string)
-    node.max_conversations = "not_a_number"
-    with pytest.raises(ValueError, match="must resolve to an integer"):
-        await node.run(State(inputs={"conversations": QRECC_CONVERSATIONS}), {})
-
-
-@pytest.mark.asyncio
-async def test_batch_eval_resolve_max_conversations_less_than_one() -> None:
-    """max_conversations < 1 raises ValueError."""
-    node = ConversationalBatchEvalNode(name="batch", max_conversations=0)
-    with pytest.raises(ValueError, match="must be >= 1"):
-        await node.run(State(inputs={"conversations": QRECC_CONVERSATIONS}), {})
-
-
 def test_batch_eval_validate_max_concurrency_invalid_string() -> None:
     """Non-integer, non-template max_concurrency raises ValueError."""
     with pytest.raises(ValueError, match="must be an integer"):
@@ -515,11 +488,11 @@ async def test_batch_eval_resolves_templated_max_concurrency() -> None:
         name="batch",
         max_concurrency="{{config.configurable.eval.max_concurrency}}",
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"eval": {"max_concurrency": 2}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 2
 
@@ -567,11 +540,11 @@ async def test_batch_eval_resolves_templated_history_window_size() -> None:
         history_window_size="{{config.configurable.eval.history_window_size}}",
         pipeline=_build_pipeline_graph(HistoryCapture(name="capture")),
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"eval": {"history_window_size": 1}}},
     )
+    node.decode_variables(state)
     await node.run(state, {})
 
     assert received_histories == [[], ["What is Python?"], []]

--- a/tests/nodes/evaluation/test_datasets.py
+++ b/tests/nodes/evaluation/test_datasets.py
@@ -334,11 +334,11 @@ async def test_qrecc_dataset_node_resolves_templated_max_conversations() -> None
         name="qrecc",
         max_conversations="{{config.configurable.qrecc.max_conversations}}",
     )
-    state = State(inputs={"qrecc_data": QRECC_SAMPLE})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"qrecc_data": QRECC_SAMPLE},
         config={"configurable": {"qrecc": {"max_conversations": 1}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 1
 
@@ -497,11 +497,11 @@ async def test_md2d_corpus_loader_node_resolves_templated_max_documents() -> Non
         name="md2d_corpus_loader",
         max_documents="{{config.configurable.corpus.max_documents}}",
     )
-    state = State(inputs={"md2d_corpus": MD2D_CORPUS_SAMPLE})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"md2d_corpus": MD2D_CORPUS_SAMPLE},
         config={"configurable": {"corpus": {"max_documents": 1}}},
     )
+    node.decode_variables(state)
 
     result = await node.run(state, {})
 

--- a/tests/nodes/test_ai_agent_node_messages.py
+++ b/tests/nodes/test_ai_agent_node_messages.py
@@ -1,9 +1,10 @@
 """AgentNode message construction tests."""
 
 from __future__ import annotations
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode
 
@@ -283,3 +284,692 @@ def test_build_messages_checkpointer_with_no_new_inputs() -> None:
     )
     assert len(messages) == 1
     assert messages[0].content == "Previous answer"
+
+
+def test_resolve_history_key_supports_literal_and_template_candidates() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=[
+            "support-room-1",
+            "{{results.resolve_history_key.session_key}}",
+        ],
+        history_key_template="session:{{conversation_key}}",
+    )
+    state = State(
+        messages=[],
+        inputs={},
+        results={"resolve_history_key": {"session_key": "ignored"}},
+        structured_response=None,
+        config=None,
+    )
+    key = node._resolve_history_key(state, {"configurable": {"thread_id": "thread-1"}})
+    assert key == "session:support-room-1"
+
+
+def test_default_history_key_candidates_exclude_config_input_and_thread() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+
+    assert (
+        "{{results.resolve_history_key.session_key}}" not in node.history_key_candidates
+    )
+    assert "{{configurable.history_key}}" not in node.history_key_candidates
+    assert "{{inputs.history_key}}" not in node.history_key_candidates
+    assert "{{thread_id}}" not in node.history_key_candidates
+
+
+def test_resolve_history_key_supports_configurable_candidate() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["{{config.configurable.history_key}}"],
+    )
+    state = State(
+        messages=[],
+        inputs={},
+        results={},
+        structured_response=None,
+        config={"configurable": {"history_key": "room-1"}},
+    )
+    assert node._resolve_history_key(state, None) == "room-1"
+
+
+def test_resolve_history_key_supports_channel_templates() -> None:
+    telegram_node = AgentNode(name="agent", ai_model="test-model")
+    telegram_state = State(
+        messages=[],
+        inputs={},
+        results={"telegram_events_parser": {"chat_id": "12345"}},
+        structured_response=None,
+        config=None,
+    )
+    assert (
+        telegram_node._resolve_history_key(
+            telegram_state, {"configurable": {"thread_id": "thread-1"}}
+        )
+        == "telegram:12345"
+    )
+
+    wecom_cs_node = AgentNode(name="agent", ai_model="test-model")
+    wecom_cs_state = State(
+        messages=[],
+        inputs={},
+        results={
+            "wecom_cs_sync": {
+                "open_kf_id": "kf-001",
+                "external_userid": "ext-abc",
+            }
+        },
+        structured_response=None,
+        config=None,
+    )
+    assert (
+        wecom_cs_node._resolve_history_key(
+            wecom_cs_state, {"configurable": {"thread_id": "thread-1"}}
+        )
+        == "wecom_cs:kf-001:ext-abc"
+    )
+
+
+def test_resolve_history_key_rejects_invalid_candidates() -> None:
+    unresolved_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["{{results.missing.value}}"],
+    )
+    invalid_state = State(
+        messages=[],
+        inputs={},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+    assert (
+        unresolved_node._resolve_history_key(
+            invalid_state, {"configurable": {"thread_id": "thread-1"}}
+        )
+        is None
+    )
+
+    invalid_chars_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["bad/key"],
+    )
+    assert (
+        invalid_chars_node._resolve_history_key(
+            invalid_state, {"configurable": {"thread_id": "thread-1"}}
+        )
+        is None
+    )
+
+    too_long_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["a" * 257],
+    )
+    assert (
+        too_long_node._resolve_history_key(
+            invalid_state, {"configurable": {"thread_id": "thread-1"}}
+        )
+        is None
+    )
+
+
+class _MemoryGraphStore:
+    def __init__(self, value: dict[str, object] | None = None) -> None:
+        self.value = value
+        self.get_calls = 0
+        self.put_calls = 0
+
+    async def aget(self, namespace: tuple[str, ...], key: str) -> object | None:
+        self.get_calls += 1
+        if self.value is None:
+            return None
+        return SimpleNamespace(namespace=namespace, key=key, value=self.value)
+
+    async def aput(
+        self,
+        namespace: tuple[str, ...],
+        key: str,
+        value: dict[str, object],
+    ) -> None:
+        self.put_calls += 1
+        self.value = value
+
+
+class _ConflictGraphStore:
+    def __init__(self) -> None:
+        self.put_calls = 0
+
+    async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+        return SimpleNamespace(
+            namespace=namespace,
+            key=key,
+            value={"version": 0, "messages": []},
+        )
+
+    async def aput(
+        self,
+        namespace: tuple[str, ...],
+        key: str,
+        value: dict[str, object],
+    ) -> None:
+        self.put_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_agentnode_graph_history_merge_trim_and_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {
+        "messages": [
+            HumanMessage(content="new question"),
+            AIMessage(content="new answer"),
+        ]
+    }
+
+    async def fake_prepare_tools(self: AgentNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "m")
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.create_agent", lambda *args, **kwargs: fake_agent
+    )
+    monkeypatch.setattr(AgentNode, "_prepare_tools", fake_prepare_tools)
+
+    store = _MemoryGraphStore(
+        value={
+            "version": 1,
+            "messages": [
+                {"role": "assistant", "content": "old-1"},
+                {"role": "user", "content": "old-2"},
+                {"role": "assistant", "content": "old-3"},
+            ],
+        }
+    )
+    runtime = SimpleNamespace(store=store)
+
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        max_messages=3,
+        history_key_candidates=["room-1"],
+    )
+    state = State(
+        messages=[],
+        inputs={"message": "new question"},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+    await node.run(
+        state,
+        {"configurable": {"thread_id": "thread-1", "__pregel_runtime": runtime}},
+    )
+
+    payload = fake_agent.ainvoke.await_args.args[0]
+    sent_messages = payload["messages"]
+    assert [message.content for message in sent_messages] == [
+        "old-2",
+        "old-3",
+        "new question",
+    ]
+    assert store.put_calls >= 1
+    assert isinstance(store.value, dict)
+    persisted_messages = store.value["messages"]  # type: ignore[index]
+    assert persisted_messages[-2:] == [
+        {"role": "user", "content": "new question"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agentnode_graph_history_disabled_skips_store_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: AgentNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "m")
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.create_agent", lambda *args, **kwargs: fake_agent
+    )
+    monkeypatch.setattr(AgentNode, "_prepare_tools", fake_prepare_tools)
+
+    class FailingStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            raise AssertionError("store should not be used when disabled")
+
+    runtime = SimpleNamespace(store=FailingStore())
+    node = AgentNode(name="agent", ai_model="test-model", use_graph_chat_history=False)
+    state = State(
+        messages=[],
+        inputs={"message": "hello"},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+    await node.run(
+        state,
+        {"configurable": {"thread_id": "thread-1", "__pregel_runtime": runtime}},
+    )
+    fake_agent.ainvoke.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_agentnode_graph_history_conflict_retry_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: AgentNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "m")
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.create_agent", lambda *args, **kwargs: fake_agent
+    )
+    monkeypatch.setattr(AgentNode, "_prepare_tools", fake_prepare_tools)
+
+    store = _ConflictGraphStore()
+    runtime = SimpleNamespace(store=store)
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["room-1"],
+    )
+    state = State(
+        messages=[],
+        inputs={"message": "hello"},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+    await node.run(
+        state,
+        {"configurable": {"thread_id": "thread-1", "__pregel_runtime": runtime}},
+    )
+    assert store.put_calls == 3
+
+
+def test_get_graph_store_handles_mapping_variants() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+
+    assert node._get_graph_store(None) is None
+    assert node._get_graph_store({"configurable": "bad"}) is None
+    assert node._get_graph_store({"configurable": {"__pregel_store": "fallback"}}) == (
+        "fallback"
+    )
+    assert (
+        node._get_graph_store(
+            {"configurable": {"__pregel_runtime": {"store": "runtime-store"}}}
+        )
+        == "runtime-store"
+    )
+    assert (
+        node._get_graph_store(
+            {
+                "configurable": {
+                    "__pregel_runtime": {"store": None},
+                    "__pregel_store": "fallback-2",
+                }
+            }
+        )
+        == "fallback-2"
+    )
+
+
+def test_resolve_history_key_skips_non_string_and_empty_candidates() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    node.history_key_candidates = [123, "{{results.empty.value}}", "room-1"]  # type: ignore[list-item]
+    state = State(
+        messages=[],
+        inputs={},
+        results={"empty": {"value": ""}},
+        structured_response=None,
+        config=None,
+    )
+    assert node._resolve_history_key(state, None) == "room-1"
+
+
+def test_resolve_history_key_rejects_invalid_template_result() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["room-1"],
+        history_key_template="{{conversation_key}}/{{conversation_key}}",
+    )
+    state = State(
+        messages=[], inputs={}, results={}, structured_response=None, config=None
+    )
+    assert node._resolve_history_key(state, None) is None
+
+
+@pytest.mark.asyncio
+async def test_store_get_item_sync_get_variants() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+
+    class SyncStore:
+        def get(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {"value": 1}
+
+    class CoroutineStore:
+        async def _async_get(self) -> object:
+            return {"value": 2}
+
+        def get(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return self._async_get()
+
+    class EmptyStore:
+        pass
+
+    assert await node._store_get_item(SyncStore(), namespace, "k") == {"value": 1}
+    assert await node._store_get_item(CoroutineStore(), namespace, "k") == {"value": 2}
+    assert await node._store_get_item(EmptyStore(), namespace, "k") is None
+
+
+@pytest.mark.asyncio
+async def test_store_put_item_sync_put_coroutine() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    calls: list[dict[str, object]] = []
+
+    class PutStore:
+        async def _async_put(self, value: dict[str, object]) -> None:
+            calls.append(value)
+
+        def put(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> object:
+            del namespace, key
+            return self._async_put(value)
+
+    await node._store_put_item(PutStore(), namespace, "k", {"x": 1})
+    assert calls == [{"x": 1}]
+
+
+@pytest.mark.asyncio
+async def test_store_put_item_sync_put_non_coroutine_and_missing_put() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    calls: list[dict[str, object]] = []
+
+    class SyncPutStore:
+        def put(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> object:
+            del namespace, key
+            calls.append(value)
+            return "done"
+
+    class MissingPutStore:
+        pass
+
+    await node._store_put_item(SyncPutStore(), namespace, "k", {"y": 2})
+    await node._store_put_item(MissingPutStore(), namespace, "k", {"z": 3})
+    assert calls == [{"y": 2}]
+
+
+def test_history_payload_from_item_and_message_normalization() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+
+    assert node._history_payload_from_item(None) == {}
+    assert node._history_payload_from_item({"value": "not-mapping"}) == {}
+    assert node._history_payload_from_item({"value": {"messages": []}}) == {
+        "messages": []
+    }
+    assert node._normalize_history_store_messages("not-list") == []
+
+    messages = node._normalize_history_store_messages(
+        [
+            "bad",
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": " "},
+            {"role": "user", "content": "b"},
+        ]
+    )
+    assert [message.content for message in messages] == ["a", "b"]
+
+
+def test_history_serialization_and_signature_helpers() -> None:
+    node = AgentNode(name="agent", ai_model="test-model", history_value_field="text")
+    serialized = node._serialize_history_messages(
+        [
+            AIMessage(content="a"),
+            HumanMessage(content=" "),
+            SystemMessage(content="system"),
+            HumanMessage(content="b"),
+        ]
+    )
+    assert serialized == [
+        {"role": "assistant", "text": "a", "content": "a"},
+        {"role": "user", "text": "b", "content": "b"},
+    ]
+    assert node._message_signature(SystemMessage(content="x")) == ("system", "x")
+    assert (
+        node._suffix_prefix_overlap(
+            [HumanMessage(content="1"), AIMessage(content="2")],
+            [AIMessage(content="2"), HumanMessage(content="3")],
+        )
+        == 1
+    )
+    assert node._history_version_from_payload({"version": "2"}) == 2
+    assert node._history_version_from_payload({"version": "x"}) == 0
+
+
+def test_extract_observed_messages_uses_inference_prefix() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    current_messages = [HumanMessage(content="old")]
+    inference_messages = [HumanMessage(content="old"), AIMessage(content="draft")]
+    result = {
+        "messages": [
+            HumanMessage(content="old"),
+            AIMessage(content="draft"),
+            AIMessage(content="final"),
+        ]
+    }
+
+    observed = node._extract_observed_messages(
+        current_messages, inference_messages, result
+    )
+    assert [message.content for message in observed] == ["old", "final"]
+
+
+@pytest.mark.asyncio
+async def test_persist_graph_history_early_returns_and_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+
+    class ReadErrorStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            msg = "read fail"
+            raise RuntimeError(msg)
+
+    class NoNewMessagesStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {
+                "value": {
+                    "version": 1,
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            }
+
+        async def aput(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> None:
+            del namespace, key, value
+            raise AssertionError("no write expected")
+
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[SystemMessage(content="ignore")],
+    )
+
+    await node._persist_graph_history(
+        store=ReadErrorStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+
+    monkeypatch.setattr(AgentNode, "_history_write_retry_limit", 0)
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_graph_history_put_failure_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    sleeps: list[float] = []
+
+    class PutErrorStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {"value": {"version": 0, "messages": []}}
+
+        async def aput(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> None:
+            del namespace, key, value
+            msg = "put fail"
+            raise RuntimeError(msg)
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(AgentNode, "_history_write_retry_limit", 2)
+    monkeypatch.setattr("orcheo.nodes.ai.random.uniform", lambda _a, _b: 0.0)
+    monkeypatch.setattr("orcheo.nodes.ai.asyncio.sleep", fake_sleep)
+
+    await node._persist_graph_history(
+        store=PutErrorStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+    assert sleeps == [node._history_retry_base_backoff_seconds]
+
+
+@pytest.mark.asyncio
+async def test_run_graph_history_fallback_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: AgentNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "m")
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.create_agent", lambda *args, **kwargs: fake_agent
+    )
+    monkeypatch.setattr(AgentNode, "_prepare_tools", fake_prepare_tools)
+
+    no_store_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["room-1"],
+    )
+    missing_key_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["{{results.missing.value}}"],
+    )
+    bad_key_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["{{results.missing.value}}"],
+    )
+    load_fail_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["room-1"],
+    )
+    state = State(
+        messages=[],
+        inputs={"message": "hello"},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+    class RaiseStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            msg = "load fail"
+            raise RuntimeError(msg)
+
+    await no_store_node.run(state, {"configurable": {"thread_id": "thread-1"}})
+    await bad_key_node.run(
+        state,
+        {"configurable": {"thread_id": "thread-1", "__pregel_runtime": object()}},
+    )
+    await missing_key_node.run(
+        state,
+        {
+            "configurable": {
+                "thread_id": "thread-1",
+                "__pregel_runtime": SimpleNamespace(store=_MemoryGraphStore()),
+            }
+        },
+    )
+    await load_fail_node.run(
+        state,
+        {
+            "configurable": {
+                "thread_id": "thread-1",
+                "__pregel_runtime": SimpleNamespace(store=RaiseStore()),
+            }
+        },
+    )

--- a/tests/runtime/test_state_builder.py
+++ b/tests/runtime/test_state_builder.py
@@ -1,0 +1,50 @@
+"""Tests for shared runtime initial-state construction."""
+
+from __future__ import annotations
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+from orcheo.runtime.state_builder import build_initial_state
+
+
+def test_build_initial_state_langgraph_script_mapping_defaults() -> None:
+    inputs = {"message": "hello"}
+
+    state = build_initial_state({"format": LANGGRAPH_SCRIPT_FORMAT}, inputs, None)
+
+    assert state["message"] == "hello"
+    assert state["inputs"] == inputs
+    assert state["results"] == {}
+    assert state["messages"] == []
+    assert state["config"] == {}
+
+
+def test_build_initial_state_langgraph_script_mapping_uses_runtime_config() -> None:
+    inputs = {"message": "hello"}
+    runtime_config = {"configurable": {"thread_id": "exec-1"}}
+
+    state = build_initial_state(
+        {"format": LANGGRAPH_SCRIPT_FORMAT},
+        inputs,
+        runtime_config,
+    )
+
+    assert state["config"] == runtime_config
+
+
+def test_build_initial_state_langgraph_script_non_mapping_passthrough() -> None:
+    payload = ["message"]
+
+    state = build_initial_state({"format": LANGGRAPH_SCRIPT_FORMAT}, payload, None)
+
+    assert state is payload
+
+
+def test_build_initial_state_default_shape() -> None:
+    inputs = {"message": "hello"}
+    runtime_config = {"run_name": "test"}
+
+    state = build_initial_state({"format": "graph"}, inputs, runtime_config)
+
+    assert state["inputs"] == inputs
+    assert state["results"] == {}
+    assert state["messages"] == []
+    assert state["config"] == runtime_config

--- a/tests/test_app_execute_workflow.py
+++ b/tests/test_app_execute_workflow.py
@@ -42,15 +42,21 @@ async def test_execute_workflow() -> None:
     mock_graph.compile.return_value = mock_compiled_graph
 
     mock_checkpointer = object()
+    mock_store = object()
 
     @asynccontextmanager
     async def fake_checkpointer(_settings):
         yield mock_checkpointer
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield mock_store
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -63,7 +69,10 @@ async def test_execute_workflow() -> None:
             runnable_config,
         )
 
-    mock_graph.compile.assert_called_once_with(checkpointer=mock_checkpointer)
+    mock_graph.compile.assert_called_once_with(
+        checkpointer=mock_checkpointer,
+        store=mock_store,
+    )
     mock_websocket.send_json.assert_any_call(steps[0])
     mock_websocket.send_json.assert_any_call(steps[1])
 
@@ -118,10 +127,15 @@ async def test_execute_workflow_langgraph_script_uses_raw_inputs() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -167,10 +181,15 @@ async def test_execute_workflow_failure_records_error() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -215,10 +234,15 @@ async def test_execute_workflow_cancelled_records_reason() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):


### PR DESCRIPTION
## Summary
This PR introduces first-class LangGraph store support (SQLite/Postgres) and adds opt-in persistent chat history for `AgentNode`, then wires the store through all backend graph compilation paths.

## Main Changes
- Added graph store configuration support:
- Added `graph_store_backend` and `graph_store_sqlite_path` to app settings/types/defaults/loader.
- Added validation for graph store backend values and SQLite graph store path (must be absolute; rejects `~`).
- Extended Postgres DSN validation so `ORCHEO_POSTGRES_DSN` is required when graph store backend is `postgres`.

- Added graph store persistence factory:
- Implemented `create_graph_store(settings)` in `src/orcheo/persistence.py`.
- Supports SQLite (`AsyncSqliteStore`) and Postgres (`AsyncPostgresStore`) with `store.setup()` and pool config.

- Wired graph store into backend execution:
- Updated graph compile callsites to `graph.compile(checkpointer=..., store=...)` in:
  - workflow execution
  - training/evaluation execution
  - triggers immediate-response path
  - ChatKit workflow executor
  - worker task execution
- Exported `create_graph_store` through backend core exports.

- Added shared runtime state builder:
- Introduced `src/orcheo/runtime/state_builder.py` with `build_initial_state(...)`.
- Replaced duplicated initial-state assembly logic in backend/chatkit/trigger paths.
- Standardized `config` presence in initial state.

- Extended `AgentNode` with graph-store chat history:
- Added opt-in fields: `use_graph_chat_history`, `history_namespace`, `history_key_template`, `history_key_candidates`, `history_value_field`.
- Added stable default key candidates for channel contexts (Telegram/WeCom variants).
- Implemented key resolution/validation (template handling, invalid-char/length/unresolved checks).
- Implemented loading persisted history, merging with current messages, and truncation to `max_messages` for inference.
- Implemented post-run persistence of observed user/assistant turns with overlap detection and bounded retry/backoff conflict handling.
- Added compatibility helpers for async/sync store APIs.

- Improved template decoding behavior in base node logic:
- Added mixed-template string interpolation support (e.g. `"x={{a}} y={{b}}"`).
- Preserved native types for single-template values.
- Stopped implicitly injecting `config` from decode arguments; decoding now relies on state-provided config.

- Updated `WebSearchNode` credential behavior:
- Added credential-placeholder resolution for `api_key` via active credential resolver.
- Removed env-var fallback requirement from runtime path; now explicitly requires configured `api_key` (e.g. `[[tavily_api_key]]`).

- Documentation and project artifacts:
- Updated `docs/environment_variables.md` with graph-store variables and other env var documentation refreshes.
- Added initiative docs under `project/initiatives/agent_chat_history/` (requirements, design, plan, rollout).

## Test Coverage Updates
- Added/updated tests for:
- graph store config validation and normalization
- `create_graph_store` sqlite/postgres/error paths
- runtime `build_initial_state`
- backend compile wiring to include `store`
- `AgentNode` history key resolution, merge/trim/persist, fallback and retry paths
- base template interpolation behavior
- `WebSearchNode` credential placeholder resolution and error handling

## Compatibility Notes
- `AgentNode` graph-backed chat history is opt-in (`use_graph_chat_history=False` by default), so existing workflows keep current behavior unless enabled.
- `WebSearchNode` behavior changes to require configured `api_key` (credential placeholders supported); relying only on `TAVILY_API_KEY` env fallback is no longer sufficient.
