### PR TITLE
Add editable workflow handles and make WeCom corp_id credential-based by default

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository/__init__.py
+++ b/apps/backend/src/orcheo_backend/app/repository/__init__.py
@@ -6,6 +6,7 @@ from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
 from orcheo_backend.app.repository.errors import (
     CronTriggerNotFoundError,
     RepositoryError,
+    WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowPublishStateError,
     WorkflowRunNotFoundError,
@@ -37,6 +38,7 @@ __all__ = [
     "CronTriggerNotFoundError",
     "RepositoryError",
     "VersionDiff",
+    "WorkflowHandleConflictError",
     "Workflow",
     "WorkflowNotFoundError",
     "WorkflowPublishStateError",

--- a/apps/backend/src/orcheo_backend/app/repository/errors.py
+++ b/apps/backend/src/orcheo_backend/app/repository/errors.py
@@ -23,6 +23,10 @@ class WorkflowPublishStateError(RepositoryError):
     """Raised when publish state transitions are invalid."""
 
 
+class WorkflowHandleConflictError(RepositoryError):
+    """Raised when a workflow handle conflicts with an existing workflow."""
+
+
 class CronTriggerNotFoundError(RepositoryError):
     """Raised when a cron trigger config cannot be located."""
 
@@ -33,5 +37,6 @@ __all__ = [
     "WorkflowVersionNotFoundError",
     "WorkflowRunNotFoundError",
     "WorkflowPublishStateError",
+    "WorkflowHandleConflictError",
     "CronTriggerNotFoundError",
 ]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
@@ -6,10 +6,12 @@ from collections.abc import Callable, Mapping
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
+from orcheo.models.workflow_refs import workflow_ref_is_uuid
 from orcheo.runtime.runnable_config import merge_runnable_configs
 from orcheo.triggers.layer import TriggerLayer
 from orcheo.vault.oauth import CredentialHealthError, OAuthCredentialService
 from orcheo_backend.app.repository.errors import (
+    WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowRunNotFoundError,
     WorkflowVersionNotFoundError,
@@ -25,6 +27,8 @@ class InMemoryRepositoryState:
         """Initialize the repository state containers and dependencies."""
         self._lock = asyncio.Lock()
         self._workflows: dict[UUID, Workflow] = {}
+        self._active_workflow_handles: dict[str, UUID] = {}
+        self._archived_workflow_handles: dict[str, list[UUID]] = {}
         self._workflow_versions: dict[UUID, list[UUID]] = {}
         self._versions: dict[UUID, WorkflowVersion] = {}
         self._runs: dict[UUID, WorkflowRun] = {}
@@ -36,6 +40,8 @@ class InMemoryRepositoryState:
         """Clear all stored workflows, versions, and runs."""
         async with self._lock:
             self._workflows.clear()
+            self._active_workflow_handles.clear()
+            self._archived_workflow_handles.clear()
             self._workflow_versions.clear()
             self._versions.clear()
             self._runs.clear()
@@ -134,6 +140,80 @@ class InMemoryRepositoryState:
         report = await service.ensure_workflow_health(workflow_id, actor=actor)
         if not report.is_healthy:
             raise CredentialHealthError(report)
+
+    def _rebuild_handle_indexes_locked(self) -> None:
+        """Rebuild handle indexes from workflow state. Caller must hold the lock."""
+        self._active_workflow_handles.clear()
+        self._archived_workflow_handles.clear()
+        archived_pairs: list[tuple[str, UUID, Any]] = []
+
+        for workflow in self._workflows.values():
+            if workflow.handle is None:
+                continue
+            if workflow.is_archived:
+                archived_pairs.append(
+                    (workflow.handle, workflow.id, workflow.updated_at)
+                )
+                continue
+            self._active_workflow_handles[workflow.handle] = workflow.id
+
+        archived_pairs.sort(key=lambda item: item[2], reverse=True)
+        for handle, workflow_id, _ in archived_pairs:
+            self._archived_workflow_handles.setdefault(handle, []).append(workflow_id)
+
+    def _ensure_handle_available_locked(
+        self,
+        handle: str | None,
+        *,
+        workflow_id: UUID | None,
+        is_archived: bool,
+    ) -> None:
+        """Ensure the provided handle is valid for assignment."""
+        if handle is None:
+            return
+
+        for existing_id in self._workflows:
+            if existing_id != workflow_id and str(existing_id) == handle:
+                msg = (
+                    "Workflow handle conflicts with an existing workflow UUID: "
+                    f"{handle}"
+                )
+                raise WorkflowHandleConflictError(msg)
+
+        for existing in self._workflows.values():
+            if existing.id == workflow_id or existing.handle != handle:
+                continue
+            if not existing.is_archived or not is_archived:
+                msg = f"Workflow handle '{handle}' is already in use."
+                raise WorkflowHandleConflictError(msg)
+
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        """Resolve a user-facing workflow ref to a canonical UUID."""
+        normalized_ref = workflow_ref.strip().lower()
+        if not normalized_ref:
+            raise WorkflowNotFoundError("workflow ref is empty")
+
+        async with self._lock:
+            active_match = self._active_workflow_handles.get(normalized_ref)
+            if active_match is not None:
+                return active_match
+
+            if include_archived:
+                archived_matches = self._archived_workflow_handles.get(normalized_ref)
+                if archived_matches:
+                    return archived_matches[0]
+
+            if workflow_ref_is_uuid(normalized_ref):
+                workflow_uuid = UUID(normalized_ref)
+                if workflow_uuid in self._workflows:
+                    return workflow_uuid
+
+        raise WorkflowNotFoundError(normalized_ref)
 
 
 __all__ = ["InMemoryRepositoryState"]

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/state.py
@@ -172,14 +172,6 @@ class InMemoryRepositoryState:
         if handle is None:
             return
 
-        for existing_id in self._workflows:
-            if existing_id != workflow_id and str(existing_id) == handle:
-                msg = (
-                    "Workflow handle conflicts with an existing workflow UUID: "
-                    f"{handle}"
-                )
-                raise WorkflowHandleConflictError(msg)
-
         for existing in self._workflows.values():
             if existing.id == workflow_id or existing.handle != handle:
                 continue

--- a/apps/backend/src/orcheo_backend/app/repository/in_memory/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository/in_memory/workflows.py
@@ -28,6 +28,7 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
         self,
         *,
         name: str,
+        handle: str | None = None,
         slug: str | None,
         description: str | None,
         tags: Iterable[str] | None,
@@ -35,14 +36,21 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
     ) -> Workflow:
         """Persist a new workflow and return the created instance."""
         async with self._lock:
+            self._ensure_handle_available_locked(
+                handle,
+                workflow_id=None,
+                is_archived=False,
+            )
             workflow = Workflow(
                 name=name,
+                handle=handle,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
             )
             workflow.record_event(actor=actor, action="workflow_created")
             self._workflows[workflow.id] = workflow
+            self._rebuild_handle_indexes_locked()
             self._workflow_versions.setdefault(workflow.id, [])
             return workflow.model_copy(deep=True)
 
@@ -54,11 +62,24 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
                 raise WorkflowNotFoundError(str(workflow_id))
             return workflow.model_copy(deep=True)
 
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        """Resolve a workflow ref using handle-first semantics."""
+        return await super().resolve_workflow_ref(
+            workflow_ref,
+            include_archived=include_archived,
+        )
+
     async def update_workflow(
         self,
         workflow_id: UUID,
         *,
         name: str | None,
+        handle: str | None = None,
         description: str | None,
         tags: Iterable[str] | None,
         is_archived: bool | None,
@@ -71,6 +92,18 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
                 raise WorkflowNotFoundError(str(workflow_id))
 
             metadata: dict[str, Any] = {}
+            next_is_archived = (
+                workflow.is_archived if is_archived is None else is_archived
+            )
+
+            if handle is not None and handle != workflow.handle:
+                self._ensure_handle_available_locked(
+                    handle,
+                    workflow_id=workflow_id,
+                    is_archived=next_is_archived,
+                )
+                metadata["handle"] = {"from": workflow.handle, "to": handle}
+                workflow.handle = handle
 
             if name is not None and name != workflow.name:
                 metadata["name"] = {"from": workflow.name, "to": name}
@@ -106,6 +139,7 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
                 action="workflow_updated",
                 metadata=metadata,
             )
+            self._rebuild_handle_indexes_locked()
             return workflow.model_copy(deep=True)
 
     async def archive_workflow(self, workflow_id: UUID, *, actor: str) -> Workflow:
@@ -113,6 +147,7 @@ class WorkflowCrudMixin(InMemoryRepositoryState):
         return await self.update_workflow(
             workflow_id,
             name=None,
+            handle=None,
             description=None,
             tags=None,
             is_archived=True,

--- a/apps/backend/src/orcheo_backend/app/repository/protocol.py
+++ b/apps/backend/src/orcheo_backend/app/repository/protocol.py
@@ -33,6 +33,7 @@ class WorkflowRepository(Protocol):
         self,
         *,
         name: str,
+        handle: str | None = None,
         slug: str | None,
         description: str | None,
         tags: Iterable[str] | None,
@@ -43,11 +44,20 @@ class WorkflowRepository(Protocol):
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         """Return a single workflow by identifier."""
 
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        """Resolve a user-facing workflow ref to the canonical UUID."""
+
     async def update_workflow(
         self,
         workflow_id: UUID,
         *,
         name: str | None,
+        handle: str | None = None,
         description: str | None,
         tags: Iterable[str] | None,
         is_archived: bool | None,

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow
+from orcheo.models.workflow_refs import normalize_workflow_handle
 from orcheo_backend.app.repository.errors import (
     WorkflowNotFoundError,
     WorkflowPublishStateError,
@@ -42,15 +43,16 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         actor: str,
     ) -> Workflow:
         await self._ensure_initialized()
+        normalized_handle = normalize_workflow_handle(handle)
         async with self._lock:
             await self._ensure_handle_available_locked(
-                handle,
+                normalized_handle,
                 workflow_id=None,
                 is_archived=False,
             )
             workflow = Workflow(
                 name=name,
-                handle=handle,
+                handle=normalized_handle,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
@@ -110,6 +112,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         actor: str,
     ) -> Workflow:
         await self._ensure_initialized()
+        normalized_handle = normalize_workflow_handle(handle)
         async with self._lock:
             workflow = await self._get_workflow_locked(workflow_id)
 
@@ -118,14 +121,17 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 workflow.is_archived if is_archived is None else is_archived
             )
 
-            if handle is not None and handle != workflow.handle:
+            if normalized_handle is not None and normalized_handle != workflow.handle:
                 await self._ensure_handle_available_locked(
-                    handle,
+                    normalized_handle,
                     workflow_id=workflow_id,
                     is_archived=next_is_archived,
                 )
-                metadata["handle"] = {"from": workflow.handle, "to": handle}
-                workflow.handle = handle
+                metadata["handle"] = {
+                    "from": workflow.handle,
+                    "to": normalized_handle,
+                }
+                workflow.handle = normalized_handle
 
             if name is not None and name != workflow.name:
                 metadata["name"] = {"from": workflow.name, "to": name}

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_workflows.py
@@ -35,6 +35,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         self,
         *,
         name: str,
+        handle: str | None = None,
         slug: str | None,
         description: str | None,
         tags: Iterable[str] | None,
@@ -42,8 +43,14 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
     ) -> Workflow:
         await self._ensure_initialized()
         async with self._lock:
+            await self._ensure_handle_available_locked(
+                handle,
+                workflow_id=None,
+                is_archived=False,
+            )
             workflow = Workflow(
                 name=name,
+                handle=handle,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
@@ -52,11 +59,20 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
             async with self._connection() as conn:
                 await conn.execute(
                     """
-                    INSERT INTO workflows (id, payload, created_at, updated_at)
-                    VALUES (%s, %s, %s, %s)
+                    INSERT INTO workflows (
+                        id,
+                        handle,
+                        is_archived,
+                        payload,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s)
                     """,
                     (
                         str(workflow.id),
+                        workflow.handle,
+                        workflow.is_archived,
                         self._dump_model(workflow),
                         workflow.created_at,
                         workflow.updated_at,
@@ -69,11 +85,25 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         async with self._lock:
             return await self._get_workflow_locked(workflow_id)
 
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        await self._ensure_initialized()
+        async with self._lock:
+            return await self._resolve_workflow_ref_locked(
+                workflow_ref,
+                include_archived=include_archived,
+            )
+
     async def update_workflow(
         self,
         workflow_id: UUID,
         *,
         name: str | None,
+        handle: str | None = None,
         description: str | None,
         tags: Iterable[str] | None,
         is_archived: bool | None,
@@ -84,6 +114,18 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
             workflow = await self._get_workflow_locked(workflow_id)
 
             metadata: dict[str, Any] = {}
+            next_is_archived = (
+                workflow.is_archived if is_archived is None else is_archived
+            )
+
+            if handle is not None and handle != workflow.handle:
+                await self._ensure_handle_available_locked(
+                    handle,
+                    workflow_id=workflow_id,
+                    is_archived=next_is_archived,
+                )
+                metadata["handle"] = {"from": workflow.handle, "to": handle}
+                workflow.handle = handle
 
             if name is not None and name != workflow.name:
                 metadata["name"] = {"from": workflow.name, "to": name}
@@ -124,10 +166,12 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 await conn.execute(
                     """
                     UPDATE workflows
-                       SET payload = %s, updated_at = %s
+                       SET handle = %s, is_archived = %s, payload = %s, updated_at = %s
                      WHERE id = %s
                     """,
                     (
+                        workflow.handle,
+                        workflow.is_archived,
                         self._dump_model(workflow),
                         workflow.updated_at,
                         str(workflow.id),
@@ -139,6 +183,7 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
         return await self.update_workflow(
             workflow_id,
             name=None,
+            handle=None,
             description=None,
             tags=None,
             is_archived=True,
@@ -168,10 +213,12 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 await conn.execute(
                     """
                     UPDATE workflows
-                       SET payload = %s, updated_at = %s
+                       SET handle = %s, is_archived = %s, payload = %s, updated_at = %s
                      WHERE id = %s
                     """,
                     (
+                        workflow.handle,
+                        workflow.is_archived,
                         self._dump_model(workflow),
                         workflow.updated_at,
                         str(workflow.id),
@@ -193,10 +240,12 @@ class WorkflowRepositoryMixin(PostgresPersistenceMixin):
                 await conn.execute(
                     """
                     UPDATE workflows
-                       SET payload = %s, updated_at = %s
+                       SET handle = %s, is_archived = %s, payload = %s, updated_at = %s
                      WHERE id = %s
                     """,
                     (
+                        workflow.handle,
+                        workflow.is_archived,
                         self._dump_model(workflow),
                         workflow.updated_at,
                         str(workflow.id),

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_persistence.py
@@ -6,8 +6,10 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow, WorkflowRun, WorkflowVersion
+from orcheo.models.workflow_refs import workflow_ref_is_uuid
 from orcheo.runtime.runnable_config import merge_runnable_configs
 from orcheo_backend.app.repository import (
+    WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowRunNotFoundError,
     WorkflowVersionNotFoundError,
@@ -35,6 +37,115 @@ class SqlitePersistenceMixin(SqliteRepositoryBase):
         if row is None:
             raise WorkflowNotFoundError(str(workflow_id))
         return self._deserialize_workflow(row["payload"])
+
+    async def _workflow_exists_locked(self, workflow_id: UUID) -> bool:
+        async with self._connection() as conn:
+            cursor = await conn.execute(
+                "SELECT 1 FROM workflows WHERE id = ?",
+                (str(workflow_id),),
+            )
+            row = await cursor.fetchone()
+        return row is not None
+
+    async def _ensure_handle_available_locked(
+        self,
+        handle: str | None,
+        *,
+        workflow_id: UUID | None,
+        is_archived: bool,
+    ) -> None:
+        """Ensure the provided handle can be assigned."""
+        if handle is None:
+            return
+
+        workflow_id_str = str(workflow_id) if workflow_id is not None else None
+        async with self._connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT id
+                  FROM workflows
+                 WHERE id = ?
+                   AND (? IS NULL OR id != ?)
+                """,
+                (handle, workflow_id_str, workflow_id_str),
+            )
+            row = await cursor.fetchone()
+            if row is not None:
+                msg = (
+                    "Workflow handle conflicts with an existing workflow UUID: "
+                    f"{handle}"
+                )
+                raise WorkflowHandleConflictError(msg)
+
+            cursor = await conn.execute(
+                """
+                SELECT id, is_archived
+                  FROM workflows
+                 WHERE handle = ?
+                   AND (? IS NULL OR id != ?)
+                """,
+                (handle, workflow_id_str, workflow_id_str),
+            )
+            rows = await cursor.fetchall()
+
+        for row in rows:
+            if not row["is_archived"] or not is_archived:
+                msg = f"Workflow handle '{handle}' is already in use."
+                raise WorkflowHandleConflictError(msg)
+
+    async def _resolve_workflow_ref_locked(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        """Resolve a workflow ref using handle-first semantics."""
+        normalized_ref = workflow_ref.strip().lower()
+        if not normalized_ref:
+            raise WorkflowNotFoundError("workflow ref is empty")
+
+        async with self._connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT id
+                  FROM workflows
+                 WHERE handle = ?
+                   AND is_archived = 0
+              ORDER BY updated_at DESC
+                 LIMIT 1
+                """,
+                (normalized_ref,),
+            )
+            row = await cursor.fetchone()
+            if row is not None:
+                return UUID(row["id"])
+
+            if include_archived:
+                cursor = await conn.execute(
+                    """
+                    SELECT id
+                      FROM workflows
+                     WHERE handle = ?
+                       AND is_archived = 1
+                  ORDER BY updated_at DESC
+                     LIMIT 1
+                    """,
+                    (normalized_ref,),
+                )
+                row = await cursor.fetchone()
+                if row is not None:
+                    return UUID(row["id"])
+
+            if workflow_ref_is_uuid(normalized_ref):
+                cursor = await conn.execute(
+                    "SELECT id FROM workflows WHERE id = ?",
+                    (normalized_ref,),
+                )
+                row = await cursor.fetchone()
+                if row is not None:
+                    return UUID(row["id"])
+
+        raise WorkflowNotFoundError(normalized_ref)
 
     async def _get_version_locked(self, version_id: UUID) -> WorkflowVersion:
         async with self._connection() as conn:

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_workflows.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_workflows.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from uuid import UUID
 from orcheo.models.workflow import Workflow
+from orcheo.models.workflow_refs import normalize_workflow_handle
 from orcheo_backend.app.repository.errors import (
     WorkflowNotFoundError,
     WorkflowPublishStateError,
@@ -42,15 +43,16 @@ class WorkflowRepositoryMixin(SqlitePersistenceMixin):
         actor: str,
     ) -> Workflow:
         await self._ensure_initialized()
+        normalized_handle = normalize_workflow_handle(handle)
         async with self._lock:
             await self._ensure_handle_available_locked(
-                handle,
+                normalized_handle,
                 workflow_id=None,
                 is_archived=False,
             )
             workflow = Workflow(
                 name=name,
-                handle=handle,
+                handle=normalized_handle,
                 slug=slug or "",
                 description=description,
                 tags=list(tags or []),
@@ -110,6 +112,7 @@ class WorkflowRepositoryMixin(SqlitePersistenceMixin):
         actor: str,
     ) -> Workflow:
         await self._ensure_initialized()
+        normalized_handle = normalize_workflow_handle(handle)
         async with self._lock:
             workflow = await self._get_workflow_locked(workflow_id)
 
@@ -118,14 +121,17 @@ class WorkflowRepositoryMixin(SqlitePersistenceMixin):
                 workflow.is_archived if is_archived is None else is_archived
             )
 
-            if handle is not None and handle != workflow.handle:
+            if normalized_handle is not None and normalized_handle != workflow.handle:
                 await self._ensure_handle_available_locked(
-                    handle,
+                    normalized_handle,
                     workflow_id=workflow_id,
                     is_archived=next_is_archived,
                 )
-                metadata["handle"] = {"from": workflow.handle, "to": handle}
-                workflow.handle = handle
+                metadata["handle"] = {
+                    "from": workflow.handle,
+                    "to": normalized_handle,
+                }
+                workflow.handle = normalized_handle
 
             if name is not None and name != workflow.name:
                 metadata["name"] = {"from": workflow.name, "to": name}

--- a/apps/backend/src/orcheo_backend/app/routers/agentensor.py
+++ b/apps/backend/src/orcheo_backend/app/routers/agentensor.py
@@ -16,33 +16,33 @@ router = APIRouter()
 
 
 @router.get(
-    "/workflows/{workflow_id}/agentensor/checkpoints",
+    "/workflows/{workflow_ref}/agentensor/checkpoints",
     response_model=list[AgentensorCheckpointResponse],
 )
 async def list_agentensor_checkpoints(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
     store: CheckpointStoreDep,
     limit: int = Query(20, ge=1, le=200),
 ) -> list[AgentensorCheckpointResponse]:
     """List checkpoints for the specified workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     checkpoints = await store.list_checkpoints(str(workflow_uuid), limit=limit)
     return [AgentensorCheckpointResponse.from_domain(item) for item in checkpoints]
 
 
 @router.get(
-    "/workflows/{workflow_id}/agentensor/checkpoints/{checkpoint_id}",
+    "/workflows/{workflow_ref}/agentensor/checkpoints/{checkpoint_id}",
     response_model=AgentensorCheckpointResponse,
 )
 async def get_agentensor_checkpoint(
-    workflow_id: str,
+    workflow_ref: str,
     checkpoint_id: str,
     repository: RepositoryDep,
     store: CheckpointStoreDep,
 ) -> AgentensorCheckpointResponse:
     """Return a single checkpoint for the workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         checkpoint = await store.get_checkpoint(checkpoint_id)
     except AgentensorCheckpointNotFoundError as exc:

--- a/apps/backend/src/orcheo_backend/app/routers/agentensor.py
+++ b/apps/backend/src/orcheo_backend/app/routers/agentensor.py
@@ -1,10 +1,13 @@
 """Agentensor checkpoint APIs."""
 
 from __future__ import annotations
-from uuid import UUID
 from fastapi import APIRouter, Query
 from orcheo.agentensor.checkpoints import AgentensorCheckpointNotFoundError
-from orcheo_backend.app.dependencies import CheckpointStoreDep
+from orcheo_backend.app.dependencies import (
+    CheckpointStoreDep,
+    RepositoryDep,
+    resolve_workflow_ref_id,
+)
 from orcheo_backend.app.errors import raise_not_found
 from orcheo_backend.app.schemas.agentensor import AgentensorCheckpointResponse
 
@@ -17,12 +20,14 @@ router = APIRouter()
     response_model=list[AgentensorCheckpointResponse],
 )
 async def list_agentensor_checkpoints(
-    workflow_id: UUID,
+    workflow_id: str,
+    repository: RepositoryDep,
     store: CheckpointStoreDep,
     limit: int = Query(20, ge=1, le=200),
 ) -> list[AgentensorCheckpointResponse]:
     """List checkpoints for the specified workflow."""
-    checkpoints = await store.list_checkpoints(str(workflow_id), limit=limit)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    checkpoints = await store.list_checkpoints(str(workflow_uuid), limit=limit)
     return [AgentensorCheckpointResponse.from_domain(item) for item in checkpoints]
 
 
@@ -31,16 +36,18 @@ async def list_agentensor_checkpoints(
     response_model=AgentensorCheckpointResponse,
 )
 async def get_agentensor_checkpoint(
-    workflow_id: UUID,
+    workflow_id: str,
     checkpoint_id: str,
+    repository: RepositoryDep,
     store: CheckpointStoreDep,
 ) -> AgentensorCheckpointResponse:
     """Return a single checkpoint for the workflow."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
         checkpoint = await store.get_checkpoint(checkpoint_id)
     except AgentensorCheckpointNotFoundError as exc:
         raise_not_found("Checkpoint not found", exc)
-    if checkpoint.workflow_id != str(workflow_id):
+    if checkpoint.workflow_id != str(workflow_uuid):
         raise_not_found("Checkpoint not found", AgentensorCheckpointNotFoundError(""))
     return AgentensorCheckpointResponse.from_domain(checkpoint)
 

--- a/apps/backend/src/orcheo_backend/app/routers/chatkit.py
+++ b/apps/backend/src/orcheo_backend/app/routers/chatkit.py
@@ -45,7 +45,7 @@ from orcheo_backend.app.chatkit_tokens import (
     ChatKitTokenConfigurationError,
     load_chatkit_token_settings,
 )
-from orcheo_backend.app.dependencies import RepositoryDep
+from orcheo_backend.app.dependencies import RepositoryDep, resolve_workflow_ref_id
 from orcheo_backend.app.errors import raise_not_found
 from orcheo_backend.app.repository import (
     WorkflowNotFoundError,
@@ -538,12 +538,13 @@ async def create_chatkit_session_endpoint(
     status_code=status.HTTP_201_CREATED,
 )
 async def trigger_chatkit_workflow(
-    workflow_id: UUID,
+    workflow_id: str,
     request: ChatKitWorkflowTriggerRequest,
     repository: RepositoryDep,
     policy: AuthorizationPolicy = Depends(get_authorization_policy),  # noqa: B008
 ) -> WorkflowRun:
     """Create a workflow run initiated from the ChatKit interface."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
         policy.require_authenticated()
     except AuthenticationError as exc:
@@ -551,7 +552,7 @@ async def trigger_chatkit_workflow(
             raise exc.as_http_exception() from exc
 
     try:
-        latest_version = await repository.get_latest_version(workflow_id)
+        latest_version = await repository.get_latest_version(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except WorkflowVersionNotFoundError as exc:
@@ -566,7 +567,7 @@ async def trigger_chatkit_workflow(
 
     try:
         run = await repository.create_run(
-            workflow_id,
+            workflow_uuid,
             workflow_version_id=latest_version.id,
             triggered_by=request.actor,
             input_payload=payload,
@@ -583,7 +584,7 @@ async def trigger_chatkit_workflow(
 
     logger.info(
         "Dispatched ChatKit workflow run",
-        extra={"workflow_id": str(workflow_id), "run_id": str(run.id)},
+        extra={"workflow_id": str(workflow_uuid), "run_id": str(run.id)},
     )
     return run
 

--- a/apps/backend/src/orcheo_backend/app/routers/chatkit.py
+++ b/apps/backend/src/orcheo_backend/app/routers/chatkit.py
@@ -533,18 +533,18 @@ async def create_chatkit_session_endpoint(
 
 
 @router.post(
-    "/chatkit/workflows/{workflow_id}/trigger",
+    "/chatkit/workflows/{workflow_ref}/trigger",
     response_model=WorkflowRun,
     status_code=status.HTTP_201_CREATED,
 )
 async def trigger_chatkit_workflow(
-    workflow_id: str,
+    workflow_ref: str,
     request: ChatKitWorkflowTriggerRequest,
     repository: RepositoryDep,
     policy: AuthorizationPolicy = Depends(get_authorization_policy),  # noqa: B008
 ) -> WorkflowRun:
     """Create a workflow run initiated from the ChatKit interface."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         policy.require_authenticated()
     except AuthenticationError as exc:

--- a/apps/backend/src/orcheo_backend/app/routers/credential_health.py
+++ b/apps/backend/src/orcheo_backend/app/routers/credential_health.py
@@ -21,16 +21,16 @@ router = APIRouter()
 
 
 @router.get(
-    "/workflows/{workflow_id}/credentials/health",
+    "/workflows/{workflow_ref}/credentials/health",
     response_model=CredentialHealthResponse,
 )
 async def get_workflow_credential_health(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
     service: CredentialServiceDep,
 ) -> CredentialHealthResponse:
     """Return cached credential health information for a workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         await repository.get_workflow(workflow_uuid)
     except WorkflowNotFoundError as exc:
@@ -54,17 +54,17 @@ async def get_workflow_credential_health(
 
 
 @router.post(
-    "/workflows/{workflow_id}/credentials/validate",
+    "/workflows/{workflow_ref}/credentials/validate",
     response_model=CredentialHealthResponse,
 )
 async def validate_workflow_credentials(
-    workflow_id: str,
+    workflow_ref: str,
     request: CredentialValidationRequest,
     repository: RepositoryDep,
     service: CredentialServiceDep,
 ) -> CredentialHealthResponse:
     """Trigger validation of workflow credentials and return the updated report."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         await repository.get_workflow(workflow_uuid)
     except WorkflowNotFoundError as exc:

--- a/apps/backend/src/orcheo_backend/app/routers/credential_health.py
+++ b/apps/backend/src/orcheo_backend/app/routers/credential_health.py
@@ -1,12 +1,12 @@
 """Credential health routes."""
 
 from __future__ import annotations
-from uuid import UUID
 from fastapi import APIRouter, HTTPException, status
 from orcheo.models import CredentialHealthStatus
 from orcheo_backend.app.dependencies import (
     CredentialServiceDep,
     RepositoryDep,
+    resolve_workflow_ref_id,
 )
 from orcheo_backend.app.errors import raise_not_found
 from orcheo_backend.app.history_utils import health_report_to_response
@@ -25,13 +25,14 @@ router = APIRouter()
     response_model=CredentialHealthResponse,
 )
 async def get_workflow_credential_health(
-    workflow_id: UUID,
+    workflow_id: str,
     repository: RepositoryDep,
     service: CredentialServiceDep,
 ) -> CredentialHealthResponse:
     """Return cached credential health information for a workflow."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        await repository.get_workflow(workflow_id)
+        await repository.get_workflow(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
 
@@ -41,10 +42,10 @@ async def get_workflow_credential_health(
             detail="Credential health service is not configured.",
         )
 
-    report = service.get_report(workflow_id)
+    report = service.get_report(workflow_uuid)
     if report is None:
         return CredentialHealthResponse(
-            workflow_id=str(workflow_id),
+            workflow_id=str(workflow_uuid),
             status=CredentialHealthStatus.UNKNOWN,
             checked_at=None,
             credentials=[],
@@ -57,14 +58,15 @@ async def get_workflow_credential_health(
     response_model=CredentialHealthResponse,
 )
 async def validate_workflow_credentials(
-    workflow_id: UUID,
+    workflow_id: str,
     request: CredentialValidationRequest,
     repository: RepositoryDep,
     service: CredentialServiceDep,
 ) -> CredentialHealthResponse:
     """Trigger validation of workflow credentials and return the updated report."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        await repository.get_workflow(workflow_id)
+        await repository.get_workflow(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
 
@@ -74,7 +76,7 @@ async def validate_workflow_credentials(
             detail="Credential health service is not configured.",
         )
 
-    report = await service.ensure_workflow_health(workflow_id, actor=request.actor)
+    report = await service.ensure_workflow_health(workflow_uuid, actor=request.actor)
     if not report.is_healthy:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/apps/backend/src/orcheo_backend/app/routers/nodes.py
+++ b/apps/backend/src/orcheo_backend/app/routers/nodes.py
@@ -5,6 +5,10 @@ import logging
 from typing import Any
 from fastapi import APIRouter, HTTPException
 from orcheo.nodes.registry import registry
+from orcheo_backend.app.dependencies import (
+    RepositoryDep,
+    resolve_optional_workflow_ref_id,
+)
 from orcheo_backend.app.schemas.nodes import (
     NodeExecutionRequest,
     NodeExecutionResponse,
@@ -23,10 +27,14 @@ logger = logging.getLogger(__name__)
 )
 async def execute_node_endpoint(
     request: NodeExecutionRequest,
+    repository: RepositoryDep,
 ) -> NodeExecutionResponse:
     """Execute a single node in isolation for testing/preview purposes."""
     node_config = request.node_config
     inputs = request.inputs
+    workflow_id = await resolve_optional_workflow_ref_id(
+        repository, request.workflow_id
+    )
 
     node_type = node_config.get("type")
     if not node_type:
@@ -49,7 +57,7 @@ async def execute_node_endpoint(
             node_class,
             node_params,
             inputs,
-            workflow_id=request.workflow_id,
+            workflow_id=workflow_id,
         )
 
         node_name = node_params.get("name", "node")

--- a/apps/backend/src/orcheo_backend/app/routers/runs.py
+++ b/apps/backend/src/orcheo_backend/app/routers/runs.py
@@ -36,18 +36,18 @@ router = APIRouter()
 
 
 @router.post(
-    "/workflows/{workflow_id}/runs",
+    "/workflows/{workflow_ref}/runs",
     response_model=WorkflowRun,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_workflow_run(
-    workflow_id: str,
+    workflow_ref: str,
     request: WorkflowRunCreateRequest,
     repository: RepositoryDep,
     _service: CredentialServiceDep,
 ) -> WorkflowRun:
     """Create a workflow execution run."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         config_payload = (
             request.runnable_config.model_dump(mode="json")
@@ -73,15 +73,15 @@ async def create_workflow_run(
 
 
 @router.get(
-    "/workflows/{workflow_id}/runs",
+    "/workflows/{workflow_ref}/runs",
     response_model=list[WorkflowRun],
 )
 async def list_workflow_runs(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
 ) -> list[WorkflowRun]:
     """List runs for a given workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         return await repository.list_runs_for_workflow(workflow_uuid)
     except WorkflowNotFoundError as exc:
@@ -173,17 +173,17 @@ async def mark_run_cancelled(
 
 
 @router.get(
-    "/workflows/{workflow_id}/executions",
+    "/workflows/{workflow_ref}/executions",
     response_model=list[RunHistoryResponse],
 )
 async def list_workflow_execution_histories(
-    workflow_id: str,
+    workflow_ref: str,
     history_store: HistoryStoreDep,
     repository: RepositoryDep,
     limit: int = Query(50, ge=1, le=200),
 ) -> list[RunHistoryResponse]:
     """Return execution histories recorded for the workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     records = await history_store.list_histories(str(workflow_uuid), limit=limit)
     return [history_to_response(record) for record in records]
 

--- a/apps/backend/src/orcheo_backend/app/routers/triggers.py
+++ b/apps/backend/src/orcheo_backend/app/routers/triggers.py
@@ -205,16 +205,16 @@ def _build_json_immediate_response(
 
 
 @router.put(
-    "/workflows/{workflow_id}/triggers/webhook/config",
+    "/workflows/{workflow_ref}/triggers/webhook/config",
     response_model=WebhookTriggerConfig,
 )
 async def configure_webhook_trigger(
-    workflow_id: str,
+    workflow_ref: str,
     request: WebhookTriggerConfig,
     repository: RepositoryDep,
 ) -> WebhookTriggerConfig:
     """Persist webhook trigger configuration for the workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         return await repository.configure_webhook_trigger(workflow_uuid, request)
     except WorkflowNotFoundError as exc:
@@ -222,15 +222,15 @@ async def configure_webhook_trigger(
 
 
 @router.get(
-    "/workflows/{workflow_id}/triggers/webhook/config",
+    "/workflows/{workflow_ref}/triggers/webhook/config",
     response_model=WebhookTriggerConfig,
 )
 async def get_webhook_trigger_config(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
 ) -> WebhookTriggerConfig:
     """Return the configured webhook trigger definition."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         return await repository.get_webhook_trigger_config(workflow_uuid)
     except WorkflowNotFoundError as exc:
@@ -266,13 +266,13 @@ async def _queue_webhook_run(
 
 
 @public_webhook_router.api_route(
-    "/workflows/{workflow_id}/triggers/webhook",
+    "/workflows/{workflow_ref}/triggers/webhook",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     response_model=WorkflowRun,
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def invoke_webhook_trigger(
-    workflow_id: str,
+    workflow_ref: str,
     request: Request,
     repository: RepositoryDep,
     vault: VaultDep,
@@ -282,7 +282,7 @@ async def invoke_webhook_trigger(
     ),
 ) -> WorkflowRun | JSONResponse | PlainTextResponse | Response:
     """Validate inbound webhook data and enqueue a workflow run."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         raw_body = await request.body()
     except Exception as exc:  # pragma: no cover - FastAPI handles body read
@@ -345,16 +345,16 @@ async def invoke_webhook_trigger(
 
 
 @router.put(
-    "/workflows/{workflow_id}/triggers/cron/config",
+    "/workflows/{workflow_ref}/triggers/cron/config",
     response_model=CronTriggerConfig,
 )
 async def configure_cron_trigger(
-    workflow_id: str,
+    workflow_ref: str,
     request: CronTriggerConfig,
     repository: RepositoryDep,
 ) -> CronTriggerConfig:
     """Persist cron trigger configuration for the workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         return await repository.configure_cron_trigger(workflow_uuid, request)
     except WorkflowNotFoundError as exc:
@@ -362,15 +362,15 @@ async def configure_cron_trigger(
 
 
 @router.get(
-    "/workflows/{workflow_id}/triggers/cron/config",
+    "/workflows/{workflow_ref}/triggers/cron/config",
     response_model=CronTriggerConfig,
 )
 async def get_cron_trigger_config(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
 ) -> CronTriggerConfig:
     """Return the configured cron trigger definition."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         return await repository.get_cron_trigger_config(workflow_uuid)
     except WorkflowNotFoundError as exc:
@@ -380,17 +380,17 @@ async def get_cron_trigger_config(
 
 
 @router.delete(
-    "/workflows/{workflow_id}/triggers/cron/config",
+    "/workflows/{workflow_ref}/triggers/cron/config",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
     response_model=None,
 )
 async def delete_cron_trigger(
-    workflow_id: str,
+    workflow_ref: str,
     repository: RepositoryDep,
 ) -> Response:
     """Remove the cron trigger configuration for the workflow."""
-    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_ref)
     try:
         await repository.delete_cron_trigger(workflow_uuid)
     except WorkflowNotFoundError as exc:

--- a/apps/backend/src/orcheo_backend/app/routers/triggers.py
+++ b/apps/backend/src/orcheo_backend/app/routers/triggers.py
@@ -21,7 +21,11 @@ from orcheo.triggers.cron import CronTriggerConfig
 from orcheo.triggers.manual import ManualDispatchRequest
 from orcheo.triggers.webhook import WebhookTriggerConfig, WebhookValidationError
 from orcheo.vault.oauth import CredentialHealthError
-from orcheo_backend.app.dependencies import RepositoryDep, VaultDep
+from orcheo_backend.app.dependencies import (
+    RepositoryDep,
+    VaultDep,
+    resolve_workflow_ref_id,
+)
 from orcheo_backend.app.errors import raise_not_found, raise_webhook_error
 from orcheo_backend.app.repository import (
     CronTriggerNotFoundError,
@@ -205,13 +209,14 @@ def _build_json_immediate_response(
     response_model=WebhookTriggerConfig,
 )
 async def configure_webhook_trigger(
-    workflow_id: UUID,
+    workflow_id: str,
     request: WebhookTriggerConfig,
     repository: RepositoryDep,
 ) -> WebhookTriggerConfig:
     """Persist webhook trigger configuration for the workflow."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        return await repository.configure_webhook_trigger(workflow_id, request)
+        return await repository.configure_webhook_trigger(workflow_uuid, request)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
 
@@ -221,12 +226,13 @@ async def configure_webhook_trigger(
     response_model=WebhookTriggerConfig,
 )
 async def get_webhook_trigger_config(
-    workflow_id: UUID,
+    workflow_id: str,
     repository: RepositoryDep,
 ) -> WebhookTriggerConfig:
     """Return the configured webhook trigger definition."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        return await repository.get_webhook_trigger_config(workflow_id)
+        return await repository.get_webhook_trigger_config(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
 
@@ -266,7 +272,7 @@ async def _queue_webhook_run(
     status_code=status.HTTP_202_ACCEPTED,
 )
 async def invoke_webhook_trigger(
-    workflow_id: UUID,
+    workflow_id: str,
     request: Request,
     repository: RepositoryDep,
     vault: VaultDep,
@@ -276,6 +282,7 @@ async def invoke_webhook_trigger(
     ),
 ) -> WorkflowRun | JSONResponse | PlainTextResponse | Response:
     """Validate inbound webhook data and enqueue a workflow run."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
         raw_body = await request.body()
     except Exception as exc:  # pragma: no cover - FastAPI handles body read
@@ -306,7 +313,7 @@ async def invoke_webhook_trigger(
     should_queue = True
     if _should_try_immediate_response(query_params):
         try:
-            version = await repository.get_latest_version(workflow_id)
+            version = await repository.get_latest_version(workflow_uuid)
             immediate_response, should_queue = await _try_immediate_response(
                 version, webhook_inputs, vault
             )
@@ -321,7 +328,7 @@ async def invoke_webhook_trigger(
         source_ip = getattr(request.client, "host", None)
         run = await _queue_webhook_run(
             repository,
-            workflow_id,
+            workflow_uuid,
             request.method,
             headers,
             query_params,
@@ -342,13 +349,14 @@ async def invoke_webhook_trigger(
     response_model=CronTriggerConfig,
 )
 async def configure_cron_trigger(
-    workflow_id: UUID,
+    workflow_id: str,
     request: CronTriggerConfig,
     repository: RepositoryDep,
 ) -> CronTriggerConfig:
     """Persist cron trigger configuration for the workflow."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        return await repository.configure_cron_trigger(workflow_id, request)
+        return await repository.configure_cron_trigger(workflow_uuid, request)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
 
@@ -358,12 +366,13 @@ async def configure_cron_trigger(
     response_model=CronTriggerConfig,
 )
 async def get_cron_trigger_config(
-    workflow_id: UUID,
+    workflow_id: str,
     repository: RepositoryDep,
 ) -> CronTriggerConfig:
     """Return the configured cron trigger definition."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        return await repository.get_cron_trigger_config(workflow_id)
+        return await repository.get_cron_trigger_config(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     except CronTriggerNotFoundError as exc:
@@ -377,12 +386,13 @@ async def get_cron_trigger_config(
     response_model=None,
 )
 async def delete_cron_trigger(
-    workflow_id: UUID,
+    workflow_id: str,
     repository: RepositoryDep,
 ) -> Response:
     """Remove the cron trigger configuration for the workflow."""
+    workflow_uuid = await resolve_workflow_ref_id(repository, workflow_id)
     try:
-        await repository.delete_cron_trigger(workflow_id)
+        await repository.delete_cron_trigger(workflow_uuid)
     except WorkflowNotFoundError as exc:
         raise_not_found("Workflow not found", exc)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/backend/src/orcheo_backend/app/routers/triggers.py
+++ b/apps/backend/src/orcheo_backend/app/routers/triggers.py
@@ -265,11 +265,35 @@ async def _queue_webhook_run(
         ) from exc
 
 
-@public_webhook_router.api_route(
+@public_webhook_router.get(
     "/workflows/{workflow_ref}/triggers/webhook",
-    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     response_model=WorkflowRun,
     status_code=status.HTTP_202_ACCEPTED,
+    operation_id="invoke_webhook_trigger_get",
+)
+@public_webhook_router.post(
+    "/workflows/{workflow_ref}/triggers/webhook",
+    response_model=WorkflowRun,
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="invoke_webhook_trigger_post",
+)
+@public_webhook_router.put(
+    "/workflows/{workflow_ref}/triggers/webhook",
+    response_model=WorkflowRun,
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="invoke_webhook_trigger_put",
+)
+@public_webhook_router.patch(
+    "/workflows/{workflow_ref}/triggers/webhook",
+    response_model=WorkflowRun,
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="invoke_webhook_trigger_patch",
+)
+@public_webhook_router.delete(
+    "/workflows/{workflow_ref}/triggers/webhook",
+    response_model=WorkflowRun,
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="invoke_webhook_trigger_delete",
 )
 async def invoke_webhook_trigger(
     workflow_ref: str,

--- a/apps/backend/src/orcheo_backend/app/routers/websocket.py
+++ b/apps/backend/src/orcheo_backend/app/routers/websocket.py
@@ -21,6 +21,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
         execute_workflow,
         execute_workflow_evaluation,
         execute_workflow_training,
+        get_repository,
     )
 
     try:
@@ -36,6 +37,8 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
     websocket.state.auth = context
 
     try:
+        repository = get_repository()
+        resolved_workflow_id = str(await repository.resolve_workflow_ref(workflow_id))
         while True:
             data = await websocket.receive_json()
 
@@ -44,7 +47,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                 execution_id = data.get("execution_id", str(uuid.uuid4()))
                 task = asyncio.create_task(
                     execute_workflow(
-                        workflow_id,
+                        resolved_workflow_id,
                         data["graph_config"],
                         data["inputs"],
                         execution_id,
@@ -60,7 +63,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                 execution_id = data.get("execution_id", str(uuid.uuid4()))
                 task = asyncio.create_task(
                     execute_workflow_evaluation(
-                        workflow_id,
+                        resolved_workflow_id,
                         data["graph_config"],
                         data.get("inputs", {}),
                         execution_id,
@@ -76,7 +79,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
                 execution_id = data.get("execution_id", str(uuid.uuid4()))
                 task = asyncio.create_task(
                     execute_workflow_training(
-                        workflow_id,
+                        resolved_workflow_id,
                         data["graph_config"],
                         data.get("inputs", {}),
                         execution_id,

--- a/apps/backend/src/orcheo_backend/app/routers/websocket.py
+++ b/apps/backend/src/orcheo_backend/app/routers/websocket.py
@@ -13,8 +13,8 @@ router = APIRouter()
 _CANNOT_SEND_AFTER_CLOSE = 'Cannot call "send" once a close message has been sent.'
 
 
-@router.websocket("/ws/workflow/{workflow_id}")
-async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
+@router.websocket("/ws/workflow/{workflow_ref}")
+async def workflow_websocket(websocket: WebSocket, workflow_ref: str) -> None:
     """Handle workflow websocket connections by delegating to the executor."""
     from orcheo_backend.app import (
         authenticate_websocket,
@@ -38,7 +38,7 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str) -> None:
 
     try:
         repository = get_repository()
-        resolved_workflow_id = str(await repository.resolve_workflow_ref(workflow_id))
+        resolved_workflow_id = str(await repository.resolve_workflow_ref(workflow_ref))
         while True:
             data = await websocket.receive_json()
 

--- a/apps/backend/src/orcheo_backend/app/schemas/credentials.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/credentials.py
@@ -26,7 +26,7 @@ class CredentialCreateRequest(BaseModel):
     actor: str = Field(default="system")
     scopes: list[str] = Field(default_factory=list)
     access: Literal["private", "shared", "public"] = "private"
-    workflow_id: UUID | None = None
+    workflow_id: str | None = None
     kind: CredentialKind = CredentialKind.SECRET
 
 
@@ -38,7 +38,7 @@ class CredentialUpdateRequest(BaseModel):
     secret: str | None = None
     actor: str = Field(default="system")
     access: Literal["private", "shared", "public"] | None = None
-    workflow_id: UUID | None = None
+    workflow_id: str | None = None
 
 
 class CredentialHealthItem(BaseModel):
@@ -133,7 +133,7 @@ class CredentialIssuanceRequest(BaseModel):
     actor: str = Field(default="system")
     name: str | None = None
     scopes: list[str] | None = None
-    workflow_id: UUID | None = None
+    workflow_id: str | None = None
     oauth_tokens: OAuthTokenRequest | None = None
 
 

--- a/apps/backend/src/orcheo_backend/app/schemas/nodes.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/nodes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 from typing import Any
-from uuid import UUID
 from pydantic import BaseModel, Field
 
 
@@ -11,7 +10,7 @@ class NodeExecutionRequest(BaseModel):
 
     node_config: dict[str, Any]
     inputs: dict[str, Any] = Field(default_factory=dict)
-    workflow_id: UUID | None = None
+    workflow_id: str | None = None
 
 
 class NodeExecutionResponse(BaseModel):

--- a/apps/backend/src/orcheo_backend/app/schemas/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/workflows.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
 from orcheo.models.workflow import Workflow
+from orcheo.models.workflow_refs import normalize_workflow_handle
 from orcheo.runtime.runnable_config import RunnableConfigModel
 
 
@@ -13,20 +14,36 @@ class WorkflowCreateRequest(BaseModel):
     """Payload for creating a new workflow."""
 
     name: str
+    handle: str | None = None
     slug: str | None = None
     description: str | None = None
     tags: list[str] = Field(default_factory=list)
     actor: str = Field(default="system")
+
+    @field_validator("handle", mode="before")
+    @classmethod
+    def _normalize_handle(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        return normalize_workflow_handle(str(value))
 
 
 class WorkflowUpdateRequest(BaseModel):
     """Payload for updating an existing workflow."""
 
     name: str | None = None
+    handle: str | None = None
     description: str | None = None
     tags: list[str] | None = None
     is_archived: bool | None = None
     actor: str = Field(default="system")
+
+    @field_validator("handle", mode="before")
+    @classmethod
+    def _normalize_handle(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        return normalize_workflow_handle(str(value))
 
 
 class WorkflowVersionCreateRequest(BaseModel):
@@ -104,6 +121,7 @@ class PublicWorkflow(BaseModel):
     """Public workflow metadata returned without authentication."""
 
     id: UUID
+    handle: str | None = None
     name: str
     description: str | None = None
     is_public: bool

--- a/apps/canvas/package-lock.json
+++ b/apps/canvas/package-lock.json
@@ -588,42 +588,42 @@
       "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz",
-      "integrity": "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.1.1",
-        "@chevrotain/types": "11.1.1",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
         "lodash-es": "4.17.23"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.1.tgz",
-      "integrity": "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.1.1",
+        "@chevrotain/types": "11.1.2",
         "lodash-es": "4.17.23"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz",
-      "integrity": "sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.1.tgz",
-      "integrity": "sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz",
-      "integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
       "license": "Apache-2.0"
     },
     "node_modules/@choojs/findup": {
@@ -7080,16 +7080,16 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
-      "integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.1.1",
-        "@chevrotain/gast": "11.1.1",
-        "@chevrotain/regexp-to-ast": "11.1.1",
-        "@chevrotain/types": "11.1.1",
-        "@chevrotain/utils": "11.1.1",
+        "@chevrotain/cst-dts-gen": "11.1.2",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/regexp-to-ast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "@chevrotain/utils": "11.1.2",
         "lodash-es": "4.17.23"
       }
     },

--- a/apps/canvas/src/features/chatkit/pages/public-chat.tsx
+++ b/apps/canvas/src/features/chatkit/pages/public-chat.tsx
@@ -130,7 +130,7 @@ export default function PublicChatPage() {
     const subject = encodeURIComponent(`Request access to ${sanitizedName}`);
     const link = typeof window !== "undefined" ? window.location.href : "";
     const body = encodeURIComponent(
-      `Hi,%0A%0ACould you confirm access for workflow "${sanitizedName}" (${workflowState.workflow.id})?%0A%0ALink: ${link}%0A`,
+      `Hi,%0A%0ACould you confirm access for workflow "${sanitizedName}" (handle: ${workflowState.workflow.handle ?? "n/a"}, id: ${workflowState.workflow.id})?%0A%0ALink: ${link}%0A`,
     );
     return `mailto:?subject=${subject}&body=${body}`;
   }, [workflowState]);
@@ -334,6 +334,18 @@ export default function PublicChatPage() {
               Chat sessions open automatically for published workflows unless
               the owner requires OAuth login.
             </p>
+            {workflowState.status === "ready" && (
+              <div className="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+                {workflowState.workflow.handle && (
+                  <code className="rounded bg-slate-100 px-2 py-1 dark:bg-slate-900">
+                    handle: {workflowState.workflow.handle}
+                  </code>
+                )}
+                <code className="rounded bg-slate-100 px-2 py-1 dark:bg-slate-900">
+                  id: {workflowState.workflow.id}
+                </code>
+              </div>
+            )}
           </div>
           <ThemeToggleButtonGroup value={theme} onChange={setTheme} />
         </div>

--- a/apps/canvas/src/features/workflow/data/workflow-types.ts
+++ b/apps/canvas/src/features/workflow/data/workflow-types.ts
@@ -26,6 +26,7 @@ export interface WorkflowEdge {
 
 export interface Workflow {
   id: string;
+  handle?: string;
   name: string;
   description?: string;
   createdAt: string;

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -80,6 +80,12 @@ export const toCanvasEdges = (edges: WorkflowEdge[]): CanvasEdge[] =>
       }) satisfies CanvasEdge,
   );
 
+export const getWorkflowRouteRef = (
+  workflow:
+    | Pick<ApiWorkflow, "id" | "handle">
+    | Pick<Workflow, "id" | "handle">,
+): string => workflow.handle ?? workflow.id;
+
 const parseCanvasMetadata = (
   metadata: unknown,
   fallbackName: string,
@@ -193,6 +199,7 @@ export const toStoredWorkflow = (
 
   return {
     id: workflow.id,
+    handle: workflow.handle ?? undefined,
     name: workflow.name,
     description: workflow.description ?? undefined,
     createdAt: workflow.created_at,

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
@@ -7,6 +7,7 @@ import type { WorkflowDiffResult, WorkflowSnapshot } from "./workflow-diff";
 
 export interface ApiWorkflow {
   id: string;
+  handle?: string | null;
   name: string;
   slug: string;
   description: string | null;
@@ -22,6 +23,7 @@ export interface ApiWorkflow {
 
 export interface PublicWorkflowMetadata {
   id: string;
+  handle?: string | null;
   name: string;
   description: string | null;
   is_public: boolean;

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/use-workflow-loader.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/use-workflow-loader.ts
@@ -210,7 +210,7 @@ export function useWorkflowLoader<TNode, TEdge>({
       }
 
       try {
-        const history = await loadWorkflowExecutions(workflowId, {
+        const history = await loadWorkflowExecutions(persisted.id, {
           workflow: persisted,
         });
         if (!isMounted) {

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/use-workflow-saver.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/hooks/use-workflow-saver.ts
@@ -19,6 +19,7 @@ import {
   saveWorkflow as persistWorkflow,
   type StoredWorkflow,
 } from "@features/workflow/lib/workflow-storage";
+import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import type { WorkflowRunnableConfig } from "@features/workflow/lib/workflow-storage.types";
 
 interface WorkflowSaverOptions {
@@ -122,8 +123,13 @@ export function useWorkflowSaver(
         description: successDescription(saved),
       });
 
-      if (!workflowIdFromRoute || workflowIdFromRoute !== saved.id) {
-        navigate(`/workflow-canvas/${saved.id}`, {
+      const nextWorkflowRouteRef = getWorkflowRouteRef(saved);
+      if (
+        !workflowIdFromRoute ||
+        (workflowIdFromRoute !== saved.id &&
+          workflowIdFromRoute !== nextWorkflowRouteRef)
+      ) {
+        navigate(`/workflow-canvas/${nextWorkflowRouteRef}`, {
           replace: !!workflowIdFromRoute,
         });
       }

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-actions.ts
@@ -8,6 +8,7 @@ import {
   deleteWorkflow,
   duplicateWorkflow,
 } from "@features/workflow/lib/workflow-storage";
+import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { type WorkflowGalleryTab } from "./types";
 
 interface WorkflowGalleryActionsArgs {
@@ -66,7 +67,7 @@ export const useWorkflowGalleryActions = (
         description: `"${workflow.name}" is ready to edit.`,
       });
 
-      handleOpenWorkflow(workflow.id);
+      handleOpenWorkflow(getWorkflowRouteRef(workflow));
     } catch (error) {
       toast({
         title: "Failed to create workflow",
@@ -97,7 +98,7 @@ export const useWorkflowGalleryActions = (
           description: `"${workflow.name}" has been added to your workspace.`,
         });
 
-        handleOpenWorkflow(workflow.id);
+        handleOpenWorkflow(getWorkflowRouteRef(workflow));
       } catch (error) {
         toast({
           title: "Failed to create workflow from template",
@@ -131,7 +132,7 @@ export const useWorkflowGalleryActions = (
           description: `"${copy.name}" is ready to edit.`,
         });
 
-        handleOpenWorkflow(copy.id);
+        handleOpenWorkflow(getWorkflowRouteRef(copy));
       } catch (error) {
         toast({
           title: "Failed to duplicate workflow",

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
@@ -15,6 +15,7 @@ vi.mock("./workflow-thumbnail", () => ({
 
 const workflow = {
   id: "workflow-1",
+  handle: "support-triage",
   name: "Support triage",
   description: "Routes inbound requests.",
   createdAt: "2026-01-01T00:00:00.000Z",
@@ -53,7 +54,7 @@ describe("WorkflowCard", () => {
     await user.click(screen.getByTestId("workflow-card"));
 
     expect(handlers.onOpenWorkflow).toHaveBeenCalledTimes(1);
-    expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(workflow.id);
+    expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(workflow.handle);
   });
 
   it("does not trigger card navigation when favorite button is clicked", async () => {
@@ -83,7 +84,7 @@ describe("WorkflowCard", () => {
     await user.click(screen.getByRole("button", { name: /^edit$/i }));
 
     expect(handlers.onOpenWorkflow).toHaveBeenCalledTimes(1);
-    expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(workflow.id);
+    expect(handlers.onOpenWorkflow).toHaveBeenCalledWith(workflow.handle);
   });
 
   it("keeps dropdown actions from triggering card navigation", async () => {

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { type Workflow } from "@features/workflow/data/workflow-data";
+import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { WorkflowThumbnail } from "./workflow-thumbnail";
 
 interface WorkflowCardProps {
@@ -57,6 +58,7 @@ export const WorkflowCard = ({
   const updatedLabel = new Date(
     workflow.updatedAt || workflow.createdAt,
   ).toLocaleDateString();
+  const workflowRouteRef = getWorkflowRouteRef(workflow);
   const isClickable = !isTemplate;
   const suppressCardOpenRef = useRef(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -80,7 +82,7 @@ export const WorkflowCard = ({
       if (target.closest('[data-card-action="true"]')) {
         return;
       }
-      onOpenWorkflow(workflow.id);
+      onOpenWorkflow(workflowRouteRef);
     }
   };
 
@@ -94,7 +96,7 @@ export const WorkflowCard = ({
     }
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      onOpenWorkflow(workflow.id);
+      onOpenWorkflow(workflowRouteRef);
     }
   };
 
@@ -170,7 +172,7 @@ export const WorkflowCard = ({
                     onSelect={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
-                      onOpenWorkflow(workflow.id);
+                      onOpenWorkflow(workflowRouteRef);
                     }}
                   >
                     <Pencil className="mr-2 h-4 w-4" />
@@ -217,6 +219,18 @@ export const WorkflowCard = ({
         <CardDescription className="line-clamp-1">
           {workflow.description || "No description provided"}
         </CardDescription>
+        {!isTemplate && (
+          <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+            {workflow.handle && (
+              <code className="rounded bg-muted px-1.5 py-0.5">
+                handle: {workflow.handle}
+              </code>
+            )}
+            <code className="rounded bg-muted px-1.5 py-0.5">
+              id: {workflow.id}
+            </code>
+          </div>
+        )}
 
         {isTemplate && workflow.sourceExample && (
           <p className="mt-1 line-clamp-1 text-xs text-muted-foreground/80">
@@ -301,7 +315,7 @@ export const WorkflowCard = ({
                 data-card-action="true"
                 onClick={(event) => {
                   stopPropagation(event);
-                  onOpenWorkflow(workflow.id);
+                  onOpenWorkflow(workflowRouteRef);
                 }}
                 onPointerDown={stopPropagation}
               >

--- a/examples/wecom_bot_responder/README.md
+++ b/examples/wecom_bot_responder/README.md
@@ -18,7 +18,6 @@ Edit `workflow_config.json` to set:
 ```json
 {
   "configurable": {
-    "corp_id": "YOUR_WECOM_CORP_ID",
     "agent_id": 1000002,
     "reply_message": "Thanks! Your message was received."
   }
@@ -27,7 +26,6 @@ Edit `workflow_config.json` to set:
 
 | Field | Description |
 |-------|-------------|
-| `corp_id` | WeCom corporation ID |
 | `agent_id` | WeCom app agent ID (integer) |
 | `reply_message` | Fixed response content to send back to the user |
 
@@ -37,6 +35,7 @@ Configure these secrets in the Orcheo vault (referenced via `[[key]]` syntax):
 
 | Secret Key | Description |
 |------------|-------------|
+| `wecom_corp_id` | WeCom corporation ID |
 | `wecom_app_secret` | WeCom app secret for access token retrieval |
 | `wecom_token` | Callback token for signature validation |
 | `wecom_encoding_aes_key` | AES key for callback payload decryption |

--- a/examples/wecom_bot_responder/workflow.py
+++ b/examples/wecom_bot_responder/workflow.py
@@ -9,11 +9,11 @@ Configure WeCom to send callback requests to:
 so signatures can be verified.
 
 Configurable inputs (workflow_config.json):
-- corp_id (WeCom corp ID)
 - agent_id (WeCom app agent ID, for internal users)
 - reply_message (fixed response content)
 
 Orcheo vault secrets required:
+- wecom_corp_id: WeCom corp ID
 - wecom_app_secret: WeCom app secret for access token
 - wecom_token: Callback token for signature validation
 - wecom_encoding_aes_key: AES key for callback decryption
@@ -92,7 +92,6 @@ async def build_graph() -> StateGraph:
         "wecom_events_parser",
         WeComEventsParserNode(
             name="wecom_events_parser",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -101,7 +100,6 @@ async def build_graph() -> StateGraph:
         "get_access_token",
         WeComAccessTokenNode(
             name="get_access_token",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -123,7 +121,6 @@ async def build_graph() -> StateGraph:
         "get_cs_access_token",
         WeComAccessTokenNode(
             name="get_cs_access_token",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 

--- a/examples/wecom_echo_history/workflow.py
+++ b/examples/wecom_echo_history/workflow.py
@@ -4,10 +4,8 @@ Configure WeCom to send callback requests to:
 `/api/workflows/{workflow_id}/triggers/webhook?preserve_raw_body=true`
 so signatures can be verified.
 
-Configurable inputs (workflow_config.json):
-- corp_id (WeCom corp ID)
-
 Orcheo vault secrets required:
+- wecom_corp_id: WeCom corp ID
 - wecom_app_secret: WeCom app secret for access token
 - wecom_token: Callback token for signature validation
 - wecom_encoding_aes_key: AES key for callback decryption
@@ -92,7 +90,6 @@ async def build_graph() -> StateGraph:
         "wecom_events_parser",
         WeComEventsParserNode(
             name="wecom_events_parser",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -101,7 +98,6 @@ async def build_graph() -> StateGraph:
         WeComAccessTokenNode(
             name="get_cs_access_token",
             app_secret="[[wecom_app_secret_eventually]]",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 

--- a/examples/wecom_event_agent/README.md
+++ b/examples/wecom_event_agent/README.md
@@ -17,7 +17,6 @@ Edit `workflow_config.json` to set:
 ```json
 {
   "configurable": {
-    "corp_id": "YOUR_WECOM_CORP_ID",
     "agent_id": 1000002,
     "events_database": "events",
     "events_collection": "events",
@@ -28,7 +27,6 @@ Edit `workflow_config.json` to set:
 
 | Field | Description |
 |-------|-------------|
-| `corp_id` | WeCom corporation ID |
 | `agent_id` | WeCom app agent ID for internal messages |
 | `events_database` | MongoDB database name for events/RSVPs |
 | `events_collection` | MongoDB collection for events |
@@ -40,6 +38,7 @@ Configure these secrets in the Orcheo vault (referenced via `[[key]]` syntax):
 
 | Secret Key | Description |
 |------------|-------------|
+| `wecom_corp_id` | WeCom corporation ID |
 | `wecom_app_secret` | WeCom app secret for access token retrieval |
 | `wecom_token` | Callback token for signature validation |
 | `wecom_encoding_aes_key` | AES key for callback payload decryption |

--- a/examples/wecom_event_agent/workflow.py
+++ b/examples/wecom_event_agent/workflow.py
@@ -5,13 +5,13 @@ Configure WeCom to send callback requests to:
 so signatures can be verified.
 
 Configurable inputs (workflow_config.json):
-- corp_id (WeCom corp ID)
 - agent_id (WeCom app agent ID for internal messages)
 - events_database (MongoDB database for events/RSVPs)
 - events_collection (MongoDB collection for events)
 - rsvps_collection (MongoDB collection for RSVPs)
 
 Orcheo vault secrets required:
+- wecom_corp_id: WeCom corp ID
 - wecom_app_secret: WeCom app secret for access token
 - wecom_token: Callback token for signature validation
 - wecom_encoding_aes_key: AES key for callback decryption
@@ -732,7 +732,6 @@ def register_wecom_and_agent_nodes(graph: StateGraph) -> None:
         "wecom_events_parser",
         WeComEventsParserNode(
             name="wecom_events_parser",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -741,7 +740,6 @@ def register_wecom_and_agent_nodes(graph: StateGraph) -> None:
         WeComAccessTokenNode(
             name="get_access_token",
             app_secret="[[wecom_app_secret_orcheo]]",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -750,7 +748,6 @@ def register_wecom_and_agent_nodes(graph: StateGraph) -> None:
         WeComAccessTokenNode(
             name="get_cs_access_token",
             app_secret="[[wecom_app_secret_orcheo]]",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 

--- a/examples/wecom_event_agent/workflow_pure_agent.py
+++ b/examples/wecom_event_agent/workflow_pure_agent.py
@@ -5,13 +5,13 @@ Configure WeCom to send callback requests to:
 so signatures can be verified.
 
 Configurable inputs (workflow_config.json):
-- corp_id (WeCom corp ID)
 - agent_id (WeCom app agent ID for internal messages)
 - events_database (MongoDB database for events/RSVPs)
 - events_collection (MongoDB collection for events)
 - rsvps_collection (MongoDB collection for RSVPs)
 
 Orcheo vault secrets required:
+- wecom_corp_id: WeCom corp ID
 - wecom_app_secret: WeCom app secret for access token
 - wecom_token: Callback token for signature validation
 - wecom_encoding_aes_key: AES key for callback decryption
@@ -149,7 +149,6 @@ async def build_graph() -> StateGraph:
         "wecom_events_parser",
         WeComEventsParserNode(
             name="wecom_events_parser",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -157,7 +156,6 @@ async def build_graph() -> StateGraph:
         "get_access_token",
         WeComAccessTokenNode(
             name="get_access_token",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 
@@ -165,7 +163,6 @@ async def build_graph() -> StateGraph:
         "get_cs_access_token",
         WeComAccessTokenNode(
             name="get_cs_access_token",
-            corp_id="{{config.configurable.corp_id}}",
         ),
     )
 

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/__init__.py
@@ -16,7 +16,12 @@ from .app import (
     workflow_app,
 )
 from .commands.listing import list_workflows
-from .commands.managing import delete_workflow, download_workflow, upload_workflow
+from .commands.managing import (
+    delete_workflow,
+    download_workflow,
+    update_workflow,
+    upload_workflow,
+)
 from .commands.running import evaluate_workflow, run_workflow
 from .commands.scheduling import schedule_workflow, unschedule_workflow
 from .commands.showing import show_workflow
@@ -105,6 +110,7 @@ __all__ = [
     "run_workflow",
     "evaluate_workflow",
     "delete_workflow",
+    "update_workflow",
     "upload_workflow",
     "download_workflow",
     "schedule_workflow",

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/app.py
@@ -10,7 +10,7 @@ workflow_app = typer.Typer(help="Inspect and operate on workflows.")
 
 WorkflowIdArgument = Annotated[
     str,
-    typer.Argument(help="Workflow identifier."),
+    typer.Argument(help="Workflow reference (UUID or handle)."),
 ]
 ActorOption = Annotated[
     str,
@@ -56,7 +56,10 @@ FilePathArgument = Annotated[
 ]
 WorkflowIdOption = Annotated[
     str | None,
-    typer.Option("--id", help="Workflow ID (for updates). Creates new if omitted."),
+    typer.Option(
+        "--id",
+        help="Workflow reference (UUID or handle) for updates. Creates new if omitted.",
+    ),
 ]
 EntrypointOption = Annotated[
     str | None,
@@ -73,7 +76,7 @@ WorkflowNameOption = Annotated[
     typer.Option(
         "--name",
         "-n",
-        help="Rename the workflow when uploading.",
+        help="Update the workflow name when uploading.",
     ),
 ]
 OutputPathOption = Annotated[

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/ingest.py
@@ -52,7 +52,7 @@ def _upload_langgraph_script(
             raise CLIError(f"Failed to fetch workflow '{workflow_id}': {exc}") from exc
         if name_override and workflow.get("name") != name_override:
             try:
-                state.client.post(
+                state.client.put(
                     f"/api/workflows/{workflow_id}",
                     json_body={"name": name_override},
                 )

--- a/packages/sdk/src/orcheo_sdk/services/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/services/__init__.py
@@ -40,6 +40,7 @@ from orcheo_sdk.services.workflows import (
     show_workflow_data,
     unpublish_workflow_data,
     unschedule_workflow_cron,
+    update_workflow_data,
     upload_workflow_data,
 )
 
@@ -51,6 +52,7 @@ __all__ = [
     "run_workflow_data",
     "delete_workflow_data",
     "upload_workflow_data",
+    "update_workflow_data",
     "download_workflow_data",
     "get_latest_workflow_version_data",
     "publish_workflow_data",

--- a/packages/sdk/src/orcheo_sdk/services/workflows/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/__init__.py
@@ -10,7 +10,10 @@ from orcheo_sdk.services.workflows.listing import (
     list_workflows_data,
     show_workflow_data,
 )
-from orcheo_sdk.services.workflows.management import delete_workflow_data
+from orcheo_sdk.services.workflows.management import (
+    delete_workflow_data,
+    update_workflow_data,
+)
 from orcheo_sdk.services.workflows.publish import (
     enrich_workflow_publish_metadata,
     publish_workflow_data,
@@ -31,6 +34,7 @@ __all__ = [
     "show_workflow_data",
     "run_workflow_data",
     "delete_workflow_data",
+    "update_workflow_data",
     "upload_workflow_data",
     "download_workflow_data",
     "get_latest_workflow_version_data",

--- a/packages/sdk/src/orcheo_sdk/services/workflows/management.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/management.py
@@ -17,3 +17,23 @@ def delete_workflow_data(
         "status": "success",
         "message": f"Workflow '{workflow_id}' deleted",
     }
+
+
+def update_workflow_data(
+    client: ApiClient,
+    workflow_id: str,
+    *,
+    name: str | None = None,
+    handle: str | None = None,
+    description: str | None = None,
+    actor: str = "cli",
+) -> dict[str, Any]:
+    """Update workflow metadata and return the backend payload."""
+    payload: dict[str, Any] = {"actor": actor}
+    if name is not None:
+        payload["name"] = name
+    if handle is not None:
+        payload["handle"] = handle
+    if description is not None:
+        payload["description"] = description
+    return client.put(f"/api/workflows/{workflow_id}", json_body=payload)

--- a/packages/sdk/src/orcheo_sdk/services/workflows/publish.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/publish.py
@@ -27,7 +27,8 @@ def _enrich_workflow(
     public_base_url: str | None = None,
 ) -> dict[str, Any]:
     enriched = dict(workflow)
-    workflow_id = str(enriched.get("id")) if enriched.get("id") else None
+    workflow_ref = enriched.get("handle") or enriched.get("id")
+    workflow_id = str(workflow_ref) if workflow_ref else None
     if workflow_id and enriched.get("is_public"):
         if public_base_url:
             enriched["share_url"] = _build_share_url(

--- a/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/upload.py
@@ -65,6 +65,8 @@ def _submit_workflow_configuration(
     """Submit workflow configuration payload to Orcheo."""
     url = f"/api/workflows/{workflow_id}" if workflow_id else "/api/workflows"
     try:
+        if workflow_id:
+            return client.put(url, json_body=workflow_config)
         return client.post(url, json_body=workflow_config)
     except Exception as exc:  # pragma: no cover - http errors handled upstream
         raise CLIError("Failed to upload workflow configuration to Orcheo.") from exc

--- a/src/orcheo/models/workflow_entities.py
+++ b/src/orcheo/models/workflow_entities.py
@@ -11,6 +11,7 @@ from typing import Any, NotRequired, TypedDict
 from uuid import UUID, uuid4
 from pydantic import Field, field_validator, model_validator
 from orcheo.models.base import TimestampedAuditModel, _utcnow
+from orcheo.models.workflow_refs import normalize_workflow_handle
 
 
 __all__ = [
@@ -58,6 +59,7 @@ class Workflow(TimestampedAuditModel):
     """Represents a workflow container with metadata and audit trail."""
 
     name: str = Field(min_length=1, max_length=128)
+    handle: str | None = Field(default=None, max_length=64)
     slug: str = ""
     description: str | None = Field(default=None, max_length=1024)
     tags: list[str] = Field(default_factory=list)
@@ -76,6 +78,13 @@ class Workflow(TimestampedAuditModel):
             msg = "Workflow name must not be empty."
             raise ValueError(msg)
         return candidate
+
+    @field_validator("handle", mode="before")
+    @classmethod
+    def _normalize_handle(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        return normalize_workflow_handle(str(value))
 
     @field_validator("description", mode="before")
     @classmethod

--- a/src/orcheo/models/workflow_refs.py
+++ b/src/orcheo/models/workflow_refs.py
@@ -1,0 +1,49 @@
+"""Shared helpers for workflow handles and refs."""
+
+from __future__ import annotations
+import re
+from uuid import UUID
+
+
+WORKFLOW_HANDLE_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+WORKFLOW_HANDLE_MAX_LENGTH = 64
+
+
+def normalize_workflow_handle(value: str | None) -> str | None:
+    """Normalize an optional workflow handle and validate its format."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        msg = "Workflow handle must not be empty."
+        raise ValueError(msg)
+    if len(normalized) > WORKFLOW_HANDLE_MAX_LENGTH:
+        msg = (
+            "Workflow handle must be at most "
+            f"{WORKFLOW_HANDLE_MAX_LENGTH} characters long."
+        )
+        raise ValueError(msg)
+    if not WORKFLOW_HANDLE_PATTERN.fullmatch(normalized):
+        msg = (
+            "Workflow handle must contain only lowercase letters, numbers, "
+            "and single hyphens."
+        )
+        raise ValueError(msg)
+    return normalized
+
+
+def workflow_ref_is_uuid(value: str) -> bool:
+    """Return whether the provided workflow ref parses as a UUID."""
+    try:
+        UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "WORKFLOW_HANDLE_MAX_LENGTH",
+    "WORKFLOW_HANDLE_PATTERN",
+    "normalize_workflow_handle",
+    "workflow_ref_is_uuid",
+]

--- a/src/orcheo/models/workflow_refs.py
+++ b/src/orcheo/models/workflow_refs.py
@@ -29,6 +29,9 @@ def normalize_workflow_handle(value: str | None) -> str | None:
             "and single hyphens."
         )
         raise ValueError(msg)
+    if workflow_ref_is_uuid(normalized):
+        msg = "Workflow handle must not use a UUID format."
+        raise ValueError(msg)
     return normalized
 
 

--- a/src/orcheo/nodes/wecom.py
+++ b/src/orcheo/nodes/wecom.py
@@ -191,7 +191,10 @@ class WeComEventsParserNode(TaskNode):
     """WeCom callback token for signature validation (from Orcheo vault)."""
     encoding_aes_key: str = "[[wecom_encoding_aes_key]]"
     """WeCom AES key for payload decryption (from Orcheo vault)."""
-    corp_id: str = Field(description="WeCom corp ID for decryption validation")
+    corp_id: str = Field(
+        default="[[wecom_corp_id]]",
+        description="WeCom corp ID for decryption validation",
+    )
     timestamp_tolerance_seconds: int = Field(
         default=300,
         description="Maximum age for WeCom signature timestamps",
@@ -1056,7 +1059,10 @@ class WeComAIBotResponseNode(TaskNode):
 class WeComAccessTokenNode(TaskNode):
     """Fetch and cache WeCom access token."""
 
-    corp_id: str = Field(description="WeCom corp ID")
+    corp_id: str = Field(
+        default="[[wecom_corp_id]]",
+        description="WeCom corp ID",
+    )
     app_secret: str = "[[wecom_app_secret]]"
     """WeCom app secret (from Orcheo vault)."""
 

--- a/tests/backend/api/test_credential_templates_errors.py
+++ b/tests/backend/api/test_credential_templates_errors.py
@@ -3,17 +3,27 @@ from uuid import uuid4
 from fastapi.testclient import TestClient
 
 
+def _create_workflow(api_client: TestClient) -> str:
+    response = api_client.post(
+        "/api/workflows",
+        json={"name": "Template Flow", "actor": "tester"},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
 def test_credential_template_get_scope_violation_returns_403(
     api_client: TestClient,
 ) -> None:
-    workflow_id = uuid4()
+    workflow_id = _create_workflow(api_client)
+    other_workflow_id = _create_workflow(api_client)
     create_response = api_client.post(
         "/api/credentials/templates",
         json={
             "name": "Restricted",
             "provider": "internal",
             "scopes": ["read"],
-            "scope": {"workflow_ids": [str(workflow_id)]},
+            "scope": {"workflow_ids": [workflow_id]},
             "actor": "tester",
         },
     )
@@ -21,7 +31,7 @@ def test_credential_template_get_scope_violation_returns_403(
 
     response = api_client.get(
         f"/api/credentials/templates/{template_id}",
-        params={"workflow_id": str(uuid4())},
+        params={"workflow_id": other_workflow_id},
     )
 
     assert response.status_code == 403
@@ -41,14 +51,15 @@ def test_credential_template_update_not_found_returns_404(
 def test_credential_template_update_scope_violation_returns_403(
     api_client: TestClient,
 ) -> None:
-    workflow_id = uuid4()
+    workflow_id = _create_workflow(api_client)
+    other_workflow_id = _create_workflow(api_client)
     create_response = api_client.post(
         "/api/credentials/templates",
         json={
             "name": "Restricted",
             "provider": "internal",
             "scopes": ["read"],
-            "scope": {"workflow_ids": [str(workflow_id)]},
+            "scope": {"workflow_ids": [workflow_id]},
             "actor": "tester",
         },
     )
@@ -56,7 +67,7 @@ def test_credential_template_update_scope_violation_returns_403(
 
     response = api_client.patch(
         f"/api/credentials/templates/{template_id}",
-        params={"workflow_id": str(uuid4())},
+        params={"workflow_id": other_workflow_id},
         json={"description": "updated", "actor": "tester"},
     )
 
@@ -74,14 +85,15 @@ def test_credential_template_delete_not_found_returns_404(
 def test_credential_template_delete_scope_violation_returns_403(
     api_client: TestClient,
 ) -> None:
-    workflow_id = uuid4()
+    workflow_id = _create_workflow(api_client)
+    other_workflow_id = _create_workflow(api_client)
     create_response = api_client.post(
         "/api/credentials/templates",
         json={
             "name": "Restricted",
             "provider": "internal",
             "scopes": ["read"],
-            "scope": {"workflow_ids": [str(workflow_id)]},
+            "scope": {"workflow_ids": [workflow_id]},
             "actor": "tester",
         },
     )
@@ -89,7 +101,7 @@ def test_credential_template_delete_scope_violation_returns_403(
 
     response = api_client.delete(
         f"/api/credentials/templates/{template_id}",
-        params={"workflow_id": str(uuid4())},
+        params={"workflow_id": other_workflow_id},
     )
 
     assert response.status_code == 403

--- a/tests/backend/api/test_public_workflow_metadata.py
+++ b/tests/backend/api/test_public_workflow_metadata.py
@@ -62,3 +62,30 @@ def test_public_workflow_metadata_rejects_archived_workflow(
     response = api_client.get(f"/api/workflows/{workflow_id}/public")
 
     assert response.status_code == 404
+
+
+def test_public_workflow_metadata_accepts_handle(
+    api_client: TestClient,
+) -> None:
+    response = api_client.post(
+        "/api/workflows",
+        json={
+            "name": "Public Handle Workflow",
+            "handle": "public-handle-workflow",
+            "actor": "tester",
+        },
+    )
+    assert response.status_code == 201
+    workflow_id = response.json()["id"]
+
+    publish_response = api_client.post(
+        f"/api/workflows/{workflow_id}/publish",
+        json={"require_login": False, "actor": "publisher"},
+    )
+    assert publish_response.status_code == 201
+
+    handle_response = api_client.get("/api/workflows/public-handle-workflow/public")
+    assert handle_response.status_code == 200
+    payload = handle_response.json()
+    assert payload["id"] == workflow_id
+    assert payload["handle"] == "public-handle-workflow"

--- a/tests/backend/api/test_workflows_crud.py
+++ b/tests/backend/api/test_workflows_crud.py
@@ -130,3 +130,47 @@ def test_workflow_handle_lookup_and_update(api_client: TestClient) -> None:
     new_handle_response = api_client.get("/api/workflows/renamed-handle-flow")
     assert new_handle_response.status_code == 200
     assert new_handle_response.json()["id"] == workflow["id"]
+
+
+def test_workflow_create_rejects_uuid_like_handle(api_client: TestClient) -> None:
+    """Workflow handles should not accept UUID-shaped values."""
+
+    response = api_client.post(
+        "/api/workflows",
+        json={
+            "name": "UUID Handle",
+            "handle": "550e8400-e29b-41d4-a716-446655440000",
+            "actor": "tester",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "UUID format" in str(response.json())
+
+
+def test_openapi_uses_workflow_ref_for_handle_aware_paths(
+    api_client: TestClient,
+) -> None:
+    """Handle-aware routes should document a consistent path parameter name."""
+
+    response = api_client.get("/openapi.json")
+    assert response.status_code == 200
+
+    paths = response.json()["paths"]
+    expected_paths = [
+        "/api/workflows/{workflow_ref}/runs",
+        "/api/workflows/{workflow_ref}/executions",
+        "/api/workflows/{workflow_ref}/triggers/webhook/config",
+        "/api/workflows/{workflow_ref}/triggers/cron/config",
+        "/api/workflows/{workflow_ref}/credentials/health",
+        "/api/workflows/{workflow_ref}/agentensor/checkpoints",
+        "/api/chatkit/workflows/{workflow_ref}/trigger",
+    ]
+
+    for path in expected_paths:
+        assert path in paths
+        operation = next(iter(paths[path].values()))
+        assert any(
+            parameter["name"] == "workflow_ref"
+            for parameter in operation.get("parameters", [])
+        )

--- a/tests/backend/api/test_workflows_crud.py
+++ b/tests/backend/api/test_workflows_crud.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import warnings
 from fastapi.testclient import TestClient
 
 
@@ -153,8 +154,15 @@ def test_openapi_uses_workflow_ref_for_handle_aware_paths(
 ) -> None:
     """Handle-aware routes should document a consistent path parameter name."""
 
-    response = api_client.get("/openapi.json")
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        response = api_client.get("/openapi.json")
     assert response.status_code == 200
+    assert not [
+        warning
+        for warning in recorded_warnings
+        if "Duplicate Operation ID" in str(warning.message)
+    ]
 
     paths = response.json()["paths"]
     expected_paths = [

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -16,6 +16,7 @@ from orcheo.triggers.cron import CronTriggerConfig
 from orcheo.triggers.webhook import WebhookTriggerConfig
 from orcheo.vault.oauth import CredentialHealthError, CredentialHealthReport
 from orcheo_backend.app.repository.errors import (
+    WorkflowHandleConflictError,
     WorkflowNotFoundError,
     WorkflowRunNotFoundError,
     WorkflowVersionNotFoundError,
@@ -294,6 +295,81 @@ async def test_persistence_resolve_workflow_ref_locked_uses_single_query(
 
 
 @pytest.mark.asyncio
+async def test_persistence_ensure_handle_available_locked_rejects_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handle validation raises when another active workflow owns the handle."""
+
+    responses: list[Any] = [
+        {"rows": [{"id": str(uuid4()), "is_archived": False}]},
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    with pytest.raises(WorkflowHandleConflictError, match="already in use"):
+        await repo._ensure_handle_available_locked(
+            "shared-handle",
+            workflow_id=None,
+            is_archived=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_persistence_ensure_handle_available_locked_allows_archived_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Archived workflows may reuse a handle owned only by archived workflows."""
+
+    responses: list[Any] = [
+        {"rows": [{"id": str(uuid4()), "is_archived": True}]},
+    ]
+    repo = make_repository(monkeypatch, responses)
+
+    await repo._ensure_handle_available_locked(
+        "shared-handle",
+        workflow_id=None,
+        is_archived=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_persistence_resolve_workflow_ref_locked_blank_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blank workflow refs raise before any query is issued."""
+
+    repo = make_repository(monkeypatch, [])
+
+    with pytest.raises(WorkflowNotFoundError, match="workflow ref is empty"):
+        await repo._resolve_workflow_ref_locked("   ")
+
+
+@pytest.mark.asyncio
+async def test_persistence_resolve_workflow_ref_locked_not_found_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workflow ref resolution raises when no matching row is found."""
+
+    repo = make_repository(monkeypatch, [{"row": None}])
+
+    with pytest.raises(WorkflowNotFoundError, match="missing-handle"):
+        await repo._resolve_workflow_ref_locked("missing-handle")
+
+
+@pytest.mark.asyncio
+async def test_postgres_repository_resolve_workflow_ref_delegates_to_locked_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public resolve_workflow_ref delegates through the initialized wrapper."""
+
+    workflow_id = uuid4()
+    repo = make_repository(monkeypatch, [{"row": {"id": str(workflow_id)}}])
+
+    resolved = await repo.resolve_workflow_ref("handle-flow")
+
+    assert resolved == workflow_id
+
+
+@pytest.mark.asyncio
 async def test_base_ensure_workflow_schema_migrations_backfills_columns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -333,6 +409,57 @@ async def test_base_ensure_workflow_schema_migrations_backfills_columns(
     assert update_params[1] is True
     assert isinstance(update_params[2], datetime)
     assert update_params[3] == str(workflow_id)
+
+
+@pytest.mark.asyncio
+async def test_base_ensure_workflow_schema_migrations_respects_existing_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing mirrored columns should not be re-added during migration."""
+
+    responses: list[Any] = [
+        {"rows": [{"column_name": "handle"}]},
+        {},
+        {"rows": []},
+    ]
+    repo = make_repository(monkeypatch, responses)
+    connection = repo._pool._connection  # type: ignore[union-attr]  # noqa: SLF001
+
+    await repo._ensure_workflow_schema_migrations(connection)
+
+    queries = [query for query, _ in connection.queries]
+    assert not any(
+        "ALTER TABLE workflows ADD COLUMN handle TEXT" in query for query in queries
+    )
+    assert any(
+        "ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE" in query
+        for query in queries
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_ensure_workflow_schema_migrations_skips_existing_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing mirrored columns should bypass both ALTER statements."""
+
+    responses: list[Any] = [
+        {"rows": [{"column_name": "handle"}, {"column_name": "is_archived"}]},
+        {"rows": []},
+    ]
+    repo = make_repository(monkeypatch, responses)
+    connection = repo._pool._connection  # type: ignore[union-attr]  # noqa: SLF001
+
+    await repo._ensure_workflow_schema_migrations(connection)
+
+    queries = [query for query, _ in connection.queries]
+    assert not any(
+        "ALTER TABLE workflows ADD COLUMN handle TEXT" in query for query in queries
+    )
+    assert not any(
+        "ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE" in query
+        for query in queries
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/backend/repository/test_webhook_triggers.py
+++ b/tests/backend/repository/test_webhook_triggers.py
@@ -21,6 +21,16 @@ async def test_webhook_configuration_requires_workflow(
 
 
 @pytest.mark.asyncio()
+async def test_get_webhook_configuration_requires_workflow(
+    repository: WorkflowRepository,
+) -> None:
+    """Fetching webhook config for a missing workflow raises an error."""
+
+    with pytest.raises(WorkflowNotFoundError):
+        await repository.get_webhook_trigger_config(uuid4())
+
+
+@pytest.mark.asyncio()
 async def test_webhook_configuration_roundtrip(
     repository: WorkflowRepository,
 ) -> None:

--- a/tests/backend/test_app_chatkit_triggers.py
+++ b/tests/backend/test_app_chatkit_triggers.py
@@ -57,6 +57,10 @@ async def test_trigger_chatkit_workflow_creates_run() -> None:
     run_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             return WorkflowVersion(
                 id=uuid4(),
@@ -87,7 +91,7 @@ async def test_trigger_chatkit_workflow_creates_run() -> None:
     )
 
     result = await trigger_chatkit_workflow(
-        workflow_id,
+        str(workflow_id),
         request,
         Repository(),
         _authenticated_policy(),
@@ -104,6 +108,10 @@ async def test_trigger_chatkit_workflow_missing_workflow() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             raise WorkflowNotFoundError("not found")
 
@@ -115,7 +123,7 @@ async def test_trigger_chatkit_workflow_missing_workflow() -> None:
 
     with pytest.raises(HTTPException) as exc_info:
         await trigger_chatkit_workflow(
-            workflow_id,
+            str(workflow_id),
             request,
             Repository(),
             _authenticated_policy(),
@@ -131,6 +139,10 @@ async def test_trigger_chatkit_workflow_credential_health_error() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             return WorkflowVersion(
                 id=uuid4(),
@@ -155,7 +167,7 @@ async def test_trigger_chatkit_workflow_credential_health_error() -> None:
 
     with pytest.raises(HTTPException) as exc_info:
         await trigger_chatkit_workflow(
-            workflow_id,
+            str(workflow_id),
             request,
             Repository(),
             _authenticated_policy(),
@@ -181,6 +193,10 @@ async def test_trigger_chatkit_workflow_handles_missing_run_workflow() -> None:
     )
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             return version
 
@@ -197,7 +213,7 @@ async def test_trigger_chatkit_workflow_handles_missing_run_workflow() -> None:
 
     with pytest.raises(HTTPException) as exc_info:
         await trigger_chatkit_workflow(
-            workflow_id,
+            str(workflow_id),
             request,
             Repository(),
             _authenticated_policy(),
@@ -223,6 +239,10 @@ async def test_trigger_chatkit_workflow_handles_missing_run_version() -> None:
     )
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             return version
 
@@ -239,7 +259,7 @@ async def test_trigger_chatkit_workflow_handles_missing_run_version() -> None:
 
     with pytest.raises(HTTPException):
         await trigger_chatkit_workflow(
-            workflow_id,
+            str(workflow_id),
             request,
             Repository(),
             _authenticated_policy(),
@@ -261,6 +281,10 @@ async def test_trigger_chatkit_workflow_requires_authentication(
     )
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_latest_version(self, wf_id):
             return WorkflowVersion(
                 id=uuid4(),
@@ -288,7 +312,7 @@ async def test_trigger_chatkit_workflow_requires_authentication(
 
     with pytest.raises(HTTPException) as exc_info:
         await trigger_chatkit_workflow(
-            workflow_id,
+            str(workflow_id),
             request,
             Repository(),
             AuthorizationPolicy(RequestContext.anonymous()),

--- a/tests/backend/test_app_credential_health.py
+++ b/tests/backend/test_app_credential_health.py
@@ -27,6 +27,14 @@ from orcheo_backend.app.schemas.credentials import CredentialValidationRequest
 
 
 class _MissingWorkflowRepository:
+    async def resolve_workflow_ref(
+        self, workflow_ref, *, include_archived: bool = True
+    ):
+        del include_archived
+        return (
+            workflow_ref if isinstance(workflow_ref, UUID) else UUID(str(workflow_ref))
+        )
+
     async def get_workflow(self, workflow_id):  # pragma: no cover - signature typing
         raise WorkflowNotFoundError("missing")
 
@@ -54,6 +62,10 @@ async def test_get_workflow_credential_health_returns_unknown_response() -> None
     """A missing cached report results in an UNKNOWN response payload."""
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del include_archived
+            return UUID(str(workflow_ref))
+
         async def get_workflow(self, workflow_id):  # noqa: D401 - simple stub
             return object()
 
@@ -72,6 +84,10 @@ async def test_get_workflow_credential_health_returns_unknown_response() -> None
 @pytest.mark.asyncio()
 async def test_get_workflow_credential_health_requires_service() -> None:
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del include_archived
+            return UUID(str(workflow_ref))
+
         async def get_workflow(self, workflow_id):
             return object()
 
@@ -88,6 +104,10 @@ async def test_validate_workflow_credentials_reports_failures() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del include_archived
+            return workflow_id
+
         async def get_workflow(self, workflow_id):
             return object()
 
@@ -160,6 +180,10 @@ async def test_validate_workflow_credentials_requires_service() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del include_archived
+            return workflow_id
+
         async def get_workflow(self, workflow_id):
             return object()
 
@@ -182,6 +206,10 @@ async def test_invoke_webhook_trigger_wraps_health_error(
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del include_archived
+            return workflow_id
+
         async def get_latest_version(self, workflow_id):
             return object()
 
@@ -213,7 +241,7 @@ async def test_invoke_webhook_trigger_wraps_health_error(
 
     with pytest.raises(HTTPException) as exc_info:
         await invoke_webhook_trigger(
-            workflow_id,
+            str(workflow_id),
             request,
             repository=Repository(),
             vault=object(),

--- a/tests/backend/test_app_credential_templates_read.py
+++ b/tests/backend/test_app_credential_templates_read.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 import pytest
 from fastapi import HTTPException
 from orcheo.models import CredentialKind, CredentialScope
 from orcheo.vault import WorkflowScopeError
 
 
-def test_list_credential_templates_success() -> None:
+class _Repository:
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        del include_archived
+        return UUID(str(workflow_ref))
+
+
+@pytest.mark.asyncio()
+async def test_list_credential_templates_success() -> None:
     """List credential templates endpoint returns templates."""
     from orcheo.models import CredentialIssuancePolicy, CredentialTemplate
     from orcheo_backend.app import list_credential_templates
@@ -44,14 +56,15 @@ def test_list_credential_templates_success() -> None:
                 ),
             ]
 
-    result = list_credential_templates(Vault())
+    result = await list_credential_templates(Vault(), _Repository())
 
     assert len(result) == 2
     assert result[0].id == str(template1_id)
     assert result[1].id == str(template2_id)
 
 
-def test_get_credential_template_success() -> None:
+@pytest.mark.asyncio()
+async def test_get_credential_template_success() -> None:
     """Get credential template endpoint returns template."""
     from orcheo.models import CredentialIssuancePolicy, CredentialTemplate
     from orcheo_backend.app import get_credential_template
@@ -72,12 +85,13 @@ def test_get_credential_template_success() -> None:
                 updated_at=datetime.now(tz=UTC),
             )
 
-    result = get_credential_template(template_id, Vault())
+    result = await get_credential_template(template_id, Vault(), _Repository())
 
     assert result.id == str(template_id)
 
 
-def test_get_credential_template_not_found() -> None:
+@pytest.mark.asyncio()
+async def test_get_credential_template_not_found() -> None:
     """Get credential template raises 404 for missing template."""
     from orcheo.vault import CredentialTemplateNotFoundError
     from orcheo_backend.app import get_credential_template
@@ -89,12 +103,13 @@ def test_get_credential_template_not_found() -> None:
             raise CredentialTemplateNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        get_credential_template(template_id, Vault())
+        await get_credential_template(template_id, Vault(), _Repository())
 
     assert exc_info.value.status_code == 404
 
 
-def test_get_credential_template_scope_error() -> None:
+@pytest.mark.asyncio()
+async def test_get_credential_template_scope_error() -> None:
     """Get credential template raises 403 for scope violations."""
     from orcheo_backend.app import get_credential_template
 
@@ -105,7 +120,7 @@ def test_get_credential_template_scope_error() -> None:
             raise WorkflowScopeError("Access denied")
 
     with pytest.raises(HTTPException) as exc_info:
-        get_credential_template(template_id, Vault())
+        await get_credential_template(template_id, Vault(), _Repository())
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Access denied"

--- a/tests/backend/test_app_execution_history.py
+++ b/tests/backend/test_app_execution_history.py
@@ -1,7 +1,7 @@
 """Tests for workflow execution history endpoints."""
 
 from __future__ import annotations
-from uuid import uuid4
+from uuid import UUID, uuid4
 import pytest
 from fastapi import HTTPException
 from orcheo_backend.app import (
@@ -9,6 +9,17 @@ from orcheo_backend.app import (
 )
 from orcheo_backend.app.history import RunHistoryNotFoundError, RunHistoryRecord
 from orcheo_backend.app.schemas.runs import RunReplayRequest
+
+
+class _Repository:
+    async def resolve_workflow_ref(
+        self,
+        workflow_ref: str,
+        *,
+        include_archived: bool = True,
+    ) -> UUID:
+        del include_archived
+        return UUID(str(workflow_ref))
 
 
 @pytest.mark.asyncio()
@@ -34,8 +45,9 @@ async def test_list_workflow_execution_histories_returns_records() -> None:
             ]
 
     response = await list_workflow_execution_histories(
-        workflow_id=workflow_id,
+        workflow_ref=str(workflow_id),
         history_store=HistoryStore(),
+        repository=_Repository(),
         limit=50,
     )
 
@@ -59,8 +71,9 @@ async def test_list_workflow_execution_histories_respects_limit() -> None:
             return []
 
     await list_workflow_execution_histories(
-        workflow_id=workflow_id,
+        workflow_ref=str(workflow_id),
         history_store=HistoryStore(),
+        repository=_Repository(),
         limit=100,
     )
 

--- a/tests/backend/test_app_integration_misc.py
+++ b/tests/backend/test_app_integration_misc.py
@@ -1,12 +1,16 @@
 """Integration tests for assorted backend endpoints."""
 
 from __future__ import annotations
-from uuid import uuid4
 from fastapi.testclient import TestClient
 
 
 def test_list_workflow_execution_histories(client: TestClient) -> None:
-    workflow_id = uuid4()
+    workflow_response = client.post(
+        "/api/workflows",
+        json={"name": "History Flow", "actor": "tester"},
+    )
+    assert workflow_response.status_code == 201
+    workflow_id = workflow_response.json()["id"]
     response = client.get(f"/api/workflows/{workflow_id}/executions?limit=50")
     assert response.status_code == 200
     assert response.json() == []

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -13,7 +13,10 @@ from orcheo_backend.app import (
     list_workflows,
     update_workflow,
 )
-from orcheo_backend.app.repository import WorkflowNotFoundError
+from orcheo_backend.app.repository import (
+    WorkflowHandleConflictError,
+    WorkflowNotFoundError,
+)
 from orcheo_backend.app.schemas.workflows import (
     WorkflowCreateRequest,
     WorkflowUpdateRequest,
@@ -79,6 +82,32 @@ async def test_create_workflow_returns_new_workflow() -> None:
     assert result.id == workflow_id
     assert result.name == "Test Workflow"
     assert result.slug == "test-workflow"
+
+
+@pytest.mark.asyncio()
+async def test_create_workflow_translates_handle_conflicts() -> None:
+    """Create workflow endpoint raises 409 for duplicate handles."""
+
+    class Repository:
+        async def create_workflow(
+            self, name, slug, description, tags, actor, handle=None
+        ):
+            del name, slug, description, tags, actor, handle
+            raise WorkflowHandleConflictError(
+                "Workflow handle 'demo' is already in use."
+            )
+
+    request = WorkflowCreateRequest(
+        name="Test Workflow",
+        handle="demo",
+        actor="admin",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_workflow(request, Repository())
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "workflow.handle.conflict"
 
 
 @pytest.mark.asyncio()
@@ -187,6 +216,37 @@ async def test_update_workflow_not_found() -> None:
         await update_workflow(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_update_workflow_translates_handle_conflicts() -> None:
+    """Update workflow endpoint raises 409 for duplicate handles."""
+
+    workflow_id = uuid4()
+
+    class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
+        async def update_workflow(
+            self, wf_id, name, description, tags, is_archived, actor, handle=None
+        ):
+            del wf_id, name, description, tags, is_archived, actor, handle
+            raise WorkflowHandleConflictError(
+                "Workflow handle 'demo' is already in use."
+            )
+
+    request = WorkflowUpdateRequest(
+        handle="demo",
+        actor="admin",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_workflow(str(workflow_id), request, Repository())
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "workflow.handle.conflict"
 
 
 @pytest.mark.asyncio()

--- a/tests/backend/test_app_workflow_crud.py
+++ b/tests/backend/test_app_workflow_crud.py
@@ -87,6 +87,10 @@ async def test_get_workflow_returns_workflow() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_workflow(self, wf_id):
             return Workflow(
                 id=wf_id,
@@ -96,7 +100,7 @@ async def test_get_workflow_returns_workflow() -> None:
                 updated_at=datetime.now(tz=UTC),
             )
 
-    result = await get_workflow(workflow_id, Repository())
+    result = await get_workflow(str(workflow_id), Repository())
 
     assert result.id == workflow_id
     assert result.name == "Test Workflow"
@@ -108,11 +112,15 @@ async def test_get_workflow_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_workflow(self, wf_id):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_workflow(workflow_id, Repository())
+        await get_workflow(str(workflow_id), Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -123,6 +131,10 @@ async def test_update_workflow_returns_updated() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def update_workflow(
             self, wf_id, name, description, tags, is_archived, actor
         ):
@@ -145,7 +157,7 @@ async def test_update_workflow_returns_updated() -> None:
         actor="admin",
     )
 
-    result = await update_workflow(workflow_id, request, Repository())
+    result = await update_workflow(str(workflow_id), request, Repository())
 
     assert result.id == workflow_id
     assert result.name == "Updated Workflow"
@@ -157,6 +169,10 @@ async def test_update_workflow_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def update_workflow(
             self, wf_id, name, description, tags, is_archived, actor
         ):
@@ -168,7 +184,7 @@ async def test_update_workflow_not_found() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await update_workflow(workflow_id, request, Repository())
+        await update_workflow(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -179,6 +195,10 @@ async def test_archive_workflow_returns_archived() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def archive_workflow(self, wf_id, actor):
             return Workflow(
                 id=wf_id,
@@ -189,7 +209,7 @@ async def test_archive_workflow_returns_archived() -> None:
                 updated_at=datetime.now(tz=UTC),
             )
 
-    result = await archive_workflow(workflow_id, Repository(), actor="admin")
+    result = await archive_workflow(str(workflow_id), Repository(), actor="admin")
 
     assert result.id == workflow_id
     assert result.is_archived is True
@@ -201,10 +221,14 @@ async def test_archive_workflow_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def archive_workflow(self, wf_id, actor):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await archive_workflow(workflow_id, Repository(), actor="admin")
+        await archive_workflow(str(workflow_id), Repository(), actor="admin")
 
     assert exc_info.value.status_code == 404

--- a/tests/backend/test_app_workflow_runs.py
+++ b/tests/backend/test_app_workflow_runs.py
@@ -52,6 +52,10 @@ async def test_create_workflow_run_success() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_run(
             self,
             wf_id,
@@ -76,7 +80,7 @@ async def test_create_workflow_run_success() -> None:
         input_payload={"key": "value"},
     )
 
-    result = await create_workflow_run(workflow_id, request, Repository(), None)
+    result = await create_workflow_run(str(workflow_id), request, Repository(), None)
 
     assert result.id == run_id
     assert result.triggered_by == "user@example.com"
@@ -90,6 +94,10 @@ async def test_create_workflow_run_workflow_not_found() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_run(
             self,
             wf_id,
@@ -108,7 +116,7 @@ async def test_create_workflow_run_workflow_not_found() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await create_workflow_run(workflow_id, request, Repository(), None)
+        await create_workflow_run(str(workflow_id), request, Repository(), None)
 
     assert exc_info.value.status_code == 404
 
@@ -121,6 +129,10 @@ async def test_create_workflow_run_version_not_found() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_run(
             self,
             wf_id,
@@ -139,7 +151,7 @@ async def test_create_workflow_run_version_not_found() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await create_workflow_run(workflow_id, request, Repository(), None)
+        await create_workflow_run(str(workflow_id), request, Repository(), None)
 
     assert exc_info.value.status_code == 404
 
@@ -152,6 +164,10 @@ async def test_create_workflow_run_credential_health_error() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_run(
             self,
             wf_id,
@@ -170,7 +186,7 @@ async def test_create_workflow_run_credential_health_error() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await create_workflow_run(workflow_id, request, Repository(), None)
+        await create_workflow_run(str(workflow_id), request, Repository(), None)
 
     assert exc_info.value.status_code == 422
 
@@ -185,6 +201,10 @@ async def test_list_workflow_runs_success() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def list_runs_for_workflow(self, wf_id):
             return [
                 WorkflowRun(
@@ -205,7 +225,7 @@ async def test_list_workflow_runs_success() -> None:
                 ),
             ]
 
-    result = await list_workflow_runs(workflow_id, Repository())
+    result = await list_workflow_runs(str(workflow_id), Repository())
 
     assert len(result) == 2
     assert result[0].id == run1_id
@@ -219,11 +239,15 @@ async def test_list_workflow_runs_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def list_runs_for_workflow(self, wf_id):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await list_workflow_runs(workflow_id, Repository())
+        await list_workflow_runs(str(workflow_id), Repository())
 
     assert exc_info.value.status_code == 404
 

--- a/tests/backend/test_app_workflow_versions_create.py
+++ b/tests/backend/test_app_workflow_versions_create.py
@@ -23,6 +23,10 @@ async def test_create_workflow_version_success() -> None:
     captured_config: dict[str, object] | None = None
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_version(
             self,
             wf_id,
@@ -53,7 +57,7 @@ async def test_create_workflow_version_success() -> None:
         created_by="admin",
     )
 
-    result = await create_workflow_version(workflow_id, request, Repository())
+    result = await create_workflow_version(str(workflow_id), request, Repository())
 
     assert result.id == version_id
     assert result.workflow_id == workflow_id
@@ -68,6 +72,10 @@ async def test_create_workflow_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_version(
             self,
             wf_id,
@@ -85,7 +93,7 @@ async def test_create_workflow_version_not_found() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await create_workflow_version(workflow_id, request, Repository())
+        await create_workflow_version(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -99,6 +107,10 @@ async def test_ingest_workflow_version_success() -> None:
     captured_config: dict[str, object] | None = None
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_version(
             self,
             wf_id,
@@ -132,7 +144,7 @@ async def test_ingest_workflow_version_success() -> None:
         created_by="admin",
     )
 
-    result = await ingest_workflow_version(workflow_id, request, Repository())
+    result = await ingest_workflow_version(str(workflow_id), request, Repository())
 
     assert result.id == version_id
     assert captured_config == {"tags": ["ingest"]}
@@ -145,6 +157,10 @@ async def test_ingest_workflow_version_script_error() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_version(
             self,
             wf_id,
@@ -171,7 +187,7 @@ async def test_ingest_workflow_version_script_error() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await ingest_workflow_version(workflow_id, request, Repository())
+        await ingest_workflow_version(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 400
 
@@ -183,6 +199,10 @@ async def test_ingest_workflow_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def create_version(
             self,
             wf_id,
@@ -206,6 +226,6 @@ async def test_ingest_workflow_version_not_found() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await ingest_workflow_version(workflow_id, request, Repository())
+        await ingest_workflow_version(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 404

--- a/tests/backend/test_app_workflow_versions_read.py
+++ b/tests/backend/test_app_workflow_versions_read.py
@@ -27,6 +27,10 @@ async def test_list_workflow_versions_success() -> None:
     version2_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def list_versions(self, wf_id):
             return [
                 WorkflowVersion(
@@ -49,7 +53,7 @@ async def test_list_workflow_versions_success() -> None:
                 ),
             ]
 
-    result = await list_workflow_versions(workflow_id, Repository())
+    result = await list_workflow_versions(str(workflow_id), Repository())
 
     assert len(result) == 2
     assert result[0].id == version1_id
@@ -65,11 +69,15 @@ async def test_list_workflow_versions_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def list_versions(self, wf_id):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await list_workflow_versions(workflow_id, Repository())
+        await list_workflow_versions(str(workflow_id), Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -82,6 +90,10 @@ async def test_get_workflow_version_success() -> None:
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_version_by_number(self, wf_id, version_number):
             return WorkflowVersion(
                 id=version_id,
@@ -93,7 +105,7 @@ async def test_get_workflow_version_success() -> None:
                 updated_at=datetime.now(tz=UTC),
             )
 
-    result = await get_workflow_version(workflow_id, 1, Repository())
+    result = await get_workflow_version(str(workflow_id), 1, Repository())
 
     assert result.id == version_id
     assert result.version == 1
@@ -107,11 +119,15 @@ async def test_get_workflow_version_workflow_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_version_by_number(self, wf_id, version_number):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_workflow_version(workflow_id, 1, Repository())
+        await get_workflow_version(str(workflow_id), 1, Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -123,11 +139,15 @@ async def test_get_workflow_version_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def get_version_by_number(self, wf_id, version_number):
             raise WorkflowVersionNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_workflow_version(workflow_id, 1, Repository())
+        await get_workflow_version(str(workflow_id), 1, Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -144,10 +164,14 @@ async def test_diff_workflow_versions_success() -> None:
         diff = ["+ node1", "- node2"]
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def diff_versions(self, wf_id, base, target):
             return Diff()
 
-    result = await diff_workflow_versions(workflow_id, 1, 2, Repository())
+    result = await diff_workflow_versions(str(workflow_id), 1, 2, Repository())
 
     assert result.base_version == 1
     assert result.target_version == 2
@@ -164,6 +188,10 @@ async def test_list_workflow_versions_handles_mermaid_render_failure(
     version_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def list_versions(self, wf_id):
             return [
                 WorkflowVersion(
@@ -182,7 +210,7 @@ async def test_list_workflow_versions_handles_mermaid_render_failure(
 
     monkeypatch.setattr(workflow_router, "_mermaid_from_graph", _raise_mermaid_failure)
 
-    result = await list_workflow_versions(workflow_id, Repository())
+    result = await list_workflow_versions(str(workflow_id), Repository())
 
     assert len(result) == 1
     assert result[0].mermaid is None
@@ -195,11 +223,15 @@ async def test_diff_workflow_versions_workflow_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def diff_versions(self, wf_id, base, target):
             raise WorkflowNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await diff_workflow_versions(workflow_id, 1, 2, Repository())
+        await diff_workflow_versions(str(workflow_id), 1, 2, Repository())
 
     assert exc_info.value.status_code == 404
 
@@ -211,10 +243,14 @@ async def test_diff_workflow_versions_version_not_found() -> None:
     workflow_id = uuid4()
 
     class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
         async def diff_versions(self, wf_id, base, target):
             raise WorkflowVersionNotFoundError("not found")
 
     with pytest.raises(HTTPException) as exc_info:
-        await diff_workflow_versions(workflow_id, 1, 2, Repository())
+        await diff_workflow_versions(str(workflow_id), 1, 2, Repository())
 
     assert exc_info.value.status_code == 404

--- a/tests/backend/test_schemas.py
+++ b/tests/backend/test_schemas.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 from orcheo.graph.ingestion import DEFAULT_SCRIPT_SIZE_LIMIT
-from orcheo_backend.app.schemas.workflows import WorkflowVersionIngestRequest
+from orcheo_backend.app.schemas.workflows import (
+    WorkflowCreateRequest,
+    WorkflowUpdateRequest,
+    WorkflowVersionIngestRequest,
+)
 
 
 def test_workflow_version_ingest_request_rejects_large_scripts() -> None:
@@ -20,3 +24,15 @@ def test_workflow_version_ingest_request_rejects_large_scripts() -> None:
             notes=None,
             created_by="tester",
         )
+
+
+def test_workflow_create_request_allows_explicit_none_handle() -> None:
+    request = WorkflowCreateRequest(name="Schema Flow", handle=None)
+
+    assert request.handle is None
+
+
+def test_workflow_update_request_allows_explicit_none_handle() -> None:
+    request = WorkflowUpdateRequest(handle=None)
+
+    assert request.handle is None

--- a/tests/backend/test_triggers_router_config.py
+++ b/tests/backend/test_triggers_router_config.py
@@ -1,0 +1,115 @@
+"""Direct unit tests for trigger configuration router branches."""
+
+from __future__ import annotations
+from uuid import UUID, uuid4
+import pytest
+from fastapi import HTTPException
+from orcheo.triggers.cron import CronTriggerConfig
+from orcheo.triggers.webhook import WebhookTriggerConfig
+from orcheo_backend.app.repository.errors import WorkflowNotFoundError
+from orcheo_backend.app.routers import triggers as triggers_router
+
+
+class _WebhookConfigMissingRepo:
+    def __init__(self, workflow_id: UUID) -> None:
+        self._workflow_id = workflow_id
+
+    async def resolve_workflow_ref(
+        self, workflow_ref: str, *, include_archived: bool = True
+    ) -> UUID:
+        del workflow_ref, include_archived
+        return self._workflow_id
+
+    async def configure_webhook_trigger(
+        self, workflow_id: UUID, request: WebhookTriggerConfig
+    ) -> WebhookTriggerConfig:
+        del workflow_id, request
+        raise WorkflowNotFoundError("missing")
+
+    async def get_webhook_trigger_config(
+        self, workflow_id: UUID
+    ) -> WebhookTriggerConfig:
+        del workflow_id
+        raise WorkflowNotFoundError("missing")
+
+
+class _CronConfigMissingRepo:
+    def __init__(self, workflow_id: UUID) -> None:
+        self._workflow_id = workflow_id
+
+    async def resolve_workflow_ref(
+        self, workflow_ref: str, *, include_archived: bool = True
+    ) -> UUID:
+        del workflow_ref, include_archived
+        return self._workflow_id
+
+    async def configure_cron_trigger(
+        self, workflow_id: UUID, request: CronTriggerConfig
+    ) -> CronTriggerConfig:
+        del workflow_id, request
+        raise WorkflowNotFoundError("missing")
+
+    async def get_cron_trigger_config(self, workflow_id: UUID) -> CronTriggerConfig:
+        del workflow_id
+        raise WorkflowNotFoundError("missing")
+
+    async def delete_cron_trigger(self, workflow_id: UUID) -> None:
+        del workflow_id
+        raise WorkflowNotFoundError("missing")
+
+
+@pytest.mark.asyncio()
+async def test_configure_webhook_trigger_translates_workflow_not_found() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await triggers_router.configure_webhook_trigger(
+            str(uuid4()),
+            WebhookTriggerConfig(),
+            _WebhookConfigMissingRepo(uuid4()),
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_get_webhook_trigger_config_translates_workflow_not_found() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await triggers_router.get_webhook_trigger_config(
+            str(uuid4()),
+            _WebhookConfigMissingRepo(uuid4()),
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_configure_cron_trigger_translates_workflow_not_found() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await triggers_router.configure_cron_trigger(
+            str(uuid4()),
+            CronTriggerConfig(expression="0 9 * * *", timezone="UTC"),
+            _CronConfigMissingRepo(uuid4()),
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_get_cron_trigger_config_translates_workflow_not_found() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await triggers_router.get_cron_trigger_config(
+            str(uuid4()),
+            _CronConfigMissingRepo(uuid4()),
+        )
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio()
+async def test_delete_cron_trigger_translates_workflow_not_found() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        await triggers_router.delete_cron_trigger(
+            str(uuid4()),
+            _CronConfigMissingRepo(uuid4()),
+        )
+
+    assert excinfo.value.status_code == 404

--- a/tests/backend/test_workflows_router_actor_and_workspace_tags.py
+++ b/tests/backend/test_workflows_router_actor_and_workspace_tags.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from types import SimpleNamespace
+from uuid import UUID
 import pytest
 from orcheo.models.workflow import Workflow
 from orcheo_backend.app.authentication import AuthorizationPolicy, RequestContext
@@ -51,6 +52,10 @@ class _Repository:
             tags=tags or [],
             is_archived=bool(is_archived),
         )
+
+    async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+        del include_archived
+        return UUID(str(workflow_ref))
 
 
 @pytest.mark.asyncio()
@@ -180,7 +185,9 @@ async def test_update_workflow_appends_workspace_tags_when_auth_enforced(
         )
     )
 
-    await workflows.update_workflow(workflow.id, request, repository, policy=policy)
+    await workflows.update_workflow(
+        str(workflow.id), request, repository, policy=policy
+    )
 
     assert repository.last_actor == "service-token-1"
     assert repository.last_tags is not None
@@ -237,7 +244,9 @@ async def test_update_workflow_preserves_none_tags_when_request_omits_tags(
         )
     )
 
-    await workflows.update_workflow(workflow.id, request, repository, policy=policy)
+    await workflows.update_workflow(
+        str(workflow.id), request, repository, policy=policy
+    )
 
     assert repository.last_actor == "service-token-3"
     assert repository.last_tags is None

--- a/tests/backend/test_workflows_router_chatkit_session.py
+++ b/tests/backend/test_workflows_router_chatkit_session.py
@@ -25,6 +25,14 @@ class _WorkflowRepo:
     def __init__(self, workflow: Workflow) -> None:
         self._workflow = workflow
 
+    async def resolve_workflow_ref(
+        self, workflow_ref: str, *, include_archived: bool = True
+    ) -> UUID:
+        del include_archived
+        if UUID(str(workflow_ref)) != self._workflow.id:
+            raise WorkflowNotFoundError(str(workflow_ref))
+        return self._workflow.id
+
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         if workflow_id != self._workflow.id:
             raise WorkflowNotFoundError(str(workflow_id))
@@ -32,6 +40,12 @@ class _WorkflowRepo:
 
 
 class _MissingWorkflowRepo:
+    async def resolve_workflow_ref(
+        self, workflow_ref: str, *, include_archived: bool = True
+    ) -> UUID:
+        del include_archived
+        raise WorkflowNotFoundError(str(workflow_ref))
+
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         raise WorkflowNotFoundError(str(workflow_id))
 
@@ -74,7 +88,7 @@ async def test_create_workflow_chatkit_session_requires_authentication() -> None
 
     with pytest.raises(AuthenticationError):
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -89,7 +103,7 @@ async def test_create_workflow_chatkit_session_requires_permissions() -> None:
 
     with pytest.raises(AuthorizationError):
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -99,6 +113,14 @@ async def test_create_workflow_chatkit_session_requires_permissions() -> None:
 class _ArchivedWorkflowRepo:
     def __init__(self, workflow: Workflow) -> None:
         self._workflow = workflow
+
+    async def resolve_workflow_ref(
+        self, workflow_ref: str, *, include_archived: bool = True
+    ) -> UUID:
+        del include_archived
+        if UUID(str(workflow_ref)) != self._workflow.id:
+            raise WorkflowNotFoundError(str(workflow_ref))
+        return self._workflow.id
 
     async def get_workflow(self, workflow_id: UUID) -> Workflow:
         if workflow_id != self._workflow.id:
@@ -113,7 +135,7 @@ async def test_create_workflow_chatkit_session_validates_workflow_exists() -> No
 
     with pytest.raises(HTTPException) as excinfo:
         await workflows.create_workflow_chatkit_session(
-            uuid4(),
+            str(uuid4()),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -133,7 +155,7 @@ async def test_create_workflow_chatkit_session_rejects_archived_workflow() -> No
 
     with pytest.raises(HTTPException) as excinfo:
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -150,7 +172,7 @@ async def test_create_workflow_chatkit_session_mints_scoped_token() -> None:
     issuer = _issuer()
 
     response = await workflows.create_workflow_chatkit_session(
-        workflow.id,
+        str(workflow.id),
         repo,
         policy=policy,
         issuer=issuer,
@@ -193,7 +215,7 @@ async def test_create_workflow_chatkit_session_requires_workspace_match() -> Non
 
     with pytest.raises(AuthorizationError):
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -214,7 +236,7 @@ async def test_chatkit_session_matches_workspace_case_insensitively() -> None:
     )
 
     response = await workflows.create_workflow_chatkit_session(
-        workflow.id,
+        str(workflow.id),
         repo,
         policy=policy,
         issuer=_issuer(),
@@ -247,7 +269,7 @@ async def test_create_workflow_chatkit_session_falls_back_to_owner() -> None:
     )
 
     response = await workflows.create_workflow_chatkit_session(
-        workflow.id,
+        str(workflow.id),
         repo,
         policy=policy,
         issuer=_issuer(),
@@ -281,7 +303,7 @@ async def test_create_workflow_chatkit_session_requires_workspace_access_for_tag
 
     with pytest.raises(AuthorizationError) as excinfo:
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -306,7 +328,7 @@ async def test_create_workflow_chatkit_session_denies_when_owner_mismatch() -> N
 
     with pytest.raises(AuthorizationError) as excinfo:
         await workflows.create_workflow_chatkit_session(
-            workflow.id,
+            str(workflow.id),
             repo,
             policy=policy,
             issuer=_issuer(),
@@ -332,7 +354,7 @@ async def test_create_workflow_chatkit_session_allows_developer_owner_mismatch()
     )
 
     response = await workflows.create_workflow_chatkit_session(
-        workflow.id,
+        str(workflow.id),
         repo,
         policy=policy,
         issuer=_issuer(),
@@ -363,7 +385,7 @@ async def test_create_workflow_chatkit_session_allows_ownerless_workflow() -> No
     )
 
     response = await workflows.create_workflow_chatkit_session(
-        workflow.id,
+        str(workflow.id),
         repo,
         policy=policy,
         issuer=_issuer(),

--- a/tests/nodes/test_wecom.py
+++ b/tests/nodes/test_wecom.py
@@ -201,6 +201,12 @@ def patch_redis(fake_redis: FakeRedis) -> FakeRedis:
 class TestWeComEventsParserNode:
     """Tests for WeComEventsParserNode."""
 
+    def test_corp_id_defaults_to_vault_placeholder(self) -> None:
+        """Test parser node corp_id defaults to the vault placeholder."""
+        node = WeComEventsParserNode(name="wecom_parser")
+
+        assert node.corp_id == "[[wecom_corp_id]]"
+
     def test_verify_signature_success(self) -> None:
         """Test successful signature verification."""
         token = "test_token"
@@ -860,6 +866,12 @@ class TestWeComEventsParserNode:
 
 class TestWeComAccessTokenNode:
     """Tests for WeComAccessTokenNode."""
+
+    def test_corp_id_defaults_to_vault_placeholder(self) -> None:
+        """Test access token node corp_id defaults to the vault placeholder."""
+        node = WeComAccessTokenNode(name="get_token")
+
+        assert node.corp_id == "[[wecom_corp_id]]"
 
     @pytest.mark.asyncio
     async def test_fetch_access_token_success(self) -> None:

--- a/tests/sdk/test_cli_workflow_update.py
+++ b/tests/sdk/test_cli_workflow_update.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import respx
 from typer.testing import CliRunner
+from orcheo_sdk.cli.errors import CLIError
 from orcheo_sdk.cli.main import app
 
 
@@ -44,3 +45,54 @@ def test_workflow_update_accepts_handle_and_updates_name_and_handle(
     assert request_body["name"] == "Renamed Workflow"
     assert request_body["handle"] == "renamed-workflow"
     assert request_body["description"] == "Updated from CLI"
+
+
+def test_workflow_update_requires_connectivity(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    result = runner.invoke(
+        app,
+        ["--offline", "workflow", "update", "wf-1", "--name", "Renamed Workflow"],
+        env=env,
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, CLIError)
+    assert "network connectivity" in str(result.exception)
+
+
+def test_workflow_update_requires_at_least_one_field(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    result = runner.invoke(
+        app,
+        ["workflow", "update", "wf-1"],
+        env=env,
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, CLIError)
+    assert "Provide at least one field to update." in str(result.exception)
+
+
+def test_workflow_update_machine_mode_prints_json(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    updated = {
+        "id": "wf-1",
+        "handle": "renamed-workflow",
+        "name": "Renamed Workflow",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.put("http://api.test/api/workflows/wf-1").mock(
+            return_value=httpx.Response(200, json=updated)
+        )
+        result = runner.invoke(
+            app,
+            ["workflow", "update", "wf-1", "--name", "Renamed Workflow"],
+            env=machine_env,
+        )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == updated

--- a/tests/sdk/test_cli_workflow_update.py
+++ b/tests/sdk/test_cli_workflow_update.py
@@ -1,0 +1,46 @@
+"""Workflow update CLI command tests."""
+
+from __future__ import annotations
+import json
+import httpx
+import respx
+from typer.testing import CliRunner
+from orcheo_sdk.cli.main import app
+
+
+def test_workflow_update_accepts_handle_and_updates_name_and_handle(
+    runner: CliRunner, env: dict[str, str]
+) -> None:
+    updated = {
+        "id": "wf-1",
+        "handle": "renamed-workflow",
+        "name": "Renamed Workflow",
+        "description": "Updated from CLI",
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        update_route = router.put(
+            "http://api.test/api/workflows/original-workflow"
+        ).mock(return_value=httpx.Response(200, json=updated))
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "update",
+                "original-workflow",
+                "--name",
+                "Renamed Workflow",
+                "--handle",
+                "renamed-workflow",
+                "--description",
+                "Updated from CLI",
+            ],
+            env=env,
+        )
+
+    assert result.exit_code == 0
+    assert "updated successfully" in result.stdout
+    request_body = json.loads(update_route.calls[0].request.content)
+    assert request_body["name"] == "Renamed Workflow"
+    assert request_body["handle"] == "renamed-workflow"
+    assert request_body["description"] == "Updated from CLI"

--- a/tests/sdk/test_cli_workflow_upload_json.py
+++ b/tests/sdk/test_cli_workflow_upload_json.py
@@ -45,7 +45,7 @@ def test_workflow_upload_json_file_update_existing(
 
     updated = {"id": "wf-1", "name": "TestWorkflow"}
     with respx.mock(assert_all_called=True) as router:
-        router.post("http://api.test/api/workflows/wf-1").mock(
+        router.put("http://api.test/api/workflows/wf-1").mock(
             return_value=httpx.Response(200, json=updated)
         )
         result = runner.invoke(

--- a/tests/sdk/test_cli_workflow_upload_langgraph_basic.py
+++ b/tests/sdk/test_cli_workflow_upload_langgraph_basic.py
@@ -234,7 +234,7 @@ def build_graph():
         router.get("http://api.test/api/workflows/wf-1").mock(
             return_value=httpx.Response(200, json=existing_workflow)
         )
-        rename_route = router.post("http://api.test/api/workflows/wf-1").mock(
+        rename_route = router.put("http://api.test/api/workflows/wf-1").mock(
             return_value=httpx.Response(
                 200, json={"id": "wf-1", "name": "Renamed Workflow"}
             )

--- a/tests/sdk/test_cli_workflow_upload_python.py
+++ b/tests/sdk/test_cli_workflow_upload_python.py
@@ -55,7 +55,7 @@ workflow = Workflow(name="TestWorkflow")
 
     updated = {"id": "wf-1", "name": "TestWorkflow"}
     with respx.mock(assert_all_called=True) as router:
-        router.post("http://api.test/api/workflows/wf-1").mock(
+        router.put("http://api.test/api/workflows/wf-1").mock(
             return_value=httpx.Response(200, json=updated)
         )
         result = runner.invoke(
@@ -112,7 +112,7 @@ workflow = Workflow(name="OldName")
 
     updated = {"id": "wf-1", "name": "Renamed Workflow"}
     with respx.mock(assert_all_called=True) as router:
-        update_route = router.post("http://api.test/api/workflows/wf-1").mock(
+        update_route = router.put("http://api.test/api/workflows/wf-1").mock(
             return_value=httpx.Response(200, json=updated)
         )
         result = runner.invoke(

--- a/tests/sdk/test_services_workflows_management.py
+++ b/tests/sdk/test_services_workflows_management.py
@@ -1,0 +1,59 @@
+"""Workflow management service helper tests."""
+
+from __future__ import annotations
+from typing import Any
+import pytest
+from orcheo_sdk.services.workflows import management
+
+
+class DummyClient:
+    """Minimal client stub for workflow management service tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def delete(self, path: str) -> dict[str, Any] | None:
+        self.calls.append({"method": "delete", "path": path})
+        return None
+
+    def put(self, path: str, *, json_body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append({"method": "put", "path": path, "json_body": json_body})
+        return {"ok": True}
+
+
+def test_delete_workflow_data_falls_back_to_default_message() -> None:
+    client = DummyClient()
+
+    result = management.delete_workflow_data(client, "wf-1")
+
+    assert result == {"status": "success", "message": "Workflow 'wf-1' deleted"}
+    assert client.calls == [{"method": "delete", "path": "/api/workflows/wf-1"}]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_payload"),
+    [
+        ({"name": "Renamed"}, {"actor": "cli", "name": "Renamed"}),
+        ({"handle": "renamed-flow"}, {"actor": "cli", "handle": "renamed-flow"}),
+        (
+            {"description": "Updated description"},
+            {"actor": "cli", "description": "Updated description"},
+        ),
+    ],
+)
+def test_update_workflow_data_includes_only_provided_fields(
+    kwargs: dict[str, Any],
+    expected_payload: dict[str, Any],
+) -> None:
+    client = DummyClient()
+
+    result = management.update_workflow_data(client, "wf-1", **kwargs)
+
+    assert result == {"ok": True}
+    assert client.calls == [
+        {
+            "method": "put",
+            "path": "/api/workflows/wf-1",
+            "json_body": expected_payload,
+        }
+    ]

--- a/tests/sdk/test_workflow_cli_upload_helpers.py
+++ b/tests/sdk/test_workflow_cli_upload_helpers.py
@@ -61,7 +61,7 @@ def test_upload_langgraph_script_rename_failure() -> None:
             assert url.endswith("/api/workflows/wf-1")
             return {"id": "wf-1", "name": "existing"}
 
-        def post(self, url: str, **payload: Any) -> Any:  # type: ignore[override]
+        def put(self, url: str, **payload: Any) -> Any:  # type: ignore[override]
             raise RuntimeError("cannot rename")
 
     state.client = RenameFailingClient()

--- a/tests/sdk/workflow_cli_test_utils.py
+++ b/tests/sdk/workflow_cli_test_utils.py
@@ -29,6 +29,10 @@ class StubClient:
         self.calls.append(("POST", url, payload))
         raise NotImplementedError
 
+    def put(self, url: str, **payload: Any) -> Any:
+        self.calls.append(("PUT", url, payload))
+        raise NotImplementedError
+
     def delete(self, url: str) -> None:  # pragma: no cover - convenience helper
         self.calls.append(("DELETE", url))
 

--- a/tests/test_app_workflow_websocket.py
+++ b/tests/test_app_workflow_websocket.py
@@ -8,6 +8,15 @@ from orcheo_backend.app.authentication import reset_authentication_state
 from orcheo_backend.app.history import InMemoryRunHistoryStore
 
 
+class _Repository:
+    def __init__(self, resolved_workflow_id: str) -> None:
+        self._resolved_workflow_id = resolved_workflow_id
+
+    async def resolve_workflow_ref(self, workflow_ref: str, *, include_archived=True):
+        del workflow_ref, include_archived
+        return self._resolved_workflow_id
+
+
 @pytest.mark.asyncio
 async def test_workflow_websocket_routes_requests(
     monkeypatch: pytest.MonkeyPatch,
@@ -30,13 +39,21 @@ async def test_workflow_websocket_routes_requests(
     }
 
     with (
-        patch("orcheo_backend.app.execute_workflow") as mock_execute,
+        patch(
+            "orcheo_backend.app.authenticate_websocket", AsyncMock(return_value=Mock())
+        ),
+        patch(
+            "orcheo_backend.app.get_repository",
+            return_value=_Repository("test-workflow"),
+        ),
+        patch(
+            "orcheo_backend.app.execute_workflow", new_callable=AsyncMock
+        ) as mock_execute,
         patch(
             "orcheo_backend.app._history_store_ref",
             {"store": InMemoryRunHistoryStore()},
         ),
     ):
-        mock_execute.return_value = None
         await workflow_websocket(mock_websocket, "test-workflow")
 
     mock_websocket.accept.assert_called_once()
@@ -76,13 +93,22 @@ async def test_workflow_websocket_routes_evaluation_requests(
     }
 
     with (
-        patch("orcheo_backend.app.execute_workflow_evaluation") as mock_execute,
+        patch(
+            "orcheo_backend.app.authenticate_websocket", AsyncMock(return_value=Mock())
+        ),
+        patch(
+            "orcheo_backend.app.get_repository",
+            return_value=_Repository("workflow-abc"),
+        ),
+        patch(
+            "orcheo_backend.app.execute_workflow_evaluation",
+            new_callable=AsyncMock,
+        ) as mock_execute,
         patch(
             "orcheo_backend.app._history_store_ref",
             {"store": InMemoryRunHistoryStore()},
         ),
     ):
-        mock_execute.return_value = None
         await workflow_websocket(mock_websocket, "workflow-abc")
 
     mock_execute.assert_called_once_with(
@@ -120,13 +146,22 @@ async def test_workflow_websocket_routes_training_requests(
     }
 
     with (
-        patch("orcheo_backend.app.execute_workflow_training") as mock_execute,
+        patch(
+            "orcheo_backend.app.authenticate_websocket", AsyncMock(return_value=Mock())
+        ),
+        patch(
+            "orcheo_backend.app.get_repository",
+            return_value=_Repository("workflow-train"),
+        ),
+        patch(
+            "orcheo_backend.app.execute_workflow_training",
+            new_callable=AsyncMock,
+        ) as mock_execute,
         patch(
             "orcheo_backend.app._history_store_ref",
             {"store": InMemoryRunHistoryStore()},
         ),
     ):
-        mock_execute.return_value = None
         await workflow_websocket(mock_websocket, "workflow-train")
 
     mock_execute.assert_called_once_with(

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -25,7 +25,7 @@ def test_create_app_returns_fastapi_instance() -> None:
         route for route in app.router.routes if isinstance(route, WebSocketRoute)
     ]
     websocket_paths = {route.path for route in websocket_routes}
-    assert "/ws/workflow/{workflow_id}" in websocket_paths
+    assert "/ws/workflow/{workflow_ref}" in websocket_paths
 
 
 def test_get_app_matches_module_level_app() -> None:

--- a/tests/test_workflow_models_workflow.py
+++ b/tests/test_workflow_models_workflow.py
@@ -53,6 +53,11 @@ def test_workflow_handle_is_normalized_and_validated() -> None:
     assert workflow.handle == "demo-flow-01"
 
 
+def test_workflow_handle_rejects_uuid_format() -> None:
+    with pytest.raises(ValidationError, match="must not use a UUID format"):
+        Workflow(name="Demo Flow", handle="550e8400-e29b-41d4-a716-446655440000")
+
+
 def test_workflow_tag_normalization() -> None:
     workflow = Workflow(name="Tagged", tags=["alpha", " Alpha ", "beta", ""])
 

--- a/tests/test_workflow_models_workflow.py
+++ b/tests/test_workflow_models_workflow.py
@@ -47,6 +47,12 @@ def test_workflow_name_and_description_are_normalized() -> None:
     assert workflow.description == "Some description"
 
 
+def test_workflow_handle_is_normalized_and_validated() -> None:
+    workflow = Workflow(name="Demo Flow", handle="Demo-Flow-01")
+
+    assert workflow.handle == "demo-flow-01"
+
+
 def test_workflow_tag_normalization() -> None:
     workflow = Workflow(name="Tagged", tags=["alpha", " Alpha ", "beta", ""])
 

--- a/tests/test_workflow_models_workflow.py
+++ b/tests/test_workflow_models_workflow.py
@@ -10,6 +10,7 @@ from orcheo.models import (
     WorkflowRunStatus,
     WorkflowVersion,
 )
+from orcheo.models.workflow_refs import normalize_workflow_handle
 
 
 def test_workflow_slug_is_derived_from_name() -> None:
@@ -56,6 +57,21 @@ def test_workflow_handle_is_normalized_and_validated() -> None:
 def test_workflow_handle_rejects_uuid_format() -> None:
     with pytest.raises(ValidationError, match="must not use a UUID format"):
         Workflow(name="Demo Flow", handle="550e8400-e29b-41d4-a716-446655440000")
+
+
+def test_normalize_workflow_handle_rejects_empty_value() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        normalize_workflow_handle("   ")
+
+
+def test_normalize_workflow_handle_rejects_overlong_value() -> None:
+    with pytest.raises(ValueError, match="at most 64 characters"):
+        normalize_workflow_handle("a" * 65)
+
+
+def test_normalize_workflow_handle_rejects_invalid_characters() -> None:
+    with pytest.raises(ValueError, match="single hyphens"):
+        normalize_workflow_handle("not_valid")
 
 
 def test_workflow_tag_normalization() -> None:


### PR DESCRIPTION
## Summary

This PR combines two related workflow and integration improvements:

1. adds editable workflow `handle`s as user-facing workflow references while keeping UUIDs as the canonical internal IDs
2. makes WeCom `corp_id` a credential by default to align WeCom workflows with the credential system

It also adds explicit CLI workflow metadata updates, including workflow name updates, and makes workflow-scoped backend routes accept either a UUID or a handle.

## What Changed

### Workflow handles and workflow updates

#### Backend

- Added `handle` to the workflow model and API schemas.
- Added shared handle normalization and validation:
  - lowercase
  - kebab-case
  - max length 64
- Added repository-level workflow ref resolution:
  - active handle first
  - archived handle next
  - UUID last
- Added handle conflict protection:
  - duplicate active handles are rejected
  - handles that shadow another workflow UUID are rejected
- Extended SQLite and Postgres workflow persistence with mirrored `handle` and `is_archived` columns plus indexes for handle lookup.
- Updated workflow-scoped routes to accept workflow refs instead of UUID-only path params, including:
  - workflows
  - runs
  - triggers
  - credential health
  - Agentensor checkpoints
  - ChatKit workflow trigger/session routes
  - websocket workflow execution
  - node execution workflow context
- Public/share URLs now prefer `handle` over UUID.

#### CLI / SDK

- Added `orcheo workflow update <workflow-ref>` with:
  - `--name`
  - `--handle`
  - `--description`
- Updated CLI help text to describe workflow arguments as workflow references.
- Added SDK support for workflow metadata updates.
- Normalized workflow updates to use `PUT /api/workflows/{workflow_ref}` consistently.
- Existing workflow upload/update flows now work with workflow refs.

#### Canvas

- Added `handle` to Canvas workflow types.
- Canvas routes and navigation now prefer `handle ?? id` for workflow URLs.
- Workflow listing and public chat surfaces now show both handle and UUID.
- Updated Canvas test backend mocks to resolve workflows by handle as well as UUID.

### WeCom credential defaults

- Changed WeCom integration defaults so `corp_id` is treated as a credential-backed value by default.
- Updated WeCom examples to use the credential-based default rather than inlining `corp_id`.
- Updated WeCom documentation/examples to match the new default behavior.
- Added test coverage for the updated WeCom node behavior.

## Behavior Notes

- UUID `id` remains the canonical internal key.
- `handle` is a user-facing alias accepted anywhere a workflow ref is used.
- Archived handles are reusable.
- Public chat and webhook URLs intentionally retarget if a handle is later reused by another workflow.
- No automatic migration from existing `slug` values was added.
- WeCom workflows now default to resolving `corp_id` from credentials rather than treating it as a normal config field.

## Tests

Validated with:

- `make format`
- `make canvas-format`
- `make lint`
- `make canvas-lint`
- `uv run pytest tests/test_workflow_models_workflow.py tests/backend/api/test_workflows_crud.py tests/backend/api/test_public_workflow_metadata.py tests/backend/api/test_workflow_chatkit_session.py tests/backend/api/test_trigger_webhook.py tests/sdk/test_cli_workflow_upload_python.py tests/sdk/test_cli_workflow_upload_json.py tests/sdk/test_cli_workflow_upload_langgraph_basic.py tests/sdk/test_workflow_cli_upload_helpers.py tests/sdk/test_cli_workflow_update.py`
- `npm --prefix apps/canvas run test -- src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx src/features/workflow/pages/workflow-canvas.test.tsx`

The earlier WeCom change also included dedicated WeCom node test coverage in `tests/nodes/test_wecom.py`.

## Follow-up

Recommended follow-up after merge:
- run broader backend API regression coverage for publish/runs/credentials paths
- manually verify public chat and webhook behavior when archived handles are reclaimed
- manually verify WeCom example workflows against credential-backed `corp_id` configuration
