### PR TITLE
Add graph-store-backed AgentNode history and wire LangGraph store across runtime entrypoints

### DIFF
--- a/apps/backend/src/orcheo_backend/app/_core_exports.py
+++ b/apps/backend/src/orcheo_backend/app/_core_exports.py
@@ -5,7 +5,7 @@ from pydantic import TypeAdapter as _PydanticTypeAdapter
 import orcheo_backend.app.workflow_execution as _workflow_execution_module
 from orcheo.config import get_settings
 from orcheo.graph.builder import build_graph
-from orcheo.persistence import create_checkpointer
+from orcheo.persistence import create_checkpointer, create_graph_store
 from orcheo_backend.app.authentication import (
     authenticate_request,
     authenticate_websocket,
@@ -124,6 +124,7 @@ __all__ = [
     "build_graph",
     "create_app",
     "create_checkpointer",
+    "create_graph_store",
     "execute_workflow",
     "execute_workflow_evaluation",
     "execute_workflow_training",

--- a/apps/backend/src/orcheo_backend/app/chatkit/message_utils.py
+++ b/apps/backend/src/orcheo_backend/app/chatkit/message_utils.py
@@ -28,7 +28,7 @@ with warnings.catch_warnings():
         WidgetRoot,
     )
 from langchain_core.messages import BaseMessage
-from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+from orcheo.runtime.state_builder import build_initial_state as build_runtime_state
 
 
 def collect_text_from_user_content(content: list[UserMessageContent]) -> str:
@@ -77,19 +77,10 @@ def stringify_langchain_message(message: Any) -> str:
 def build_initial_state(
     graph_config: Mapping[str, Any],
     inputs: Mapping[str, Any],
+    runtime_config: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any]:
     """Create the initial workflow state for the configured format."""
-    if graph_config.get("format") == LANGGRAPH_SCRIPT_FORMAT:
-        state = dict(inputs)
-        state.setdefault("inputs", dict(inputs))
-        state.setdefault("results", {})
-        state.setdefault("messages", [])
-        return state
-    return {
-        "messages": [],
-        "results": {},
-        "inputs": dict(inputs),
-    }
+    return build_runtime_state(graph_config, inputs, runtime_config)
 
 
 def extract_reply_from_state(state: Mapping[str, Any]) -> str | None:

--- a/project/initiatives/agent_chat_history/2_design.md
+++ b/project/initiatives/agent_chat_history/2_design.md
@@ -6,7 +6,7 @@
 - **Author:** Codex
 - **Owner:** Shaojie Jiang
 - **Date:** 2026-02-26
-- **Status:** Draft
+- **Status:** Approved
 
 ---
 

--- a/project/initiatives/agent_chat_history/3_plan.md
+++ b/project/initiatives/agent_chat_history/3_plan.md
@@ -28,13 +28,13 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 1.1: Add config types/defaults in `src/orcheo/config/app_settings.py` (`AppSettings`) for graph store backend and sqlite path.
+- [x] Task 1.1: Add config types/defaults in `src/orcheo/config/app_settings.py` (`AppSettings`) for graph store backend and sqlite path.
   - Dependencies: None
-- [ ] Task 1.2: Add validation rules in `AppSettings` and loader normalization (absolute SQLite path; reject `~` and relative values).
+- [x] Task 1.2: Add validation rules in `AppSettings` and loader normalization (absolute SQLite path; reject `~` and relative values).
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
+- [x] Task 1.3: Implement `create_graph_store(settings)` in `src/orcheo/persistence.py` for SQLite/Postgres.
   - Dependencies: Task 1.2
-- [ ] Task 1.4: Add persistence tests for graph store factory (sqlite/postgres/error paths).
+- [x] Task 1.4: Add persistence tests for graph store factory (sqlite/postgres/error paths).
   - Dependencies: Task 1.3
 
 ---
@@ -45,11 +45,11 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 2.1: Update workflow execution compile paths to include `store`.
+- [x] Task 2.1: Update workflow execution compile paths to include `store`.
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Update trigger/worker/ChatKit executor compile paths to include `store`.
+- [x] Task 2.2: Update trigger/worker/ChatKit executor compile paths to include `store`.
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Add/adjust backend unit tests that patch compile calls to assert `store` wiring.
+- [x] Task 2.3: Add/adjust backend unit tests that patch compile calls to assert `store` wiring.
   - Dependencies: Task 2.2
 
 ---
@@ -60,16 +60,16 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable conversation-key precedence (explicit/channel-derived before `thread_id` fallback).
-  - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) including `results.*` references.
+- [x] Task 3.1: Add `AgentNode` toggle and keying fields with safe defaults (`use_graph_chat_history=False`) and stable channel-derived default key candidates.
+  - Acceptance note: `history_key_template` and `history_key_candidates` accept both literal strings and Orcheo templates (`{{...}}`) resolved from workflow state (for example `results.*`, `inputs.*`, `config.*`).
   - Dependencies: Milestone 1
-- [ ] Task 3.2: Implement deterministic key validation (empty/unresolved-template/invalid-char/length checks) before store read/write.
+- [x] Task 3.2: Implement deterministic key validation (empty/unresolved-template/invalid-char/length checks) before store read/write.
   - Dependencies: Task 3.1
-- [ ] Task 3.3: Implement store read and message normalization path before agent invoke.
+- [x] Task 3.3: Implement store read and message normalization path before agent invoke.
   - Dependencies: Task 3.1
-- [ ] Task 3.4: Implement merge + `max_messages` trimming + post-run store update with bounded optimistic-concurrency retry policy.
+- [x] Task 3.4: Implement merge + `max_messages` trimming + post-run store update with bounded optimistic-concurrency retry policy.
   - Dependencies: Task 3.3
-- [ ] Task 3.5: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
+- [x] Task 3.5: Add node tests for enabled/disabled behavior, key resolution, and trim semantics.
   - Acceptance note: include test cases for literal keys and `{{...}}` template keys resolved from previous node results.
   - Acceptance note: include explicit Telegram and WeCom CS fixture cases and persistent-conflict fallback behavior.
   - Dependencies: Task 3.4
