### PR TITLE
Fix runnable template resolution and harden cron-trigger handling

### DIFF
--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
@@ -315,9 +315,21 @@ class PostgresRepositoryBase:
             for row in rows:
                 run_id = UUID(row["id"])
                 workflow_id = UUID(row["workflow_id"])
+                status = row["status"]
                 self._trigger_layer.track_run(workflow_id, run_id)
-                if row["triggered_by"] == "cron":  # pragma: no branch
-                    self._trigger_layer.register_cron_run(run_id)
+                if (
+                    row["triggered_by"] == "cron"
+                    and status != WorkflowRunStatus.FAILED.value
+                ):
+                    try:
+                        self._trigger_layer.register_cron_run(run_id)
+                    except Exception:
+                        logger.warning(
+                            "Skipped cron overlap registration for run %s "
+                            "(workflow %s): overlap conflict during hydration",
+                            run_id,
+                            workflow_id,
+                        )
 
     async def _refresh_cron_triggers(self) -> None:
         """Refresh cron trigger configs to reflect the latest persisted state."""

--- a/apps/backend/src/orcheo_backend/app/repository_sqlite/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_sqlite/_base.py
@@ -253,9 +253,21 @@ class SqliteRepositoryBase:
             for row in await cursor.fetchall():
                 run_id = UUID(row["id"])
                 workflow_id = UUID(row["workflow_id"])
+                status = row["status"]
                 self._trigger_layer.track_run(workflow_id, run_id)
-                if row["triggered_by"] == "cron":
-                    self._trigger_layer.register_cron_run(run_id)
+                if (
+                    row["triggered_by"] == "cron"
+                    and status != WorkflowRunStatus.FAILED.value
+                ):
+                    try:
+                        self._trigger_layer.register_cron_run(run_id)
+                    except Exception:
+                        logger.warning(
+                            "Skipped cron overlap registration for run %s "
+                            "(workflow %s): overlap conflict during hydration",
+                            run_id,
+                            workflow_id,
+                        )
 
     async def _refresh_cron_triggers(self) -> None:
         """Refresh cron trigger configs to reflect the latest persisted state."""