@@ -82,7 +82,7 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 #### Task Checklist
 
-- [ ] Task 4.1: Run targeted test suites for config, persistence, backend workflow execution, and AI node message handling.
+- [x] Task 4.1: Run targeted test suites for config, persistence, backend workflow execution, and AI node message handling.
   - Dependencies: Milestones 2 and 3
 - [ ] Task 4.2: SQLite staging verification — validate store factory, compile wiring, and node history behavior with SQLite backend using repeated callbacks with stable conversation IDs (WeCom/Telegram-like payloads).
   - Dependencies: Task 4.1
@@ -90,9 +90,9 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
   - Dependencies: Task 4.2
 - [ ] Task 4.4: Add observability signals (metrics/log fields) and verify dashboards/alerts for read/write failures, key-resolution failures, and truncation events.
   - Dependencies: Task 4.3
-- [ ] Task 4.5: Document rollback playbook per rollout phase (SQLite staging, Postgres staging, production opt-in).
+- [x] Task 4.5: Document rollback playbook per rollout phase (SQLite staging, Postgres staging, production opt-in).
   - Dependencies: Task 4.4
-- [ ] Task 4.6: Publish migration + user-facing guidance for workflows moving from manual session assembly to graph-store chat history.
+- [x] Task 4.6: Publish migration + user-facing guidance for workflows moving from manual session assembly to graph-store chat history.
   - Dependencies: Task 4.5
 
 ---
@@ -101,5 +101,6 @@ Deliver graph-store support (SQLite/Postgres) and `AgentNode` opt-in chat-histor
 
 | Date | Author | Changes |
 |------|--------|---------|
+| 2026-02-27 | Codex | Updated Milestone 3 notes to reflect channel-derived default candidates and state-based template resolution |
 | 2026-02-27 | Codex | Clarified config module targets, added key-validation/retry tasks, observability, rollback, and migration documentation tasks |
 | 2026-02-26 | Codex | Initial draft |

--- a/project/initiatives/agent_chat_history/3_plan.md
+++ b/project/initiatives/agent_chat_history/3_plan.md
@@ -6,7 +6,7 @@
 - **Author:** Codex
 - **Owner:** Shaojie Jiang
 - **Date:** 2026-02-26
-- **Status:** Draft
+- **Status:** Approved
 
 ---
 

--- a/project/initiatives/agent_chat_history/4_rollout_playbook.md
+++ b/project/initiatives/agent_chat_history/4_rollout_playbook.md
@@ -1,0 +1,82 @@
+# Rollout Playbook
+
+- **Version:** 0.2
+- **Author:** Codex
+- **Owner:** Shaojie Jiang
+- **Date:** 2026-02-27
+
+## Scope
+
+Operational rollback and migration guidance for graph-store-backed `AgentNode` chat history.
+
+## Rollback Playbook
+
+### Phase 1: SQLite Staging
+
+Trigger conditions:
+- Graph compilation fails after store wiring changes.
+- SQLite store setup/read/write errors regress staging stability.
+
+Rollback:
+1. Set `ORCHEO_GRAPH_STORE_BACKEND=sqlite` and keep `ORCHEO_GRAPH_STORE_SQLITE_PATH` pointed at a valid absolute path for diagnostics.
+2. Disable workflow-level history usage by setting `use_graph_chat_history=false` for affected `AgentNode` definitions.
+3. Redeploy backend/worker services.
+4. Validate that workflow runs still succeed with checkpointer-only behavior.
+
+### Phase 2: Postgres Staging
+
+Trigger conditions:
+- DSN/pool configuration errors.
+- Persistent store write conflicts or latency regressions.
+
+Rollback:
+1. Switch `ORCHEO_GRAPH_STORE_BACKEND=sqlite` for staging workloads.
+2. Keep `use_graph_chat_history=false` on unstable workflows until Postgres configuration is corrected.
+3. Redeploy services and rerun callback replay validation.
+
+### Phase 3: Production Opt-In
+
+Trigger conditions:
+- Channel-specific key resolution failures.
+- Elevated graph-history read/write failures.
+
+Rollback:
+1. Disable `use_graph_chat_history` on affected production workflows first (fastest and lowest-risk rollback).
+2. If backend-wide issues persist, switch to `ORCHEO_GRAPH_STORE_BACKEND=sqlite` with a known-good path.
+3. If required, roll back backend image to previous release and keep the feature toggle disabled.
+
+## Migration Guidance
+
+### Prerequisites
+
+1. Configure graph store:
+  - `ORCHEO_GRAPH_STORE_BACKEND=sqlite|postgres`
+  - `ORCHEO_GRAPH_STORE_SQLITE_PATH` must be absolute when backend is `sqlite`
+  - `ORCHEO_POSTGRES_DSN` required when backend is `postgres`
+2. Ensure workflows compile with both checkpointer and store wiring (covered by backend unit tests).
+
+### Node Configuration Migration
+
+1. Enable feature per `AgentNode`:
+  - `use_graph_chat_history: true`
+2. Keep defaults unless customization is needed:
+  - `history_namespace: ["agent_chat_history"]`
+  - `history_key_template: "{{conversation_key}}"`
+3. Keep default channel-derived `history_key_candidates`; add custom candidates only when workflow-specific keys are required (for example `{{results.resolve_history_key.session_key}}` or `{{config.configurable.history_key}}`).
+
+### Validation Checklist
+
+1. Replay repeated callbacks for the same Telegram/WeCom identities and verify context continuity.
+2. Confirm unresolved or invalid keys do not crash runs (node should degrade to in-memory behavior).
+3. Verify truncation behavior: inference payload keeps latest `max_messages`, while store history keeps appended turns.
+4. Monitor warning logs for:
+  - key-resolution failures
+  - store read failures
+  - store write conflicts/failures
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-02-27 | Codex | Updated migration guidance to remove `thread_id` fallback dependency and align custom key examples with state-based `{{config.*}}` templates |
+| 2026-02-27 | Codex | Initial draft |

--- a/src/orcheo/config/__init__.py
+++ b/src/orcheo/config/__init__.py
@@ -12,6 +12,7 @@ from orcheo.config.loader import (
 from orcheo.config.types import (
     ChatKitBackend,
     CheckpointBackend,
+    GraphStoreBackend,
     RepositoryBackend,
     VaultBackend,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "VaultSettings",
     "ChatKitBackend",
     "CheckpointBackend",
+    "GraphStoreBackend",
     "RepositoryBackend",
     "VaultBackend",
     "_DEFAULTS",

--- a/src/orcheo/config/defaults.py
+++ b/src/orcheo/config/defaults.py
@@ -1,8 +1,13 @@
 """Default values shared across configuration models."""
 
+from pathlib import Path
+
+
 _DEFAULTS: dict[str, object] = {
     "CHECKPOINT_BACKEND": "sqlite",
     "SQLITE_PATH": "~/.orcheo/checkpoints.sqlite",
+    "GRAPH_STORE_BACKEND": "sqlite",
+    "GRAPH_STORE_SQLITE_PATH": str(Path.home() / ".orcheo" / "graph_store.sqlite"),
     "REPOSITORY_BACKEND": "sqlite",
     "REPOSITORY_SQLITE_PATH": "~/.orcheo/workflows.sqlite",
     "CHATKIT_BACKEND": "sqlite",

--- a/src/orcheo/config/loader.py
+++ b/src/orcheo/config/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from functools import lru_cache
+from pathlib import Path
 from dynaconf import Dynaconf
 from pydantic import ValidationError
 from orcheo.config.app_settings import AppSettings
@@ -27,6 +28,12 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
         settings = AppSettings(
             checkpoint_backend=source.get("CHECKPOINT_BACKEND"),
             sqlite_path=source.get("SQLITE_PATH", _DEFAULTS["SQLITE_PATH"]),
+            graph_store_backend=source.get(
+                "GRAPH_STORE_BACKEND", _DEFAULTS["GRAPH_STORE_BACKEND"]
+            ),
+            graph_store_sqlite_path=source.get(
+                "GRAPH_STORE_SQLITE_PATH", _DEFAULTS["GRAPH_STORE_SQLITE_PATH"]
+            ),
             repository_backend=source.get(
                 "REPOSITORY_BACKEND", _DEFAULTS["REPOSITORY_BACKEND"]
             ),
@@ -106,6 +113,11 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
     )
     normalized.set("CHECKPOINT_BACKEND", settings.checkpoint_backend)
     normalized.set("SQLITE_PATH", settings.sqlite_path)
+    normalized.set("GRAPH_STORE_BACKEND", settings.graph_store_backend)
+    normalized.set(
+        "GRAPH_STORE_SQLITE_PATH",
+        str(Path(settings.graph_store_sqlite_path).resolve(strict=False)),
+    )
     normalized.set("REPOSITORY_BACKEND", settings.repository_backend)
     normalized.set("REPOSITORY_SQLITE_PATH", settings.repository_sqlite_path)
     normalized.set("CHATKIT_BACKEND", settings.chatkit_backend)

--- a/src/orcheo/config/types.py
+++ b/src/orcheo/config/types.py
@@ -4,8 +4,15 @@ from typing import Literal
 
 
 CheckpointBackend = Literal["sqlite", "postgres"]
+GraphStoreBackend = Literal["sqlite", "postgres"]
 ChatKitBackend = Literal["sqlite", "postgres"]
 RepositoryBackend = Literal["inmemory", "sqlite", "postgres"]
 VaultBackend = Literal["inmemory", "file", "aws_kms", "postgres"]
 
-__all__ = ["ChatKitBackend", "CheckpointBackend", "RepositoryBackend", "VaultBackend"]
+__all__ = [
+    "ChatKitBackend",
+    "CheckpointBackend",
+    "GraphStoreBackend",
+    "RepositoryBackend",
+    "VaultBackend",
+]

--- a/src/orcheo/persistence.py
+++ b/src/orcheo/persistence.py
@@ -1,4 +1,4 @@
-"""Persistence helpers that create LangGraph checkpoint savers."""
+"""Persistence helpers that create LangGraph checkpoint savers and stores."""
 
 from __future__ import annotations
 import importlib
@@ -9,21 +9,27 @@ from typing import Any, cast
 import aiosqlite
 from dynaconf import Dynaconf
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-from orcheo.config import CheckpointBackend
+from langgraph.store.sqlite.aio import AsyncSqliteStore
+from orcheo.config import CheckpointBackend, GraphStoreBackend
 
 
 AsyncPostgresSaver: Any | None
 AsyncConnectionPool: Any | None
 DictRowFactory: Any | None
+AsyncPostgresStore: Any | None
 
 try:  # pragma: no cover - optional dependency
     AsyncPostgresSaver = importlib.import_module(
         "langgraph.checkpoint.postgres.aio"
     ).AsyncPostgresSaver
+    AsyncPostgresStore = importlib.import_module(
+        "langgraph.store.postgres.aio"
+    ).AsyncPostgresStore
     AsyncConnectionPool = importlib.import_module("psycopg_pool").AsyncConnectionPool
     DictRowFactory = importlib.import_module("psycopg.rows").dict_row
 except Exception:  # pragma: no cover - fallback when dependency missing
     AsyncPostgresSaver = None
+    AsyncPostgresStore = None
     AsyncConnectionPool = None
     DictRowFactory = None
 
@@ -97,4 +103,46 @@ async def create_checkpointer(settings: Dynaconf) -> AsyncIterator[Any]:
         return
 
     msg = "Unsupported checkpoint backend configured."
+    raise ValueError(msg)
+
+
+@asynccontextmanager
+async def create_graph_store(settings: Dynaconf) -> AsyncIterator[Any]:
+    """Create a LangGraph store based on the configured backend."""
+    backend = cast(GraphStoreBackend, settings.graph_store_backend)
+
+    if backend == "sqlite":
+        sqlite_path = Path(str(settings.graph_store_sqlite_path))
+        sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async with AsyncSqliteStore.from_conn_string(str(sqlite_path)) as store:
+            await store.setup()
+            yield store
+        return
+
+    if backend == "postgres":
+        if AsyncPostgresStore is None:  # pragma: no cover
+            msg = "Postgres graph store requires langgraph postgres extras."
+            raise RuntimeError(msg)
+
+        dsn = settings.postgres_dsn
+        if dsn is None:  # pragma: no cover - defensive, validated earlier
+            msg = "Postgres backend requires ORCHEO_POSTGRES_DSN to be set."
+            raise RuntimeError(msg)
+
+        pool_config = {
+            "min_size": int(settings.postgres_pool_min_size),
+            "max_size": int(settings.postgres_pool_max_size),
+            "timeout": float(settings.postgres_pool_timeout),
+            "max_idle": float(settings.postgres_pool_max_idle),
+        }
+        async with AsyncPostgresStore.from_conn_string(
+            dsn,
+            pool_config=pool_config,
+        ) as store:
+            await store.setup()
+            yield store
+        return
+
+    msg = "Unsupported graph store backend configured."
     raise ValueError(msg)

--- a/src/orcheo/runtime/__init__.py
+++ b/src/orcheo/runtime/__init__.py
@@ -13,6 +13,7 @@ from .credentials import (
     get_active_credential_resolver,
     parse_credential_reference,
 )
+from .state_builder import build_initial_state
 
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "credential_resolution",
     "get_active_credential_resolver",
     "parse_credential_reference",
+    "build_initial_state",
 ]

--- a/src/orcheo/runtime/state_builder.py
+++ b/src/orcheo/runtime/state_builder.py
@@ -1,0 +1,38 @@
+"""Shared runtime state assembly helpers."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+
+
+def build_initial_state(
+    graph_config: Mapping[str, Any],
+    inputs: Any,
+    runtime_config: Mapping[str, Any] | None = None,
+) -> Any:
+    """Return the initial workflow state used by runtime entrypoints."""
+    runtime_state_config = (
+        dict(runtime_config) if isinstance(runtime_config, Mapping) else {}
+    )
+
+    if graph_config.get("format") == LANGGRAPH_SCRIPT_FORMAT:
+        if not isinstance(inputs, Mapping):
+            return inputs
+        state = dict(inputs)
+        state.setdefault("inputs", dict(inputs))
+        state.setdefault("results", {})
+        state.setdefault("messages", [])
+        state["config"] = runtime_state_config
+        return state
+
+    normalized_inputs = dict(inputs) if isinstance(inputs, Mapping) else inputs
+    return {
+        "messages": [],
+        "results": {},
+        "inputs": normalized_inputs,
+        "config": runtime_state_config,
+    }
+
+
+__all__ = ["build_initial_state"]

--- a/tests/backend/test_chatkit_helpers.py
+++ b/tests/backend/test_chatkit_helpers.py
@@ -117,6 +117,7 @@ def testbuild_initial_state_langgraph_script() -> None:
     assert result["inputs"] == inputs
     assert result["messages"] == []
     assert result["results"] == {}
+    assert result["config"] == {}
 
 
 def testbuild_initial_state_default() -> None:
@@ -127,6 +128,7 @@ def testbuild_initial_state_default() -> None:
     assert result["messages"] == []
     assert result["results"] == {}
     assert result["inputs"] == {"message": "test"}
+    assert result["config"] == {}
 
 
 def testextract_reply_from_state_direct_reply() -> None:

--- a/tests/backend/test_chatkit_server_helpers.py
+++ b/tests/backend/test_chatkit_server_helpers.py
@@ -90,6 +90,7 @@ def test_build_initial_state_langgraph_format() -> None:
     assert result["metadata"] == {"key": "value"}
     assert result["messages"] == []
     assert result["results"] == {}
+    assert result["config"] == {}
 
 
 def test_build_initial_state_standard_format() -> None:
@@ -100,6 +101,7 @@ def test_build_initial_state_standard_format() -> None:
     assert "messages" in result
     assert "results" in result
     assert "inputs" in result
+    assert "config" in result
     assert result["inputs"] == inputs
 
 

--- a/tests/backend/worker/test_tasks_workflow_execution.py
+++ b/tests/backend/worker/test_tasks_workflow_execution.py
@@ -228,36 +228,46 @@ class TestExecuteWorkflow:
                             return_value=mock_checkpointer,
                         ):
                             with patch(
-                                "orcheo_backend.app.workflow_execution._build_initial_state",
-                                return_value={},
+                                "orcheo.persistence.create_graph_store",
+                                return_value=mock_checkpointer,
                             ):
-                                with patch("orcheo.config.get_settings"):
-                                    with patch(
-                                        "orcheo.runtime.runnable_config.merge_runnable_configs"
-                                    ) as mock_merge:
-                                        mock_config = MagicMock()
-                                        mock_config.to_runnable_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.to_state_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.to_json_config = MagicMock(
-                                            return_value={}
-                                        )
-                                        mock_config.tags = []
-                                        mock_config.callbacks = []
-                                        mock_config.metadata = {}
-                                        mock_config.run_name = None
-                                        mock_merge.return_value = mock_config
-
+                                with patch(
+                                    "orcheo_backend.app.workflow_execution._build_initial_state",
+                                    return_value={},
+                                ):
+                                    with patch("orcheo.config.get_settings"):
                                         with patch(
-                                            "orcheo.runtime.credentials.credential_resolution"
-                                        ):
-                                            result = await _execute_workflow(mock_run)
+                                            "orcheo.runtime.runnable_config.merge_runnable_configs"
+                                        ) as mock_merge:
+                                            mock_config = MagicMock()
+                                            mock_config.to_runnable_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.to_state_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.to_json_config = MagicMock(
+                                                return_value={}
+                                            )
+                                            mock_config.tags = []
+                                            mock_config.callbacks = []
+                                            mock_config.metadata = {}
+                                            mock_config.run_name = None
+                                            mock_merge.return_value = mock_config
+
+                                            with patch(
+                                                "orcheo.runtime.credentials.credential_resolution"
+                                            ):
+                                                result = await _execute_workflow(
+                                                    mock_run
+                                                )
 
         assert result["status"] == "succeeded"
         mock_repo.mark_run_succeeded.assert_called_once()
+        mock_graph.compile.assert_called_once_with(
+            checkpointer=mock_checkpointer,
+            store=mock_checkpointer,
+        )
         mock_history.start_run.assert_awaited_once()
         mock_history.append_step.assert_awaited()
         mock_history.mark_completed.assert_awaited_once()

--- a/tests/config/test_app_settings.py
+++ b/tests/config/test_app_settings.py
@@ -60,3 +60,10 @@ def test_coerce_postgres_pool_float_defaults_and_valid_values() -> None:
     assert AppSettings._coerce_postgres_pool_float(45.5) == 45.5
     # String numbers are converted
     assert AppSettings._coerce_postgres_pool_float("120.5") == 120.5
+
+
+def test_coerce_graph_store_backend_defaults_and_valid_values() -> None:
+    """Graph store backend coercion should mirror checkpoint backend behavior."""
+
+    assert AppSettings._coerce_graph_store_backend(None) == "sqlite"
+    assert AppSettings._coerce_graph_store_backend("POSTGRES") == "postgres"

--- a/tests/nodes/conversational_search/test_web_search.py
+++ b/tests/nodes/conversational_search/test_web_search.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 import respx
 from langchain_core.runnables import RunnableConfig
+import orcheo.nodes.conversational_search.retrieval as retrieval_mod
 from orcheo.graph.state import State
 from orcheo.nodes.conversational_search import WebSearchNode
 from orcheo.nodes.conversational_search.models import SearchResult
@@ -141,6 +142,22 @@ async def test_web_search_node_requires_api_key_when_not_suppressed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_web_search_node_rejects_whitespace_api_key_when_not_suppressed() -> None:
+    """WebSearchNode should treat whitespace api_key as missing."""
+    node = WebSearchNode(name="web", api_key="   ", suppress_errors=False)
+    state = State(
+        inputs={"query": "hello"},
+        results={},
+        structured_response=None,
+    )
+
+    with pytest.raises(
+        ValueError, match="WebSearchNode requires api_key to be configured"
+    ):
+        await node.run(state, {})
+
+
+@pytest.mark.asyncio
 async def test_web_search_node_resolves_api_key_from_credential_vault() -> None:
     """WebSearchNode should resolve api_key placeholders via active resolver."""
     state = State(
@@ -163,6 +180,38 @@ async def test_web_search_node_resolves_api_key_from_credential_vault() -> None:
             await node.run(state, {})
 
     assert captured["json"]["api_key"] == "vault-key"
+
+
+def test_web_search_node_raises_for_placeholder_without_active_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential placeholders require an active credential resolver."""
+    node = WebSearchNode(name="web", api_key="[[telegram_bot]]")
+    monkeypatch.setattr(retrieval_mod, "get_active_credential_resolver", lambda: None)
+
+    with pytest.raises(ValueError, match="no active credential resolver is available"):
+        node._resolve_api_key()
+
+
+def test_web_search_node_raises_when_resolved_credential_is_not_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolved credential values must be strings."""
+
+    class _BadResolver:
+        def resolve(self, reference: object) -> int:
+            del reference
+            return 123
+
+    node = WebSearchNode(name="web", api_key="[[telegram_bot]]")
+    monkeypatch.setattr(
+        retrieval_mod, "get_active_credential_resolver", lambda: _BadResolver()
+    )
+
+    with pytest.raises(
+        ValueError, match="Resolved WebSearchNode api_key credential must be a string"
+    ):
+        node._resolve_api_key()
 
 
 @pytest.mark.asyncio

--- a/tests/nodes/evaluation/test_batch.py
+++ b/tests/nodes/evaluation/test_batch.py
@@ -159,11 +159,11 @@ async def test_batch_eval_resolves_templated_max_conversations() -> None:
         name="batch",
         max_conversations="{{config.configurable.qrecc.max_conversations}}",
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"qrecc": {"max_conversations": 1}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 1
     assert result["total_turns"] == 2
@@ -460,33 +460,6 @@ def test_batch_eval_validate_max_conversations_none() -> None:
     assert node.max_conversations is None
 
 
-def test_batch_eval_validate_max_conversations_invalid_string() -> None:
-    """Non-integer, non-template string raises ValueError."""
-    with pytest.raises(ValueError, match="must be an integer"):
-        ConversationalBatchEvalNode(name="batch", max_conversations="bad")
-
-
-@pytest.mark.asyncio
-async def test_batch_eval_resolve_max_conversations_invalid_string() -> None:
-    """String that can't resolve to int raises ValueError at runtime."""
-    node = ConversationalBatchEvalNode(
-        name="batch",
-        max_conversations="{{config.configurable.max}}",
-    )
-    # Simulate template not resolved (stays as string)
-    node.max_conversations = "not_a_number"
-    with pytest.raises(ValueError, match="must resolve to an integer"):
-        await node.run(State(inputs={"conversations": QRECC_CONVERSATIONS}), {})
-
-
-@pytest.mark.asyncio
-async def test_batch_eval_resolve_max_conversations_less_than_one() -> None:
-    """max_conversations < 1 raises ValueError."""
-    node = ConversationalBatchEvalNode(name="batch", max_conversations=0)
-    with pytest.raises(ValueError, match="must be >= 1"):
-        await node.run(State(inputs={"conversations": QRECC_CONVERSATIONS}), {})
-
-
 def test_batch_eval_validate_max_concurrency_invalid_string() -> None:
     """Non-integer, non-template max_concurrency raises ValueError."""
     with pytest.raises(ValueError, match="must be an integer"):
@@ -515,11 +488,11 @@ async def test_batch_eval_resolves_templated_max_concurrency() -> None:
         name="batch",
         max_concurrency="{{config.configurable.eval.max_concurrency}}",
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"eval": {"max_concurrency": 2}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 2
 
@@ -567,11 +540,11 @@ async def test_batch_eval_resolves_templated_history_window_size() -> None:
         history_window_size="{{config.configurable.eval.history_window_size}}",
         pipeline=_build_pipeline_graph(HistoryCapture(name="capture")),
     )
-    state = State(inputs={"conversations": QRECC_CONVERSATIONS})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"conversations": QRECC_CONVERSATIONS},
         config={"configurable": {"eval": {"history_window_size": 1}}},
     )