--- a/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
+++ b/packages/sdk/src/orcheo_sdk/cli/workflow/commands/managing.py
@@ -29,6 +29,7 @@ from orcheo_sdk.cli.workflow.inputs import (
 from orcheo_sdk.services import (
     delete_workflow_data,
     download_workflow_data,
+    sync_cron_schedule_if_changed,
     update_workflow_data,
     upload_workflow_data,
 )
@@ -91,14 +92,29 @@ def upload_workflow(
         runnable_config=runnable_config,
         console=state.console,
     )
+    resolved_id = workflow_id or result.get("id")
+
+    # Auto-update cron schedule if it was already registered and has changed.
+    cron_sync: dict[str, str] | None = None
+    if resolved_id:
+        try:
+            cron_sync = sync_cron_schedule_if_changed(state.client, resolved_id)
+        except Exception:  # noqa: BLE001
+            cron_sync = None
+
     if not state.human:
+        if cron_sync and cron_sync.get("status") == "updated":
+            result["cron_schedule"] = cron_sync
         print_json(result)
         return
-    identifier = workflow_id or result.get("id") or "workflow"
+    identifier = resolved_id or "workflow"
     action = "updated" if workflow_id else "uploaded"
     success_message = f"[green]Workflow '{identifier}' {action} successfully.[/green]"
     state.console.print(success_message)
     render_json(state.console, result, title="Workflow")
+    if cron_sync and cron_sync.get("status") == "updated":
+        state.console.print(f"[green]{cron_sync['message']}[/green]")
+        render_json(state.console, cron_sync.get("config", {}), title="Cron trigger")
 
 
 @workflow_app.command("update")

--- a/packages/sdk/src/orcheo_sdk/services/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/services/__init__.py
@@ -38,6 +38,7 @@ from orcheo_sdk.services.workflows import (
     run_workflow_data,
     schedule_workflow_cron,
     show_workflow_data,
+    sync_cron_schedule_if_changed,
     unpublish_workflow_data,
     unschedule_workflow_cron,
     update_workflow_data,
@@ -59,6 +60,7 @@ __all__ = [
     "unpublish_workflow_data",
     "enrich_workflow_publish_metadata",
     "schedule_workflow_cron",
+    "sync_cron_schedule_if_changed",
     "unschedule_workflow_cron",
     # Nodes
     "list_nodes_data",

--- a/packages/sdk/src/orcheo_sdk/services/workflows/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/__init__.py
@@ -21,6 +21,7 @@ from orcheo_sdk.services.workflows.publish import (
 )
 from orcheo_sdk.services.workflows.scheduling import (
     schedule_workflow_cron,
+    sync_cron_schedule_if_changed,
     unschedule_workflow_cron,
 )
 from orcheo_sdk.services.workflows.upload import upload_workflow_data
@@ -42,5 +43,6 @@ __all__ = [
     "unpublish_workflow_data",
     "enrich_workflow_publish_metadata",
     "schedule_workflow_cron",
+    "sync_cron_schedule_if_changed",
     "unschedule_workflow_cron",
 ]

--- a/packages/sdk/src/orcheo_sdk/services/workflows/scheduling.py
+++ b/packages/sdk/src/orcheo_sdk/services/workflows/scheduling.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 from orcheo.graph.ingestion.config import LANGGRAPH_SCRIPT_FORMAT
 from orcheo.triggers.cron import CronTriggerConfig
-from orcheo_sdk.cli.errors import CLIError
+from orcheo_sdk.cli.errors import APICallError, CLIError
 from orcheo_sdk.cli.http import ApiClient
 from orcheo_sdk.services.workflows.versions import get_latest_workflow_version_data
 
@@ -35,6 +35,42 @@ def schedule_workflow_cron(
     return {
         "status": "scheduled",
         "message": f"Cron trigger scheduled for workflow '{workflow_id}'.",
+        "config": response or payload,
+    }
+
+
+def sync_cron_schedule_if_changed(
+    client: ApiClient,
+    workflow_id: str,
+) -> dict[str, Any]:
+    """Update the cron schedule when one exists and the config changed."""
+    try:
+        existing = client.get(f"/api/workflows/{workflow_id}/triggers/cron/config")
+    except APICallError as exc:
+        if exc.status_code == 404:
+            return {"status": "noop", "reason": "no_existing_schedule"}
+        raise
+
+    version = get_latest_workflow_version_data(client, workflow_id)
+    graph = version.get("graph")
+    if not isinstance(graph, Mapping):
+        return {"status": "noop", "reason": "no_graph"}
+    new_config = _extract_cron_config(graph)
+    if new_config is None:
+        return {"status": "noop", "reason": "no_cron_trigger"}
+
+    existing_config = CronTriggerConfig(**existing)
+    if new_config == existing_config:
+        return {"status": "noop", "reason": "unchanged"}
+
+    payload = new_config.model_dump(mode="json")
+    response = client.put(
+        f"/api/workflows/{workflow_id}/triggers/cron/config",
+        json_body=payload,
+    )
+    return {
+        "status": "updated",
+        "message": f"Cron schedule updated for workflow '{workflow_id}'.",
         "config": response or payload,
     }
 
@@ -94,4 +130,8 @@ def _extract_nodes(graph: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return []
 
 
-__all__ = ["schedule_workflow_cron", "unschedule_workflow_cron"]
+__all__ = [
+    "schedule_workflow_cron",
+    "sync_cron_schedule_if_changed",
+    "unschedule_workflow_cron",
+]

--- a/src/orcheo/edges/base.py
+++ b/src/orcheo/edges/base.py
@@ -17,8 +17,8 @@ class BaseEdge(BaseRunnable):
 
     async def __call__(self, state: State, config: RunnableConfig) -> str | list[Send]:
         """Execute the edge and return the routing decision."""
-        self.decode_variables(state, config=config)
-        result = await self.run(state, config)
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
         return result
 
     @abstractmethod

--- a/src/orcheo/nodes/agent_tools/tools.py
+++ b/src/orcheo/nodes/agent_tools/tools.py
@@ -35,8 +35,8 @@ async def _run_mongodb_node(
         "messages": [],
     }
     runnable_config = config or RunnableConfig()
-    node.decode_variables(state, config=runnable_config)
-    return await node.run(state, runnable_config)
+    resolved = node.resolved_for_run(state, config=runnable_config)
+    return await resolved.run(state, runnable_config)
 
 
 def _normalize_mongodb_sort(

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -196,6 +196,17 @@ class AgentNode(AINode):
     )
     """Fields resolved by ``_resolve_history_key``, skipped in general decode."""
 
+    def _compute_run_updates(self, state: State) -> dict[str, Any]:
+        """Skip deferred fields that are resolved by _resolve_history_key."""
+        updates: dict[str, Any] = {}
+        for key, value in self.__dict__.items():
+            if key in self._DEFERRED_DECODE_FIELDS:
+                continue
+            decoded = self._decode_value(value, state)
+            if decoded is not value:
+                updates[key] = decoded
+        return updates
+
     def decode_variables(
         self,
         state: Any,

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -191,6 +191,24 @@ class AgentNode(AINode):
     history_value_field: str = "content"
     """Field name used when persisting text content into store records."""
 
+    _DEFERRED_DECODE_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"history_key_template", "history_key_candidates"}
+    )
+    """Fields resolved by ``_resolve_history_key``, skipped in general decode."""
+
+    def decode_variables(
+        self,
+        state: Any,
+        *,
+        config: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Decode variables, skipping fields handled by _resolve_history_key."""
+        del config
+        for key, value in self.__dict__.items():
+            if key in self._DEFERRED_DECODE_FIELDS:
+                continue
+            self.__dict__[key] = self._decode_value(value, state)
+
     @field_serializer("system_prompt", when_used="json")
     def _serialize_system_prompt(self, value: str | TextTensor | None) -> str | None:
         """Normalize TextTensor prompts into JSON-safe strings."""

--- a/src/orcheo/nodes/base.py
+++ b/src/orcheo/nodes/base.py
@@ -4,7 +4,7 @@ import logging
 import re
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Self, cast
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel
 from orcheo.graph.state import State
@@ -44,17 +44,25 @@ class BaseRunnable(BaseModel):
         if isinstance(value, str):
             return self._decode_string_value(value, state)
         if isinstance(value, BaseModel):
-            # Handle Pydantic models by decoding their dict representation
-            for field_name in value.__class__.model_fields:
-                field_value = getattr(value, field_name)
-                decoded = self._decode_value(field_value, state)
-                setattr(value, field_name, decoded)
-            return value
+            # Rebuild nested Pydantic models so shared node instances
+            # do not retain resolved template state across invocations.
+            updates = {
+                field_name: self._decode_value(getattr(value, field_name), state)
+                for field_name in value.__class__.model_fields
+            }
+            return value.model_copy(update=updates)
         if isinstance(value, dict):
             return {k: self._decode_value(v, state) for k, v in value.items()}
         if isinstance(value, list):
             return [self._decode_value(item, state) for item in value]
         return value
+
+    def _decoded_updates(self, state: State) -> dict[str, Any]:
+        """Return decoded field values without mutating the runnable."""
+        return {
+            key: self._decode_value(value, state)
+            for key, value in self.__dict__.items()
+        }
 
     def _decode_string_value(
         self,
@@ -157,8 +165,18 @@ class BaseRunnable(BaseModel):
     ) -> None:
         """Decode the variables in attributes of the runnable."""
         del config
-        for key, value in self.__dict__.items():
-            self.__dict__[key] = self._decode_value(value, state)
+        self.__dict__.update(self._decoded_updates(state))
+
+    def resolved_for_run(
+        self,
+        state: State,
+        *,
+        config: Mapping[str, Any] | None = None,
+    ) -> Self:
+        """Return a copy with templates resolved for the current invocation."""
+        runnable = cast(Self, self.model_copy())
+        runnable.decode_variables(state, config=config)
+        return runnable
 
 
 class BaseNode(BaseRunnable):
@@ -206,9 +224,9 @@ class AINode(BaseNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and wrap the result in a messages key."""
-        self.decode_variables(state, config=config)
-        result = await self.run(state, config)
-        return self._serialize_result(result)
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
+        return runnable._serialize_result(result)
 
     @abstractmethod
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
@@ -221,9 +239,9 @@ class TaskNode(BaseNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and wrap the result in a outputs key."""
-        self.decode_variables(state, config=config)
-        result = await self.run(state, config)
-        serialized_result = self._serialize_result(result)
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
+        serialized_result = runnable._serialize_result(result)
         return {"results": {self.name: serialized_result}}
 
     @abstractmethod

--- a/src/orcheo/nodes/base.py
+++ b/src/orcheo/nodes/base.py
@@ -38,24 +38,54 @@ class BaseRunnable(BaseModel):
         value: Any,
         state: State,
     ) -> Any:
-        """Recursively decode a value that may contain template strings."""
+        """Recursively decode a value that may contain template strings.
+
+        Identity-preserving: returns the *same* object when no resolution
+        is needed, enabling cheap ``is`` checks for copy-on-write callers.
+        """
         if isinstance(value, CredentialReference):
             return self._resolve_credential_reference(value)
         if isinstance(value, str):
             return self._decode_string_value(value, state)
         if isinstance(value, BaseModel):
-            # Rebuild nested Pydantic models so shared node instances
-            # do not retain resolved template state across invocations.
-            updates = {
-                field_name: self._decode_value(getattr(value, field_name), state)
-                for field_name in value.__class__.model_fields
-            }
-            return value.model_copy(update=updates)
+            return self._decode_model_value(value, state)
         if isinstance(value, dict):
-            return {k: self._decode_value(v, state) for k, v in value.items()}
+            return self._decode_dict_value(value, state)
         if isinstance(value, list):
-            return [self._decode_value(item, state) for item in value]
+            return self._decode_list_value(value, state)
         return value
+
+    def _decode_model_value(self, value: BaseModel, state: State) -> BaseModel:
+        """Decode a nested Pydantic model, returning the same object if unchanged."""
+        changed: dict[str, Any] = {}
+        for field_name in value.__class__.model_fields:
+            original = getattr(value, field_name)
+            decoded = self._decode_value(original, state)
+            if decoded is not original:
+                changed[field_name] = decoded
+        return value.model_copy(update=changed) if changed else value
+
+    def _decode_dict_value(self, value: dict[str, Any], state: State) -> dict[str, Any]:
+        """Decode a dict, returning the same object if no values changed."""
+        new_dict: dict[str, Any] = {}
+        any_changed = False
+        for k, v in value.items():
+            decoded = self._decode_value(v, state)
+            new_dict[k] = decoded
+            if decoded is not v:
+                any_changed = True
+        return new_dict if any_changed else value
+
+    def _decode_list_value(self, value: list[Any], state: State) -> list[Any]:
+        """Decode a list, returning the same object if no items changed."""
+        new_list: list[Any] = []
+        any_changed = False
+        for item in value:
+            decoded = self._decode_value(item, state)
+            new_list.append(decoded)
+            if decoded is not item:
+                any_changed = True
+        return new_list if any_changed else value
 
     def _decoded_updates(self, state: State) -> dict[str, Any]:
         """Return decoded field values without mutating the runnable."""
@@ -167,16 +197,35 @@ class BaseRunnable(BaseModel):
         del config
         self.__dict__.update(self._decoded_updates(state))
 
+    def _compute_run_updates(self, state: State) -> dict[str, Any]:
+        """Return only the fields whose values changed during resolution.
+
+        Subclasses may override to exclude fields from resolution (see
+        ``AgentNode`` which defers history-key fields).
+        """
+        updates: dict[str, Any] = {}
+        for key, value in self.__dict__.items():
+            decoded = self._decode_value(value, state)
+            if decoded is not value:
+                updates[key] = decoded
+        return updates
+
     def resolved_for_run(
         self,
         state: State,
         *,
         config: Mapping[str, Any] | None = None,
     ) -> Self:
-        """Return a copy with templates resolved for the current invocation."""
-        runnable = cast(Self, self.model_copy())
-        runnable.decode_variables(state, config=config)
-        return runnable
+        """Return a copy with templates resolved for the current invocation.
+
+        Uses copy-on-write: avoids the ``model_copy()`` allocation when no
+        field values actually changed during template resolution.
+        """
+        del config
+        changed = self._compute_run_updates(state)
+        if not changed:
+            return self
+        return cast(Self, self.model_copy(update=changed))
 
 
 class BaseNode(BaseRunnable):

--- a/src/orcheo/nodes/rss.py
+++ b/src/orcheo/nodes/rss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import datetime
+from email.utils import parsedate_to_datetime
 from typing import Any
 from xml.etree import ElementTree
 import httpx
@@ -82,6 +83,31 @@ class RSSNode(TaskNode):
                 return text
         return fallback_href
 
+    @staticmethod
+    def _normalize_date(raw: str) -> str:
+        """Normalize an RSS/Atom date string to UTC ISO 8601.
+
+        Handles RFC 2822 (RSS 2.0) and ISO 8601 (Atom) formats.
+        Returns an empty string when the date cannot be parsed.
+        """
+        if not raw:
+            return ""
+        # RFC 2822 – used by RSS 2.0 <pubDate>
+        try:
+            dt = parsedate_to_datetime(raw)
+            return dt.astimezone(datetime.UTC).isoformat()
+        except (ValueError, TypeError):
+            pass
+        # ISO 8601 – used by Atom <published>/<updated>
+        try:
+            dt = datetime.datetime.fromisoformat(raw)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.UTC)
+            return dt.astimezone(datetime.UTC).isoformat()
+        except ValueError:
+            pass
+        return ""
+
     @classmethod
     def _parse_items(cls, body: str) -> list[dict[str, str]]:
         """Parse RSS/Atom items from an XML body."""
@@ -108,6 +134,7 @@ class RSSNode(TaskNode):
                     "link": link,
                     "description": description,
                     "pubDate": pub_date,
+                    "isoDate": cls._normalize_date(pub_date),
                 }
             )
         return items
@@ -146,6 +173,7 @@ class RSSNode(TaskNode):
                     "link": item.get("link", ""),
                     "description": item.get("description", ""),
                     "pubDate": item.get("pubDate", ""),
+                    "isoDate": item.get("isoDate", ""),
                     "source": url,
                     "read": False,
                     "fetched_at": now_iso,

--- a/src/orcheo/nodes/telegram.py
+++ b/src/orcheo/nodes/telegram.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 from typing import Any
+from langchain_core.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 from telegram import Bot
@@ -264,6 +265,18 @@ class TelegramEventsParserNode(TaskNode):
             "message_id": msg.get("message_id"),
             "should_process": should_process,
         }
+
+    async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Execute the node and inject user text as a HumanMessage into state."""
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
+        serialized = runnable._serialize_result(result)
+        output: dict[str, Any] = {"results": {self.name: serialized}}
+        if isinstance(serialized, dict) and serialized.get("should_process"):
+            text = serialized.get("text", "")
+            if isinstance(text, str) and text.strip():
+                output["messages"] = [HumanMessage(content=text)]
+        return output
 
 
 __all__ = ["MessageTelegram", "TelegramEventsParserNode", "escape_markdown"]

--- a/src/orcheo/nodes/wecom.py
+++ b/src/orcheo/nodes/wecom.py
@@ -506,9 +506,9 @@ class WeComEventsParserNode(TaskNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and merge agent messages into state."""
-        self.decode_variables(state, config=config)
-        result = await self.run(state, config)
-        serialized = self._serialize_result(result)
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
+        serialized = runnable._serialize_result(result)
         output: dict[str, Any] = {"results": {self.name: serialized}}
         if isinstance(serialized, dict):  # pragma: no branch
             agent_messages = serialized.pop("agent_messages", None)
@@ -1570,7 +1570,7 @@ async def _close_cs_redis_client(redis_client: redis.Redis | None) -> None:
     if redis_client is None:
         return
     try:
-        await redis_client.close()
+        await redis_client.aclose()
     except redis.RedisError:
         return
 
@@ -1935,9 +1935,9 @@ class WeComCustomerServiceSyncNode(TaskNode):
 
     async def __call__(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Execute the node and merge agent messages into state."""
-        self.decode_variables(state, config=config)
-        result = await self.run(state, config)
-        serialized = self._serialize_result(result)
+        runnable = self.resolved_for_run(state, config=config)
+        result = await runnable.run(state, config)
+        serialized = runnable._serialize_result(result)
         output: dict[str, Any] = {"results": {self.name: serialized}}
         if isinstance(serialized, dict):  # pragma: no branch
             agent_messages = serialized.pop("agent_messages", None)
@@ -1974,6 +1974,32 @@ class WeComCustomerServiceSendNode(TaskNode):
     )
     message: str = Field(description="Message content to send")
     msg_type: str = Field(default="text", description="Message type (text only)")
+    raise_on_error: bool = Field(
+        default=False,
+        description="Raise ValueError when send fails instead of returning is_error",
+    )
+
+    def _error_result(
+        self,
+        *,
+        error: str | None = None,
+        errcode: int | None = None,
+        errmsg: str | None = None,
+    ) -> dict[str, Any]:
+        """Return a structured error result or raise when configured."""
+        result: dict[str, Any] = {"is_error": True}
+        if error is not None:
+            result["error"] = error
+        if errcode is not None:
+            result["errcode"] = errcode
+        if errmsg is not None:
+            result["errmsg"] = errmsg
+
+        if self.raise_on_error:
+            detail = error or errmsg or "Unknown error"
+            raise ValueError(f"WeCom customer service send failed: {detail}")
+
+        return result
 
     async def send_message(
         self,
@@ -2011,11 +2037,10 @@ class WeComCustomerServiceSendNode(TaskNode):
                     "external_userid": external_userid,
                 },
             )
-            return {
-                "is_error": True,
-                "errcode": errcode,
-                "errmsg": data.get("errmsg", "Unknown error"),
-            }
+            return self._error_result(
+                errcode=errcode,
+                errmsg=data.get("errmsg", "Unknown error"),
+            )
 
         logger.info(
             "WeCom CS message delivered",
@@ -2067,7 +2092,7 @@ class WeComCustomerServiceSendNode(TaskNode):
             )
         finally:
             if redis_client is not None:  # pragma: no branch
-                await redis_client.close()
+                await redis_client.aclose()
         return {
             "is_error": False,
             "errcode": 0,
@@ -2100,7 +2125,7 @@ class WeComCustomerServiceSendNode(TaskNode):
                     "reason": "missing_access_token",
                 },
             )
-            return {"is_error": True, "error": "No access token available"}
+            return self._error_result(error="No access token available")
 
         open_kf_id = (
             self.open_kf_id
@@ -2118,7 +2143,7 @@ class WeComCustomerServiceSendNode(TaskNode):
                     "reason": "missing_open_kf_id",
                 },
             )
-            return {"is_error": True, "error": "No open_kf_id provided"}
+            return self._error_result(error="No open_kf_id provided")
 
         if not external_userid:
             logger.warning(
@@ -2129,7 +2154,7 @@ class WeComCustomerServiceSendNode(TaskNode):
                     "reason": "missing_external_userid",
                 },
             )
-            return {"is_error": True, "error": "No external_userid provided"}
+            return self._error_result(error="No external_userid provided")
 
         payload: dict[str, Any] = {
             "touser": external_userid,

--- a/src/orcheo/triggers/cron.py
+++ b/src/orcheo/triggers/cron.py
@@ -137,6 +137,36 @@ class CronTriggerConfig(BaseModel):
             raise CronValidationError(msg)
         return self
 
+    _HIGH_FREQUENCY_THRESHOLD_SECONDS = 300  # 5 minutes
+
+    @model_validator(mode="after")
+    def _validate_overlap_frequency(self) -> CronTriggerConfig:
+        """Reject allow_overlapping=False with high-frequency schedules.
+
+        Cron expressions that fire more often than every 5 minutes are almost
+        certainly misconfigured when combined with overlap protection, as any
+        run exceeding the interval will permanently block future dispatches.
+        """
+        if self.allow_overlapping:
+            return self
+        try:
+            it = croniter(self.expression)
+            first = it.get_next(datetime)
+            second = it.get_next(datetime)
+            interval = (second - first).total_seconds()
+        except Exception:
+            return self
+        if interval < self._HIGH_FREQUENCY_THRESHOLD_SECONDS:
+            msg = (
+                f"Cron expression '{self.expression}' fires every "
+                f"{int(interval)}s, but allow_overlapping is disabled. "
+                f"This risks permanently blocking the schedule. Either "
+                f"increase the interval to at least 5 minutes or set "
+                f"allow_overlapping to true."
+            )
+            raise CronValidationError(msg)
+        return self
+
     def timezone_info(self) -> ZoneInfo:
         """Return the ZoneInfo instance for the configured timezone."""
         return ZoneInfo(self.timezone)

--- a/tests/backend/repository/test_postgres_repository.py
+++ b/tests/backend/repository/test_postgres_repository.py
@@ -1095,9 +1095,9 @@ async def test_hydrate_trigger_state(monkeypatch: pytest.MonkeyPatch) -> None:
     w_id = uuid4()
     retry_conf = RetryPolicyConfig(max_attempts=5).model_dump(mode="json")
     webhook_conf = WebhookTriggerConfig(allowed_methods={"GET"}).model_dump(mode="json")
-    cron_conf = CronTriggerConfig(expression="* * * * *", timezone="UTC").model_dump(
-        mode="json"
-    )
+    cron_conf = CronTriggerConfig(
+        expression="* * * * *", timezone="UTC", allow_overlapping=True
+    ).model_dump(mode="json")
 
     # We need to skip schema exec in _ensure_initialized implicitly by mocking
     # _connection to consume schema statements
@@ -1162,7 +1162,9 @@ async def test_refresh_cron_triggers_sync(monkeypatch: pytest.MonkeyPatch) -> No
     assert w_id not in repo._trigger_layer._cron_states
 
     # 1. Add cron
-    cron_conf = CronTriggerConfig(expression="* * * * *", timezone="UTC")
+    cron_conf = CronTriggerConfig(
+        expression="* * * * *", timezone="UTC", allow_overlapping=True
+    )
     responses = [
         {
             "rows": [

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -1222,9 +1222,9 @@ async def test_hydrate_trigger_state_with_cron_run(
     """Test _hydrate_trigger_state registers runs triggered by cron."""
     w_id = uuid4()
     run_id = uuid4()
-    cron_conf = CronTriggerConfig(expression="* * * * *", timezone="UTC").model_dump(
-        mode="json"
-    )
+    cron_conf = CronTriggerConfig(
+        expression="* * * * *", timezone="UTC", allow_overlapping=True
+    ).model_dump(mode="json")
 
     class SmartFakeConnection:
         def __init__(self) -> None:
@@ -1426,7 +1426,9 @@ async def test_triggers_dispatch_due_cron_runs_with_naive_datetime(
     version_payload = _version_payload(version_id, workflow_id)
 
     repo = make_repository(monkeypatch, [])
-    config = CronTriggerConfig(expression="* * * * *", timezone="UTC")
+    config = CronTriggerConfig(
+        expression="* * * * *", timezone="UTC", allow_overlapping=True
+    )
     repo._trigger_layer.configure_cron(workflow_id, config)
 
     # Mock to return version
@@ -1484,7 +1486,9 @@ async def test_triggers_dispatch_due_cron_runs_enqueues_runs(
     version_payload = _version_payload(version_id, workflow_id)
 
     repo = make_repository(monkeypatch, [])
-    config = CronTriggerConfig(expression="* * * * *", timezone="UTC")
+    config = CronTriggerConfig(
+        expression="* * * * *", timezone="UTC", allow_overlapping=True
+    )
     repo._trigger_layer.configure_cron(workflow_id, config)
 
     version = WorkflowVersion.model_validate(version_payload)

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -1695,3 +1695,162 @@ async def test_triggers_dispatch_manual_runs_success(
     assert len(runs) == 1
     assert runs[0].id == run_id
     assert mock_enqueue.called
+
+
+@pytest.mark.asyncio
+async def test_hydrate_trigger_state_non_cron_run_skips_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-cron triggered runs are tracked but not registered in the cron overlap set.
+
+    This exercises the False branch of the 'triggered_by == cron' condition inside
+    _hydrate_trigger_state (line 320->315 in coverage terms).
+    """
+    w_id = uuid4()
+    run_id = uuid4()
+    cron_conf = CronTriggerConfig(expression="0 9 * * *", timezone="UTC").model_dump(
+        mode="json"
+    )
+
+    class SmartFakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[tuple[str, Any]] = []
+            self.commits = 0
+            self.rollbacks = 0
+
+        async def execute(self, query: str, params: Any = None) -> FakeCursor:
+            self.queries.append((query, params))
+            if "information_schema.columns" in query:
+                return FakeCursor(rows=[])
+            if "FROM cron_triggers" in query:
+                return FakeCursor(
+                    rows=[
+                        {
+                            "workflow_id": str(w_id),
+                            "config": cron_conf,
+                            "last_dispatched_at": None,
+                        }
+                    ]
+                )
+            if "workflow_runs" in query and "status" in query:
+                # Return a webhook-triggered (non-cron) PENDING run
+                return FakeCursor(
+                    rows=[
+                        {
+                            "id": str(run_id),
+                            "workflow_id": str(w_id),
+                            "triggered_by": "webhook",
+                            "status": "pending",
+                        }
+                    ]
+                )
+            return FakeCursor(rows=[])
+
+        async def commit(self) -> None:
+            self.commits += 1
+
+        async def rollback(self) -> None:
+            self.rollbacks += 1
+
+        async def __aenter__(self) -> SmartFakeConnection:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+    repo = make_repository(monkeypatch, [], initialized=False)
+    repo._pool = FakePool(SmartFakeConnection())  # type: ignore[arg-type]
+    repo._initialized = False
+
+    await repo._ensure_initialized()
+
+    # The run should be tracked but NOT in the cron overlap registry
+    assert run_id in repo._trigger_layer._run_workflows  # noqa: SLF001
+    assert run_id not in repo._trigger_layer._cron_run_index  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_hydrate_trigger_state_cron_overlap_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two non-failed cron runs with allow_overlapping=False logs a warning.
+
+    When the second register_cron_run raises CronOverlapError during hydration
+    the exception is caught and a warning is emitted (lines 326-327 in coverage).
+    """
+    import logging
+
+    w_id = uuid4()
+    run_id_1 = uuid4()
+    run_id_2 = uuid4()
+    cron_conf = CronTriggerConfig(
+        expression="0 9 * * *", timezone="UTC", allow_overlapping=False
+    ).model_dump(mode="json")
+
+    class SmartFakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[tuple[str, Any]] = []
+            self.commits = 0
+            self.rollbacks = 0
+
+        async def execute(self, query: str, params: Any = None) -> FakeCursor:
+            self.queries.append((query, params))
+            if "information_schema.columns" in query:
+                return FakeCursor(rows=[])
+            if "FROM cron_triggers" in query:
+                return FakeCursor(
+                    rows=[
+                        {
+                            "workflow_id": str(w_id),
+                            "config": cron_conf,
+                            "last_dispatched_at": None,
+                        }
+                    ]
+                )
+            if "workflow_runs" in query and "status" in query:
+                # Two PENDING cron runs for the same workflow
+                return FakeCursor(
+                    rows=[
+                        {
+                            "id": str(run_id_1),
+                            "workflow_id": str(w_id),
+                            "triggered_by": "cron",
+                            "status": "pending",
+                        },
+                        {
+                            "id": str(run_id_2),
+                            "workflow_id": str(w_id),
+                            "triggered_by": "cron",
+                            "status": "pending",
+                        },
+                    ]
+                )
+            return FakeCursor(rows=[])
+
+        async def commit(self) -> None:
+            self.commits += 1
+
+        async def rollback(self) -> None:
+            self.rollbacks += 1
+
+        async def __aenter__(self) -> SmartFakeConnection:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+    repo = make_repository(monkeypatch, [], initialized=False)
+    repo._pool = FakePool(SmartFakeConnection())  # type: ignore[arg-type]
+    repo._initialized = False
+
+    with caplog.at_level(logging.WARNING):
+        await repo._ensure_initialized()
+
+    assert any(
+        "Skipped cron overlap registration" in record.message
+        for record in caplog.records
+    )
+    # First run should be registered; second skipped due to overlap
+    assert run_id_1 in repo._trigger_layer._cron_run_index  # noqa: SLF001
+    assert run_id_2 not in repo._trigger_layer._cron_run_index  # noqa: SLF001

--- a/tests/backend/repository/test_sqlite_repository.py
+++ b/tests/backend/repository/test_sqlite_repository.py
@@ -732,3 +732,80 @@ async def test_sqlite_revoke_archived_workflow_raises_not_found(
             await repository.revoke_publish(workflow.id, actor="author")
     finally:
         await repository.reset()
+
+
+@pytest.mark.asyncio()
+async def test_sqlite_hydrate_cron_overlap_logs_warning(
+    tmp_path_factory: pytest.TempPathFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When two non-failed cron runs exist with allow_overlapping=False the second
+    register_cron_run call raises and the warning is logged during hydration."""
+    import json
+    import logging
+    from uuid import uuid4
+
+    db_path = tmp_path_factory.mktemp("repo") / "overlap-hydrate.sqlite"
+    repository = SqliteWorkflowRepository(db_path)
+
+    try:
+        workflow = await repository.create_workflow(
+            name="Overlap Hydrate",
+            slug=None,
+            description=None,
+            tags=None,
+            actor="author",
+        )
+        version = await repository.create_version(
+            workflow.id,
+            graph={},
+            metadata={},
+            notes=None,
+            created_by="author",
+        )
+        await repository.configure_cron_trigger(
+            workflow.id,
+            CronTriggerConfig(expression="0 9 * * *", timezone="UTC"),
+        )
+
+        now = datetime(2025, 1, 1, 9, 0, tzinfo=UTC)
+        now_str = now.isoformat()
+        run_id_1 = uuid4()
+        run_id_2 = uuid4()
+
+        # Insert two pending cron-triggered runs directly to bypass dispatch logic
+        async with repository._connection() as conn:
+            for run_id in (run_id_1, run_id_2):
+                await conn.execute(
+                    """
+                    INSERT INTO workflow_runs
+                        (id, workflow_id, workflow_version_id, status,
+                         triggered_by, payload, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(run_id),
+                        str(workflow.id),
+                        str(version.id),
+                        "pending",
+                        "cron",
+                        json.dumps({}),
+                        now_str,
+                        now_str,
+                    ),
+                )
+
+        # Create a fresh repository on the same DB so hydration runs from scratch
+        fresh_repository = SqliteWorkflowRepository(db_path)
+        try:
+            with caplog.at_level(logging.WARNING):
+                await fresh_repository._ensure_initialized()
+
+            assert any(
+                "Skipped cron overlap registration" in record.message
+                for record in caplog.records
+            )
+        finally:
+            await fresh_repository.reset()
+    finally:
+        await repository.reset()

--- a/tests/backend/repository/test_sqlite_repository.py
+++ b/tests/backend/repository/test_sqlite_repository.py
@@ -257,7 +257,9 @@ async def test_sqlite_cron_dispatch_reflects_external_unschedule(
         )
         await api_repository.configure_cron_trigger(
             workflow.id,
-            CronTriggerConfig(expression="* * * * *", timezone="UTC"),
+            CronTriggerConfig(
+                expression="* * * * *", timezone="UTC", allow_overlapping=True
+            ),
         )
 
         first_runs = await worker_repository.dispatch_due_cron_runs(

--- a/tests/edges/test_if_else.py
+++ b/tests/edges/test_if_else.py
@@ -144,3 +144,28 @@ async def test_if_else_node_with_and_logic_all_fail() -> None:
     result = await node(state, RunnableConfig())
 
     assert result == "false"
+
+
+@pytest.mark.asyncio
+async def test_if_else_re_resolves_templates_per_invocation() -> None:
+    node = IfElse(
+        name="condition",
+        conditions=[
+            {
+                "left": "{{loop.done}}",
+                "operator": "is_falsy",
+            }
+        ],
+    )
+
+    first = await node(
+        State({"results": {"loop": {"done": False}}}),
+        RunnableConfig(),
+    )
+    second = await node(
+        State({"results": {"loop": {"done": True}}}),
+        RunnableConfig(),
+    )
+
+    assert first == "true"
+    assert second == "false"

--- a/tests/nodes/test_agent_tools_helpers.py
+++ b/tests/nodes/test_agent_tools_helpers.py
@@ -12,8 +12,9 @@ async def test_run_mongodb_node_uses_active_config(monkeypatch) -> None:
     captured: dict[str, RunnableConfig | None] = {}
 
     class FakeNode:
-        def decode_variables(self, state, config=None):  # type: ignore[no-untyped-def]
-            captured["decode_config"] = config
+        def resolved_for_run(self, state, config=None):  # type: ignore[no-untyped-def]
+            captured["resolved_config"] = config
+            return self
 
         async def run(self, state, config):  # type: ignore[no-untyped-def]
             captured["run_config"] = config
@@ -30,7 +31,7 @@ async def test_run_mongodb_node_uses_active_config(monkeypatch) -> None:
 
     result = await tools._run_mongodb_node(FakeNode())
     assert result == {"ok": True}
-    assert captured["decode_config"] is config
+    assert captured["resolved_config"] is config
     assert captured["run_config"] is config
     assert called.get("requested")
 

--- a/tests/nodes/test_ai_agent_node_prompt_handling.py
+++ b/tests/nodes/test_ai_agent_node_prompt_handling.py
@@ -107,3 +107,30 @@ def test_decode_variables_interpolates_mixed_system_prompt_templates() -> None:
     node.decode_variables(state)
 
     assert node.system_prompt == "internal=alice external=wxid_42"
+
+
+def test_compute_run_updates_skips_deferred_fields_and_decodes_others() -> None:
+    """_compute_run_updates omits history_key_template/candidates and resolves
+    other template fields such as system_prompt (lines 201-208)."""
+    node = AgentNode(
+        name="agent",
+        ai_model="test-model",
+        # history_key_template contains {{ so stays as str, but is deferred
+        history_key_template="{{inputs.ctx}}",
+        # system_prompt also contains {{ so stays as str, and is NOT deferred
+        system_prompt="user:{{inputs.ctx}}",
+    )
+    state = State(
+        {
+            "inputs": {"ctx": "my-ctx"},
+            "results": {},
+        }
+    )
+
+    updates = node._compute_run_updates(state)
+
+    # Deferred fields must not appear in updates
+    assert "history_key_template" not in updates
+    assert "history_key_candidates" not in updates
+    # Non-deferred template field is decoded
+    assert updates.get("system_prompt") == "user:my-ctx"

--- a/tests/nodes/test_base_ai_node.py
+++ b/tests/nodes/test_base_ai_node.py
@@ -27,3 +27,21 @@ async def test_ai_node_call() -> None:
     result = await node(state, config)
 
     assert result == {"messages": {"result": "test_value"}}
+
+
+@pytest.mark.asyncio
+async def test_ai_node_call_re_resolves_templates_per_invocation() -> None:
+    node = MockAINode(name="test_ai", input_var="{{payload.value}}")
+
+    first = await node(
+        State({"results": {"payload": {"value": "first"}}}),
+        RunnableConfig(),
+    )
+    second = await node(
+        State({"results": {"payload": {"value": "second"}}}),
+        RunnableConfig(),
+    )
+
+    assert first == {"messages": {"result": "first"}}
+    assert second == {"messages": {"result": "second"}}
+    assert node.input_var == "{{payload.value}}"

--- a/tests/nodes/test_base_task_node.py
+++ b/tests/nodes/test_base_task_node.py
@@ -216,3 +216,21 @@ async def test_task_node_call() -> None:
 
     result = await node(state, config)
     assert result == {"results": {"test_task": {"result": "test_value"}}}
+
+
+@pytest.mark.asyncio
+async def test_task_node_call_re_resolves_templates_per_invocation() -> None:
+    node = MockTaskNode(name="test_task", input_var="{{payload.value}}")
+
+    first = await node(
+        State({"results": {"payload": {"value": "first"}}}),
+        RunnableConfig(),
+    )
+    second = await node(
+        State({"results": {"payload": {"value": "second"}}}),
+        RunnableConfig(),
+    )
+
+    assert first == {"results": {"test_task": {"result": "first"}}}
+    assert second == {"results": {"test_task": {"result": "second"}}}
+    assert node.input_var == "{{payload.value}}"

--- a/tests/nodes/test_logic_set_variable_node.py
+++ b/tests/nodes/test_logic_set_variable_node.py
@@ -197,6 +197,24 @@ async def test_for_loop_node_raw_index_none() -> None:
     assert result["index"] == 1
 
 
+@pytest.mark.asyncio
+async def test_for_loop_node_re_resolves_templated_items_per_invocation() -> None:
+    """Templated item sources should be resolved fresh for each invocation."""
+    node = ForLoopNode(name="loop", items="{{source.items}}")
+
+    first = await node(
+        State({"results": {"source": {"items": ["a"]}}}),
+        RunnableConfig(),
+    )
+    second = await node(
+        State({"results": {"source": {"items": ["b"]}}}),
+        RunnableConfig(),
+    )
+
+    assert first["results"]["loop"]["current_item"] == "a"
+    assert second["results"]["loop"]["current_item"] == "b"
+
+
 def test_build_nested_empty_path_raises() -> None:
     """An empty path string raises ValueError."""
     with pytest.raises(ValueError, match="non-empty string"):

--- a/tests/nodes/test_rss.py
+++ b/tests/nodes/test_rss.py
@@ -260,3 +260,28 @@ def test_extract_link_second_non_alternate_href_skips_overwrite() -> None:
     )
     result = RSSNode._extract_link(parent)
     assert result == "https://example.com/first"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_date – targeting uncovered lines 98, 105, 107-109
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_date_rfc2822_returns_utc_iso() -> None:
+    """_normalize_date converts a valid RFC 2822 date to UTC ISO 8601 (line 98)."""
+    raw = "Mon, 15 Jan 2024 10:00:00 +0000"
+    result = RSSNode._normalize_date(raw)
+    assert result == "2024-01-15T10:00:00+00:00"
+
+
+def test_normalize_date_naive_iso_datetime_gains_utc() -> None:
+    """_normalize_date adds UTC to a naive ISO 8601 datetime (line 105)."""
+    raw = "2024-01-15T10:00:00"  # no timezone suffix
+    result = RSSNode._normalize_date(raw)
+    assert result == "2024-01-15T10:00:00+00:00"
+
+
+def test_normalize_date_invalid_string_returns_empty() -> None:
+    """_normalize_date returns empty string when both parsers fail (lines 107-109)."""
+    result = RSSNode._normalize_date("not-a-date")
+    assert result == ""

--- a/tests/nodes/test_telegram.py
+++ b/tests/nodes/test_telegram.py
@@ -499,3 +499,25 @@ async def test_parser_run_username_fallback_to_username_field() -> None:
     payload = result["results"]["parser"]
 
     assert payload["username"] == "alice_bot"
+
+
+@pytest.mark.asyncio
+async def test_parser_run_whitespace_text_does_not_inject_message() -> None:
+    """should_process=True but whitespace-only text skips HumanMessage injection."""
+    # Whitespace text is truthy so bool(chat_id and text) is True, but text.strip()
+    # returns "" which is falsy – the 'messages' key must NOT appear in the output.
+    state = _message_state(
+        body={
+            "message": {
+                "message_id": 1,
+                "from": {"id": 1, "first_name": "Alice"},
+                "chat": {"id": 5, "type": "private"},
+                "text": "   ",
+            }
+        }
+    )
+    node = _make_parser()
+    result = await node(state, None)
+
+    assert "messages" not in result
+    assert result["results"]["parser"]["should_process"] is True

--- a/tests/nodes/test_wecom.py
+++ b/tests/nodes/test_wecom.py
@@ -1826,6 +1826,45 @@ class TestWeComCustomerServiceSendNode:
         assert result["errmsg"] == "invalid external_userid"
 
     @pytest.mark.asyncio
+    async def test_send_message_api_error_raises_when_configured(
+        self, patch_redis: FakeRedis
+    ) -> None:
+        """Opt-in strict mode raises instead of returning an error result."""
+        node = WeComCustomerServiceSendNode(
+            name="wecom_cs_send",
+            open_kf_id="wkABC123",
+            external_userid="wmXYZ789",
+            message="Hello!",
+            raise_on_error=True,
+        )
+
+        state = State(
+            messages=[],
+            inputs={},
+            results={
+                "get_access_token": {
+                    "access_token": "test_token",
+                    "expires_in": 7200,
+                },
+            },
+        )
+
+        send_response = MagicMock()
+        send_response.json.return_value = {
+            "errcode": 95017,
+            "errmsg": "invalid external_userid",
+        }
+        send_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=send_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("orcheo.nodes.wecom.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(ValueError, match="WeCom customer service send failed"):
+                await node.run(state, RunnableConfig())
+
+    @pytest.mark.asyncio
     async def test_send_non_text_message_falls_back_to_text(
         self, patch_redis: FakeRedis
     ) -> None:

--- a/tests/nodes/test_wecom.py
+++ b/tests/nodes/test_wecom.py
@@ -180,7 +180,7 @@ class FakeRedis:
                 zset.pop(member, None)
         return removed
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         return None
 
 
@@ -2012,14 +2012,14 @@ class TestWeComCustomerServiceSendNode:
         mock_client.aclose = AsyncMock()
 
         fake_redis = AsyncMock()
-        fake_redis.close = AsyncMock()
+        fake_redis.aclose = AsyncMock()
 
         with patch("orcheo.nodes.wecom.httpx.AsyncClient", return_value=mock_client):
             with patch("redis.asyncio.from_url", return_value=fake_redis):
                 result = await node.run(state, RunnableConfig())
 
         assert result["is_error"] is False
-        fake_redis.close.assert_awaited_once()
+        fake_redis.aclose.assert_awaited_once()
 
 
 # get_access_token_from_state tests
@@ -2329,7 +2329,7 @@ class TestWeComHelperFunctions:
     @pytest.mark.asyncio
     async def test_close_cs_redis_client_ignores_errors(self):
         class Dummy:
-            async def close(self) -> None:
+            async def aclose(self) -> None:
                 raise redis.RedisError("boom")
 
         await _close_cs_redis_client(Dummy())

--- a/tests/sdk/test_cli_workflow_upload_managing.py
+++ b/tests/sdk/test_cli_workflow_upload_managing.py
@@ -1,0 +1,164 @@
+"""Upload workflow command tests for cron sync branches in managing.py."""
+
+from __future__ import annotations
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+from orcheo_sdk.cli.config import CLISettings
+from orcheo_sdk.cli.state import CLIState
+from orcheo_sdk.cli.workflow.commands import managing
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class _FakeContext:
+    def __init__(self, state: CLIState) -> None:
+        self._state = state
+
+    def ensure_object(self, _obj_type: type) -> CLIState:
+        return self._state
+
+
+def _make_state(*, offline: bool = False, human: bool = True) -> CLIState:
+    settings = CLISettings(
+        api_url="http://api",
+        service_token=None,
+        profile="default",
+        offline=offline,
+    )
+    return CLIState(
+        settings=settings,
+        client=SimpleNamespace(),  # type: ignore[arg-type]
+        cache=SimpleNamespace(),  # type: ignore[arg-type]
+        console=_FakeConsole(),  # type: ignore[arg-type]
+        human=human,
+    )
+
+
+def _context(state: CLIState) -> _FakeContext:
+    return _FakeContext(state)
+
+
+def test_upload_workflow_no_resolved_id_skips_cron_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When upload returns no id and workflow_id is None, cron sync is skipped."""
+    cron_sync_called: list[bool] = []
+
+    monkeypatch.setattr(
+        managing,
+        "upload_workflow_data",
+        lambda *_args, **_kwargs: {},  # no "id" key → resolved_id is None
+    )
+    monkeypatch.setattr(
+        managing,
+        "sync_cron_schedule_if_changed",
+        lambda *_args, **_kwargs: cron_sync_called.append(True) or {},
+    )
+    monkeypatch.setattr(
+        managing,
+        "render_json",
+        lambda *_args, **_kwargs: None,
+    )
+
+    state = _make_state()
+    ctx = _context(state)
+    py_file = tmp_path / "wf.py"
+    py_file.write_text("# empty", encoding="utf-8")
+
+    managing.upload_workflow(ctx, py_file)
+
+    # Cron sync must not be invoked when resolved_id is falsy (branch 99->105)
+    assert not cron_sync_called
+    # identifier falls back to "workflow" when resolved_id is None
+    assert any("workflow" in msg for msg in state.console.messages)
+
+
+def test_upload_workflow_machine_mode_includes_cron_schedule_when_updated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Machine mode upload includes cron_schedule in output when cron was updated."""
+    monkeypatch.setattr(
+        managing,
+        "upload_workflow_data",
+        lambda *_args, **_kwargs: {"id": "wf-1", "name": "my-wf"},
+    )
+    monkeypatch.setattr(
+        managing,
+        "sync_cron_schedule_if_changed",
+        lambda *_args, **_kwargs: {
+            "status": "updated",
+            "message": "Cron schedule updated for workflow 'wf-1'.",
+            "config": {"expression": "0 * * * *"},
+        },
+    )
+    printed: list[dict[str, object]] = []
+    monkeypatch.setattr(managing, "print_json", lambda data: printed.append(data))
+
+    state = _make_state(human=False)
+    ctx = _context(state)
+    py_file = tmp_path / "wf.py"
+    py_file.write_text("# empty", encoding="utf-8")
+
+    managing.upload_workflow(ctx, py_file)
+
+    # Line 107: result["cron_schedule"] = cron_sync is set before print_json
+    assert len(printed) == 1
+    output = printed[0]
+    assert output["id"] == "wf-1"
+    assert "cron_schedule" in output
+    assert output["cron_schedule"]["status"] == "updated"  # type: ignore[index]
+
+
+def test_upload_workflow_human_mode_prints_cron_message_when_updated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Human mode upload prints cron update message and renders config."""
+    monkeypatch.setattr(
+        managing,
+        "upload_workflow_data",
+        lambda *_args, **_kwargs: {"id": "wf-1", "name": "my-wf"},
+    )
+    monkeypatch.setattr(
+        managing,
+        "sync_cron_schedule_if_changed",
+        lambda *_args, **_kwargs: {
+            "status": "updated",
+            "message": "Cron schedule updated for workflow 'wf-1'.",
+            "config": {"expression": "0 * * * *"},
+        },
+    )
+    render_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        managing,
+        "render_json",
+        lambda _console, payload, *, title=None: render_calls.append(
+            {"payload": payload, "title": title}
+        ),
+    )
+
+    state = _make_state(human=True)
+    ctx = _context(state)
+    py_file = tmp_path / "wf.py"
+    py_file.write_text("# empty", encoding="utf-8")
+
+    managing.upload_workflow(ctx, py_file)
+
+    # Line 116: cron message is printed in green
+    cron_messages = [m for m in state.console.messages if "Cron schedule updated" in m]
+    assert len(cron_messages) == 1
+    assert "[green]" in cron_messages[0]
+
+    # Line 117: cron config is rendered under "Cron trigger" title
+    cron_renders = [c for c in render_calls if c.get("title") == "Cron trigger"]
+    assert len(cron_renders) == 1
+    assert cron_renders[0]["payload"] == {"expression": "0 * * * *"}

--- a/tests/sdk/test_services_workflows_scheduling.py
+++ b/tests/sdk/test_services_workflows_scheduling.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from orcheo.graph.ingestion.config import LANGGRAPH_SCRIPT_FORMAT
 from orcheo.triggers.cron import CronTriggerConfig
-from orcheo_sdk.cli.errors import CLIError
+from orcheo_sdk.cli.errors import APICallError, CLIError
 from orcheo_sdk.services.workflows import scheduling
 
 
@@ -41,7 +41,7 @@ def test_schedule_workflow_cron_configures_trigger(
                 {
                     "name": "cron_trigger",
                     "type": "CronTriggerNode",
-                    "expression": "* * * * *",
+                    "expression": "*/5 * * * *",
                     "timezone": "UTC",
                     "allow_overlapping": False,
                     "start_at": None,
@@ -72,7 +72,7 @@ def test_schedule_workflow_cron_configures_trigger(
 
     assert result["status"] == "scheduled"
     assert captured["path"] == "/api/workflows/wf-123/triggers/cron/config"
-    assert captured["json_body"]["expression"] == "* * * * *"
+    assert captured["json_body"]["expression"] == "*/5 * * * *"
 
 
 def test_schedule_workflow_cron_rejects_multiple_triggers(
@@ -192,3 +192,148 @@ def test_extract_cron_config_uses_defaults_when_expression_and_timezone_blank() 
     assert config.expression == default_config.expression
     assert config.timezone == default_config.timezone
     assert config.allow_overlapping is False
+
+
+# ---------------------------------------------------------------------------
+# sync_cron_schedule_if_changed – lines 50-71
+# ---------------------------------------------------------------------------
+
+
+def test_sync_cron_schedule_noop_when_no_existing_schedule() -> None:
+    """Returns noop when no cron schedule exists (404 on GET)."""
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            raise APICallError("Not Found", status_code=404)
+
+    result = scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+    assert result == {"status": "noop", "reason": "no_existing_schedule"}
+
+
+def test_sync_cron_schedule_reraises_non_404_api_error() -> None:
+    """Re-raises APICallError when the status code is not 404."""
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            raise APICallError("Server Error", status_code=500)
+
+    with pytest.raises(APICallError, match="Server Error"):
+        scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+
+
+def test_sync_cron_schedule_noop_when_graph_not_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returns noop with no_graph reason when graph data is not a Mapping."""
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            return {"expression": "* * * * *"}
+
+    monkeypatch.setattr(
+        scheduling,
+        "get_latest_workflow_version_data",
+        lambda *_args, **_kwargs: {"graph": "not-a-map"},
+    )
+
+    result = scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+    assert result == {"status": "noop", "reason": "no_graph"}
+
+
+def test_sync_cron_schedule_noop_when_no_cron_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returns noop with no_cron_trigger reason when workflow has no cron node."""
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            return {"expression": "* * * * *"}
+
+    monkeypatch.setattr(
+        scheduling,
+        "get_latest_workflow_version_data",
+        lambda *_args, **_kwargs: {"graph": {"nodes": []}},
+    )
+
+    result = scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+    assert result == {"status": "noop", "reason": "no_cron_trigger"}
+
+
+def test_sync_cron_schedule_noop_when_config_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returns noop with unchanged reason when existing and new configs match."""
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            return {
+                "expression": "0 * * * *",
+                "timezone": "UTC",
+                "allow_overlapping": False,
+            }
+
+    monkeypatch.setattr(
+        scheduling,
+        "get_latest_workflow_version_data",
+        lambda *_args, **_kwargs: {
+            "graph": {
+                "nodes": [
+                    {
+                        "type": "CronTriggerNode",
+                        "expression": "0 * * * *",
+                        "timezone": "UTC",
+                        "allow_overlapping": False,
+                    }
+                ]
+            }
+        },
+    )
+
+    result = scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+    assert result == {"status": "noop", "reason": "unchanged"}
+
+
+def test_sync_cron_schedule_updates_when_config_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PUTs the new config and returns updated status when cron config differs."""
+    captured: dict[str, object] = {}
+
+    class _Client:
+        def get(self, _path: str) -> dict[str, object]:
+            return {
+                "expression": "0 * * * *",
+                "timezone": "UTC",
+                "allow_overlapping": False,
+            }
+
+        def put(
+            self, path: str, *, json_body: dict[str, object] | None = None
+        ) -> dict[str, object]:
+            captured["path"] = path
+            captured["json_body"] = json_body
+            return json_body or {}
+
+    monkeypatch.setattr(
+        scheduling,
+        "get_latest_workflow_version_data",
+        lambda *_args, **_kwargs: {
+            "graph": {
+                "nodes": [
+                    {
+                        "type": "CronTriggerNode",
+                        "expression": "*/30 * * * *",
+                        "timezone": "UTC",
+                        "allow_overlapping": False,
+                    }
+                ]
+            }
+        },
+    )
+
+    result = scheduling.sync_cron_schedule_if_changed(_Client(), "wf-123")
+
+    assert result["status"] == "updated"
+    assert "wf-123" in result["message"]
+    assert captured["path"] == "/api/workflows/wf-123/triggers/cron/config"
+    assert captured["json_body"]["expression"] == "*/30 * * * *"  # type: ignore[index]

--- a/tests/test_triggers_cron.py
+++ b/tests/test_triggers_cron.py
@@ -158,6 +158,30 @@ def test_cron_trigger_rejects_invalid_timezone() -> None:
         CronTriggerConfig(expression="0 * * * *", timezone="Mars/Phobos")
 
 
+def test_cron_trigger_rejects_high_frequency_without_overlap() -> None:
+    """High-frequency cron with allow_overlapping=False should be rejected."""
+
+    with pytest.raises(ValidationError) as exc:
+        CronTriggerConfig(expression="* * * * *", allow_overlapping=False)
+
+    assert "fires every 60s" in str(exc.value)
+    assert "allow_overlapping" in str(exc.value)
+
+
+def test_cron_trigger_allows_high_frequency_with_overlap() -> None:
+    """High-frequency cron with allow_overlapping=True should be accepted."""
+
+    config = CronTriggerConfig(expression="* * * * *", allow_overlapping=True)
+    assert config.expression == "* * * * *"
+
+
+def test_cron_trigger_allows_low_frequency_without_overlap() -> None:
+    """Low-frequency cron (>= 5 min) with allow_overlapping=False is fine."""
+
+    config = CronTriggerConfig(expression="0 9 * * *", allow_overlapping=False)
+    assert config.expression == "0 9 * * *"
+
+
 def test_cron_state_with_last_dispatched_at_computes_next_correctly() -> None:
     """When last_dispatched_at is provided, the next fire time is computed from it."""
     config = CronTriggerConfig(expression="0 9 * * *", timezone="UTC")

--- a/tests/test_triggers_cron.py
+++ b/tests/test_triggers_cron.py
@@ -277,3 +277,24 @@ def test_cron_state_with_start_at_and_last_dispatched_prefers_last_dispatched() 
     tomorrow_9am = datetime(2025, 1, 2, 9, 0, tzinfo=UTC)
     due_tomorrow = state.peek_due(now=tomorrow_9am)
     assert due_tomorrow == tomorrow_9am
+
+
+def test_cron_validate_overlap_frequency_exception_falls_back_gracefully() -> None:
+    """When croniter raises during interval calculation the validator returns self."""
+    from unittest.mock import MagicMock, patch
+
+    # Patch croniter so the first call (field_validator) succeeds but
+    # the second call (model_validator) raises an unexpected exception.
+    original_croniter_results = [MagicMock(), Exception("unexpected")]
+
+    def side_effect(*args: object, **kwargs: object) -> object:
+        result = original_croniter_results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    with patch("orcheo.triggers.cron.croniter", side_effect=side_effect):
+        # Should NOT raise – the except block returns self
+        config = CronTriggerConfig(expression="0 9 * * *", allow_overlapping=False)
+
+    assert config.expression == "0 9 * * *"

--- a/tests/triggers_layer/test_cron.py
+++ b/tests/triggers_layer/test_cron.py
@@ -92,7 +92,9 @@ def test_collect_due_cron_dispatches_skips_unhealthy_workflows() -> None:
     layer = TriggerLayer(health_guard=Guard())
     layer.configure_cron(
         workflow_id,
-        CronTriggerConfig(expression="* * * * *", timezone="UTC"),
+        CronTriggerConfig(
+            expression="* * * * *", timezone="UTC", allow_overlapping=True
+        ),
     )
 
     plans = layer.collect_due_cron_dispatches(now=datetime.now(tz=UTC))


### PR DESCRIPTION
## Summary

This PR fixes stateful template resolution bugs across nodes/edges and tightens cron scheduling behavior across the SDK and backend.

## What Changed

- Resolve runnable templates on per-invocation copies instead of mutating shared node/edge instances
- Update AI/task nodes, edges, agent-tool helpers, Telegram/WeCom parser nodes, and nested Pydantic decoding to use the new per-run resolution flow
- Preserve deferred history-key fields in `AgentNode` so they are resolved only by the dedicated history-key logic
- Add RSS `isoDate` normalization for RSS/Atom timestamps
- Inject Telegram user text into workflow state as a `HumanMessage` when an event should be processed
- Add optional strict error handling for WeCom customer service sends via `raise_on_error`
- Switch WeCom Redis cleanup to `aclose()`

## Cron Improvements

- Add validation to reject high-frequency cron schedules with `allow_overlapping=False`
- Make repository trigger hydration skip failed cron runs and tolerate overlap-registration conflicts during startup
- Add SDK support to auto-sync an existing cron trigger when a workflow upload changes its cron config
- Export the new cron sync service through the SDK service surface

## Tests

- Add regression coverage for re-resolving templated values across repeated node/edge invocations
- Add cron validation tests for overlap/frequency combinations
- Update repository and trigger-layer tests to use explicit overlapping where required
- Add WeCom strict-error-path coverage