+    node.decode_variables(state)
     await node.run(state, {})
 
     assert received_histories == [[], ["What is Python?"], []]

--- a/tests/nodes/evaluation/test_datasets.py
+++ b/tests/nodes/evaluation/test_datasets.py
@@ -334,11 +334,11 @@ async def test_qrecc_dataset_node_resolves_templated_max_conversations() -> None
         name="qrecc",
         max_conversations="{{config.configurable.qrecc.max_conversations}}",
     )
-    state = State(inputs={"qrecc_data": QRECC_SAMPLE})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"qrecc_data": QRECC_SAMPLE},
         config={"configurable": {"qrecc": {"max_conversations": 1}}},
     )
+    node.decode_variables(state)
     result = await node.run(state, {})
     assert result["total_conversations"] == 1
 
@@ -497,11 +497,11 @@ async def test_md2d_corpus_loader_node_resolves_templated_max_documents() -> Non
         name="md2d_corpus_loader",
         max_documents="{{config.configurable.corpus.max_documents}}",
     )
-    state = State(inputs={"md2d_corpus": MD2D_CORPUS_SAMPLE})
-    node.decode_variables(
-        state,
+    state = State(
+        inputs={"md2d_corpus": MD2D_CORPUS_SAMPLE},
         config={"configurable": {"corpus": {"max_documents": 1}}},
     )
+    node.decode_variables(state)
 
     result = await node.run(state, {})
 

--- a/tests/nodes/test_ai_agent_node_messages.py
+++ b/tests/nodes/test_ai_agent_node_messages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode
 
@@ -602,3 +602,374 @@ async def test_agentnode_graph_history_conflict_retry_fallback(
         {"configurable": {"thread_id": "thread-1", "__pregel_runtime": runtime}},
     )
     assert store.put_calls == 3
+
+
+def test_get_graph_store_handles_mapping_variants() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+
+    assert node._get_graph_store(None) is None
+    assert node._get_graph_store({"configurable": "bad"}) is None
+    assert node._get_graph_store({"configurable": {"__pregel_store": "fallback"}}) == (
+        "fallback"
+    )
+    assert (
+        node._get_graph_store(
+            {"configurable": {"__pregel_runtime": {"store": "runtime-store"}}}
+        )
+        == "runtime-store"
+    )
+    assert (
+        node._get_graph_store(
+            {
+                "configurable": {
+                    "__pregel_runtime": {"store": None},
+                    "__pregel_store": "fallback-2",
+                }
+            }
+        )
+        == "fallback-2"
+    )
+
+
+def test_resolve_history_key_skips_non_string_and_empty_candidates() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    node.history_key_candidates = [123, "{{results.empty.value}}", "room-1"]  # type: ignore[list-item]
+    state = State(
+        messages=[],
+        inputs={},
+        results={"empty": {"value": ""}},
+        structured_response=None,
+        config=None,
+    )
+    assert node._resolve_history_key(state, None) == "room-1"
+
+
+def test_resolve_history_key_rejects_invalid_template_result() -> None:
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        history_key_candidates=["room-1"],
+        history_key_template="{{conversation_key}}/{{conversation_key}}",
+    )
+    state = State(
+        messages=[], inputs={}, results={}, structured_response=None, config=None
+    )
+    assert node._resolve_history_key(state, None) is None
+
+
+@pytest.mark.asyncio
+async def test_store_get_item_sync_get_variants() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+
+    class SyncStore:
+        def get(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {"value": 1}
+
+    class CoroutineStore:
+        async def _async_get(self) -> object:
+            return {"value": 2}
+
+        def get(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return self._async_get()
+
+    class EmptyStore:
+        pass
+
+    assert await node._store_get_item(SyncStore(), namespace, "k") == {"value": 1}
+    assert await node._store_get_item(CoroutineStore(), namespace, "k") == {"value": 2}
+    assert await node._store_get_item(EmptyStore(), namespace, "k") is None
+
+
+@pytest.mark.asyncio
+async def test_store_put_item_sync_put_coroutine() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    calls: list[dict[str, object]] = []
+
+    class PutStore:
+        async def _async_put(self, value: dict[str, object]) -> None:
+            calls.append(value)
+
+        def put(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> object:
+            del namespace, key
+            return self._async_put(value)
+
+    await node._store_put_item(PutStore(), namespace, "k", {"x": 1})
+    assert calls == [{"x": 1}]
+
+
+@pytest.mark.asyncio
+async def test_store_put_item_sync_put_non_coroutine_and_missing_put() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    calls: list[dict[str, object]] = []
+
+    class SyncPutStore:
+        def put(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> object:
+            del namespace, key
+            calls.append(value)
+            return "done"
+
+    class MissingPutStore:
+        pass
+
+    await node._store_put_item(SyncPutStore(), namespace, "k", {"y": 2})
+    await node._store_put_item(MissingPutStore(), namespace, "k", {"z": 3})
+    assert calls == [{"y": 2}]
+
+
+def test_history_payload_from_item_and_message_normalization() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+
+    assert node._history_payload_from_item(None) == {}
+    assert node._history_payload_from_item({"value": "not-mapping"}) == {}
+    assert node._history_payload_from_item({"value": {"messages": []}}) == {
+        "messages": []
+    }
+    assert node._normalize_history_store_messages("not-list") == []
+
+    messages = node._normalize_history_store_messages(
+        [
+            "bad",
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": " "},
+            {"role": "user", "content": "b"},
+        ]
+    )
+    assert [message.content for message in messages] == ["a", "b"]
+
+
+def test_history_serialization_and_signature_helpers() -> None:
+    node = AgentNode(name="agent", ai_model="test-model", history_value_field="text")
+    serialized = node._serialize_history_messages(
+        [
+            AIMessage(content="a"),
+            HumanMessage(content=" "),
+            SystemMessage(content="system"),
+            HumanMessage(content="b"),
+        ]
+    )
+    assert serialized == [
+        {"role": "assistant", "text": "a", "content": "a"},
+        {"role": "user", "text": "b", "content": "b"},
+    ]
+    assert node._message_signature(SystemMessage(content="x")) == ("system", "x")
+    assert (
+        node._suffix_prefix_overlap(
+            [HumanMessage(content="1"), AIMessage(content="2")],
+            [AIMessage(content="2"), HumanMessage(content="3")],
+        )
+        == 1
+    )
+    assert node._history_version_from_payload({"version": "2"}) == 2
+    assert node._history_version_from_payload({"version": "x"}) == 0
+
+
+def test_extract_observed_messages_uses_inference_prefix() -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    current_messages = [HumanMessage(content="old")]
+    inference_messages = [HumanMessage(content="old"), AIMessage(content="draft")]
+    result = {
+        "messages": [
+            HumanMessage(content="old"),
+            AIMessage(content="draft"),
+            AIMessage(content="final"),
+        ]
+    }
+
+    observed = node._extract_observed_messages(
+        current_messages, inference_messages, result
+    )
+    assert [message.content for message in observed] == ["old", "final"]
+
+
+@pytest.mark.asyncio
+async def test_persist_graph_history_early_returns_and_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+
+    class ReadErrorStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            msg = "read fail"
+            raise RuntimeError(msg)
+
+    class NoNewMessagesStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {
+                "value": {
+                    "version": 1,
+                    "messages": [{"role": "user", "content": "hello"}],
+                }
+            }
+
+        async def aput(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> None:
+            del namespace, key, value
+            raise AssertionError("no write expected")
+
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[SystemMessage(content="ignore")],
+    )
+
+    await node._persist_graph_history(
+        store=ReadErrorStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+
+    monkeypatch.setattr(AgentNode, "_history_write_retry_limit", 0)
+    await node._persist_graph_history(
+        store=NoNewMessagesStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_graph_history_put_failure_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = AgentNode(name="agent", ai_model="test-model")
+    namespace = ("ns",)
+    sleeps: list[float] = []
+
+    class PutErrorStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            return {"value": {"version": 0, "messages": []}}
+
+        async def aput(
+            self,
+            namespace: tuple[str, ...],
+            key: str,
+            value: dict[str, object],
+        ) -> None:
+            del namespace, key, value
+            msg = "put fail"
+            raise RuntimeError(msg)
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(AgentNode, "_history_write_retry_limit", 2)
+    monkeypatch.setattr("orcheo.nodes.ai.random.uniform", lambda _a, _b: 0.0)
+    monkeypatch.setattr("orcheo.nodes.ai.asyncio.sleep", fake_sleep)
+
+    await node._persist_graph_history(
+        store=PutErrorStore(),
+        namespace=namespace,
+        key="k",
+        observed_messages=[HumanMessage(content="hello")],
+    )
+    assert sleeps == [node._history_retry_base_backoff_seconds]
+
+
+@pytest.mark.asyncio
+async def test_run_graph_history_fallback_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_agent = AsyncMock()
+    fake_agent.ainvoke.return_value = {"messages": [AIMessage(content="done")]}
+
+    async def fake_prepare_tools(self: AgentNode):  # type: ignore[unused-argument]
+        return []
+
+    monkeypatch.setattr("orcheo.nodes.ai.init_chat_model", lambda *args, **kwargs: "m")
+    monkeypatch.setattr(
+        "orcheo.nodes.ai.create_agent", lambda *args, **kwargs: fake_agent
+    )
+    monkeypatch.setattr(AgentNode, "_prepare_tools", fake_prepare_tools)
+
+    no_store_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["room-1"],
+    )
+    missing_key_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["{{results.missing.value}}"],
+    )
+    bad_key_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["{{results.missing.value}}"],
+    )
+    load_fail_node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        use_graph_chat_history=True,
+        history_key_candidates=["room-1"],
+    )
+    state = State(
+        messages=[],
+        inputs={"message": "hello"},
+        results={},
+        structured_response=None,
+        config=None,
+    )
+
+    class RaiseStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+            del namespace, key
+            msg = "load fail"
+            raise RuntimeError(msg)
+
+    await no_store_node.run(state, {"configurable": {"thread_id": "thread-1"}})
+    await bad_key_node.run(
+        state,
+        {"configurable": {"thread_id": "thread-1", "__pregel_runtime": object()}},
+    )
+    await missing_key_node.run(
+        state,
+        {
+            "configurable": {
+                "thread_id": "thread-1",
+                "__pregel_runtime": SimpleNamespace(store=_MemoryGraphStore()),
+            }
+        },
+    )
+    await load_fail_node.run(
+        state,
+        {
+            "configurable": {
+                "thread_id": "thread-1",
+                "__pregel_runtime": SimpleNamespace(store=RaiseStore()),
+            }
+        },
+    )

--- a/tests/runtime/test_state_builder.py
+++ b/tests/runtime/test_state_builder.py
@@ -1,0 +1,50 @@
+"""Tests for shared runtime initial-state construction."""
+
+from __future__ import annotations
+from orcheo.graph.ingestion import LANGGRAPH_SCRIPT_FORMAT
+from orcheo.runtime.state_builder import build_initial_state
+
+
+def test_build_initial_state_langgraph_script_mapping_defaults() -> None:
+    inputs = {"message": "hello"}
+
+    state = build_initial_state({"format": LANGGRAPH_SCRIPT_FORMAT}, inputs, None)
+
+    assert state["message"] == "hello"
+    assert state["inputs"] == inputs
+    assert state["results"] == {}
+    assert state["messages"] == []
+    assert state["config"] == {}
+
+
+def test_build_initial_state_langgraph_script_mapping_uses_runtime_config() -> None:
+    inputs = {"message": "hello"}
+    runtime_config = {"configurable": {"thread_id": "exec-1"}}
+
+    state = build_initial_state(
+        {"format": LANGGRAPH_SCRIPT_FORMAT},
+        inputs,
+        runtime_config,
+    )
+
+    assert state["config"] == runtime_config
+
+
+def test_build_initial_state_langgraph_script_non_mapping_passthrough() -> None:
+    payload = ["message"]
+
+    state = build_initial_state({"format": LANGGRAPH_SCRIPT_FORMAT}, payload, None)
+
+    assert state is payload
+
+
+def test_build_initial_state_default_shape() -> None:
+    inputs = {"message": "hello"}
+    runtime_config = {"run_name": "test"}
+
+    state = build_initial_state({"format": "graph"}, inputs, runtime_config)
+
+    assert state["inputs"] == inputs
+    assert state["results"] == {}
+    assert state["messages"] == []
+    assert state["config"] == runtime_config

--- a/tests/test_app_execute_workflow.py
+++ b/tests/test_app_execute_workflow.py
@@ -42,15 +42,21 @@ async def test_execute_workflow() -> None:
     mock_graph.compile.return_value = mock_compiled_graph
 
     mock_checkpointer = object()
+    mock_store = object()
 
     @asynccontextmanager
     async def fake_checkpointer(_settings):
         yield mock_checkpointer
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield mock_store
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -63,7 +69,10 @@ async def test_execute_workflow() -> None:
             runnable_config,
         )
 
-    mock_graph.compile.assert_called_once_with(checkpointer=mock_checkpointer)
+    mock_graph.compile.assert_called_once_with(
+        checkpointer=mock_checkpointer,
+        store=mock_store,
+    )
     mock_websocket.send_json.assert_any_call(steps[0])
     mock_websocket.send_json.assert_any_call(steps[1])
 
@@ -118,10 +127,15 @@ async def test_execute_workflow_langgraph_script_uses_raw_inputs() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -167,10 +181,15 @@ async def test_execute_workflow_failure_records_error() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):
@@ -215,10 +234,15 @@ async def test_execute_workflow_cancelled_records_reason() -> None:
     async def fake_checkpointer(_settings):
         yield object()
 
+    @asynccontextmanager
+    async def fake_graph_store(_settings):
+        yield object()
+
     history_store = InMemoryRunHistoryStore()
 
     with (
         patch("orcheo_backend.app.create_checkpointer", fake_checkpointer),
+        patch("orcheo_backend.app.create_graph_store", fake_graph_store),
         patch("orcheo_backend.app.build_graph", return_value=mock_graph),
         patch("orcheo_backend.app._history_store_ref", {"store": history_store}),
     ):


### PR DESCRIPTION
## Summary
This PR adds first-class graph store support and enables opt-in `AgentNode` chat history persistence/retrieval from the LangGraph store, while standardizing runtime state initialization across backend execution paths.

## What changed
- Added graph store config surface:
  - `ORCHEO_GRAPH_STORE_BACKEND` (`sqlite|postgres`)
  - `ORCHEO_GRAPH_STORE_SQLITE_PATH` (absolute-path validation)
  - Included graph store backend in Postgres DSN requirement checks.
- Added `create_graph_store(settings)` in `src/orcheo/persistence.py` with SQLite/Postgres implementations and setup.
- Wired `store=` into graph compilation across backend execution paths:
  - Workflow execution (including evaluation/training)
  - Trigger immediate execution
  - Worker task execution
  - ChatKit workflow executor
- Added shared runtime initial-state builder (`src/orcheo/runtime/state_builder.py`) and migrated call sites to use it so mapping-based payloads consistently include `state["config"]`.
- Extended `AgentNode` with graph-store history support:
  - New toggle and settings (`use_graph_chat_history`, namespace/key template/candidates, value field)
  - Deterministic key resolution/validation
  - History load + merge + trim before invoke
  - Persist observed turns after invoke with bounded retry/backoff and conflict fallback
  - Default key candidates now focus on channel-derived keys (no default `thread_id` fallback).
- Improved template decoding in `BaseRunnable`:
  - Supports mixed-string interpolation with multiple `{{...}}` templates
  - Preserves native type for single-template values
  - Stops injecting `config` into state in `decode_variables` (state config now built at runtime entrypoints).
- Updated `WebSearchNode` API key behavior:
  - Removed env-var fallback
  - Requires `api_key` to be configured
  - Supports resolving credential placeholders (e.g. `[[tavily_api_key]]`) via active credential resolver.
- Updated docs and initiative artifacts:
  - Expanded environment variable documentation
  - Updated requirements/design/plan docs
  - Added rollout playbook (`project/initiatives/agent_chat_history/4_rollout_playbook.md`).

## Tests updated
- Added/updated tests for:
  - Graph store config validation and defaults
  - Graph store factory (sqlite/postgres/error paths)
  - Shared state builder behavior
  - Backend compile wiring with `store=...`
  - `AgentNode` key resolution/history merge-persist/retry behavior
  - Template interpolation behavior in base node decoding
  - `WebSearchNode` credential-based API key resolution and required-key validation.

## Notes
- Behavior change: `WebSearchNode` no longer falls back to `TAVILY_API_KEY`; workflows should set `api_key` explicitly (prefer credential placeholders).
- Behavior change: default `AgentNode` history candidates no longer include `{{thread_id}}`; workflow authors can still add explicit custom candidates.
