### PR TITLE
Add graph-store message append support and configurable WeCom timeouts

### DIFF
--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -39,7 +39,12 @@ from orcheo.nodes.mongodb import (
 )
 from orcheo.nodes.registry import NodeMetadata, NodeRegistry, registry
 from orcheo.nodes.slack import SlackEventsParserNode, SlackNode
-from orcheo.nodes.storage import PostgresNode, SQLiteNode
+from orcheo.nodes.storage import (
+    GraphStoreAppendMessageNode,
+    PostgresNode,
+    SQLiteNode,
+    get_graph_store,
+)
 from orcheo.nodes.sub_workflow import SubWorkflowNode
 from orcheo.nodes.telegram import MessageTelegram, TelegramEventsParserNode
 from orcheo.nodes.triggers import (
@@ -79,6 +84,8 @@ __all__ = [
     "MongoDBEnsureSearchIndexNode",
     "MongoDBEnsureVectorIndexNode",
     "MongoDBHybridSearchNode",
+    "GraphStoreAppendMessageNode",
+    "get_graph_store",
     "PostgresNode",
     "SQLiteNode",
     "SlackNode",

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -27,6 +27,7 @@ from orcheo.nodes.agent_tools.context import (
 from orcheo.nodes.agent_tools.registry import tool_registry
 from orcheo.nodes.base import AINode, TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.nodes.storage import get_graph_store as _get_graph_store_fn
 
 
 logger = logging.getLogger(__name__)
@@ -413,23 +414,7 @@ class AgentNode(AINode):
 
     def _get_graph_store(self, config: RunnableConfig | None) -> Any | None:
         """Return the runtime graph store when available."""
-        if not isinstance(config, Mapping):
-            return None
-        configurable = config.get("configurable", {})
-        if not isinstance(configurable, Mapping):
-            return None
-
-        runtime = configurable.get("__pregel_runtime")
-        if runtime is not None:
-            if isinstance(runtime, Mapping):
-                maybe_store = runtime.get("store")
-                if maybe_store is not None:
-                    return maybe_store
-            maybe_store = getattr(runtime, "store", None)
-            if maybe_store is not None:
-                return maybe_store
-
-        return configurable.get("__pregel_store")
+        return _get_graph_store_fn(config)
 
     def _history_namespace_tuple(self) -> tuple[str, ...]:
         namespace = tuple(

--- a/src/orcheo/nodes/storage.py
+++ b/src/orcheo/nodes/storage.py
@@ -245,9 +245,14 @@ class GraphStoreAppendMessageNode(TaskNode):
             value = item.get("value")
 
         if isinstance(value, dict):
-            value.setdefault("version", 0)
-            value.setdefault("messages", [])
-            return value
+            payload = dict(value)
+            version = payload.get("version", 0)
+            payload["version"] = version if isinstance(version, int | float) else 0
+
+            messages = payload.get("messages", [])
+            payload["messages"] = messages if isinstance(messages, list) else []
+
+            return payload
 
         return {"version": 0, "messages": []}
 
@@ -261,12 +266,21 @@ class GraphStoreAppendMessageNode(TaskNode):
             )
             return {"history_written": False}
 
-        key = (self.key or "").strip()
+        key_raw = self.key
+        if key_raw is None:
+            key = ""
+        elif isinstance(key_raw, str):
+            key = key_raw.strip()
+        elif isinstance(key_raw, int | float | bool):
+            key = str(key_raw).strip()
+        else:
+            key = ""
+
         if not key or "{{" in key or "}}" in key:
             logger.warning(
                 "GraphStoreAppendMessageNode '%s': invalid key after resolution: %r",
                 self.name,
-                key,
+                key_raw,
             )
             return {"history_written": False}
 

--- a/src/orcheo/nodes/storage.py
+++ b/src/orcheo/nodes/storage.py
@@ -1,7 +1,8 @@
-"""Storage nodes providing database access."""
+"""Storage nodes providing database access and graph store operations."""
 
 from __future__ import annotations
 import asyncio
+import logging
 import sqlite3
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -15,12 +16,43 @@ from orcheo.nodes.registry import NodeMetadata, registry
 if TYPE_CHECKING:
     pass
 
+logger = logging.getLogger(__name__)
+
 
 def _rows_to_dicts(
     columns: Sequence[str], rows: Sequence[Sequence[Any]]
 ) -> list[dict[str, Any]]:
     """Convert database rows into dictionaries keyed by column name."""
     return [dict(zip(columns, row, strict=False)) for row in rows]
+
+
+def get_graph_store(config: RunnableConfig | None) -> Any | None:
+    """Return the LangGraph runtime store from a :class:`RunnableConfig`.
+
+    Resolution order:
+
+    1. ``config["configurable"]["__pregel_runtime"].store`` (Mapping or attribute)
+    2. ``config["configurable"]["__pregel_store"]`` (direct fallback)
+
+    Returns ``None`` when no store is available.
+    """
+    if not isinstance(config, Mapping):
+        return None
+    configurable = config.get("configurable", {})
+    if not isinstance(configurable, Mapping):
+        return None
+
+    runtime = configurable.get("__pregel_runtime")
+    if runtime is not None:
+        if isinstance(runtime, Mapping):
+            maybe_store = runtime.get("store")
+            if maybe_store is not None:
+                return maybe_store
+        maybe_store = getattr(runtime, "store", None)
+        if maybe_store is not None:
+            return maybe_store
+
+    return configurable.get("__pregel_store")
 
 
 @registry.register(
@@ -145,4 +177,144 @@ class SQLiteNode(TaskNode):
         return await asyncio.to_thread(self._execute)
 
 
-__all__ = ["PostgresNode", "SQLiteNode"]
+@registry.register(
+    NodeMetadata(
+        name="GraphStoreAppendMessageNode",
+        description=(
+            "Append a message to a versioned chat history item in the "
+            "LangGraph graph store."
+        ),
+        category="storage",
+    )
+)
+class GraphStoreAppendMessageNode(TaskNode):
+    """Append a single message to a versioned graph-store history item.
+
+    All string fields support ``{{template}}`` resolution via Orcheo's
+    ``resolved_for_run`` mechanism.  Example usage::
+
+        GraphStoreAppendMessageNode(
+            name="persist_history",
+            key="telegram:{{for_each_subscriber.current_item.chat_id}}",
+            content="{{format_digest.content}}",
+        )
+    """
+
+    namespace: list[str] = Field(
+        default_factory=lambda: ["agent_chat_history"],
+        description="Store namespace (converted to tuple internally).",
+    )
+    key: str = Field(
+        description=(
+            "Store key identifying the conversation slot. "
+            "Supports {{template}} resolution."
+        ),
+    )
+    role: str = Field(
+        default="assistant",
+        description="Message role, e.g. 'assistant' or 'user'.",
+    )
+    content: str = Field(
+        description="Message content to append. Supports {{template}} resolution.",
+    )
+
+    def _namespace_tuple(self) -> tuple[str, ...]:
+        """Convert the namespace list to a tuple, filtering blanks."""
+        ns = tuple(
+            entry.strip()
+            for entry in self.namespace
+            if isinstance(entry, str) and entry.strip()
+        )
+        return ns or ("agent_chat_history",)
+
+    @staticmethod
+    def _extract_payload(item: Any) -> dict[str, Any]:
+        """Extract a mutable payload dict from a store item.
+
+        Handles three representations:
+
+        1. ``None`` → fresh payload
+        2. Object with ``.value`` attribute (LangGraph ``Item``)
+        3. ``Mapping`` with ``"value"`` key (serialised item)
+        """
+        if item is None:
+            return {"version": 0, "messages": []}
+
+        value = getattr(item, "value", None)
+        if value is None and isinstance(item, Mapping):
+            value = item.get("value")
+
+        if isinstance(value, dict):
+            value.setdefault("version", 0)
+            value.setdefault("messages", [])
+            return value
+
+        return {"version": 0, "messages": []}
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Append the message to the graph store and return write status."""
+        store = get_graph_store(config)
+        if store is None:
+            logger.debug(
+                "GraphStoreAppendMessageNode '%s': no graph store available.",
+                self.name,
+            )
+            return {"history_written": False}
+
+        key = (self.key or "").strip()
+        if not key or "{{" in key or "}}" in key:
+            logger.warning(
+                "GraphStoreAppendMessageNode '%s': invalid key after resolution: %r",
+                self.name,
+                key,
+            )
+            return {"history_written": False}
+
+        if not self.content:
+            logger.warning(
+                "GraphStoreAppendMessageNode '%s': empty content after resolution.",
+                self.name,
+            )
+            return {"history_written": False}
+
+        namespace = self._namespace_tuple()
+
+        try:
+            item = await store.aget(namespace, key)
+        except Exception:
+            logger.warning(
+                "GraphStoreAppendMessageNode '%s': failed to read store "
+                "(namespace=%s, key='%s').",
+                self.name,
+                namespace,
+                key,
+                exc_info=True,
+            )
+            return {"history_written": False}
+
+        payload = self._extract_payload(item)
+        payload["messages"].append({"role": self.role, "content": self.content})
+        payload["version"] = payload.get("version", 0) + 1
+
+        try:
+            await store.aput(namespace, key, payload)
+        except Exception:
+            logger.warning(
+                "GraphStoreAppendMessageNode '%s': failed to write store "
+                "(namespace=%s, key='%s').",
+                self.name,
+                namespace,
+                key,
+                exc_info=True,
+            )
+            return {"history_written": False}
+
+        return {"history_written": True}
+
+
+__all__ = [
+    "get_graph_store",
+    "GraphStoreAppendMessageNode",
+    "PostgresNode",
+    "SQLiteNode",
+]

--- a/src/orcheo/nodes/wecom.py
+++ b/src/orcheo/nodes/wecom.py
@@ -44,6 +44,7 @@ MIN_DECRYPTED_LEN = RANDOM_PREFIX_LEN + MSG_LEN_BYTES
 CS_MESSAGE_TTL_SECONDS = 3 * 24 * 60 * 60
 CS_REDIS_PREFIX = "wecom:cs"
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+DEFAULT_TIMEOUT = 10.0
 
 
 def verify_wecom_signature(
@@ -890,7 +891,7 @@ class WeComAIBotResponseNode(TaskNode):
         description="Template card payload for template_card replies",
     )
     timeout: float | None = Field(
-        default=10.0,
+        default=DEFAULT_TIMEOUT,
         description="Timeout in seconds for the response_url request",
     )
 
@@ -1065,13 +1066,17 @@ class WeComAccessTokenNode(TaskNode):
     )
     app_secret: str = "[[wecom_app_secret]]"
     """WeCom app secret (from Orcheo vault)."""
+    timeout: float | None = Field(
+        default=DEFAULT_TIMEOUT,
+        description="Timeout in seconds for the access token request",
+    )
 
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Fetch access token from WeCom API."""
         url = "https://qyapi.weixin.qq.com/cgi-bin/gettoken"
         params = {"corpid": self.corp_id, "corpsecret": self.app_secret}
 
-        client = httpx.AsyncClient(timeout=10.0)
+        client = httpx.AsyncClient(timeout=self.timeout)
         try:
             response = await client.get(url, params=params)
             response.raise_for_status()
@@ -1110,6 +1115,10 @@ class WeComSendMessageNode(TaskNode):
     )
     message: str = Field(description="Message content to send")
     msg_type: str = Field(default="text", description="Message type (text or markdown)")
+    timeout: float | None = Field(
+        default=DEFAULT_TIMEOUT,
+        description="Timeout in seconds for the send message request",
+    )
 
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
         """Send message to WeCom chat."""
@@ -1176,7 +1185,7 @@ class WeComSendMessageNode(TaskNode):
         else:
             payload["text"] = {"content": self.message}
 
-        client = httpx.AsyncClient(timeout=10.0)
+        client = httpx.AsyncClient(timeout=self.timeout)
         try:
             response = await client.post(url, params=params, json=payload)
             response.raise_for_status()
@@ -1252,7 +1261,7 @@ class WeComGroupPushNode(TaskNode):
     )
     content: str = Field(description="Message content to send")
     timeout: float | None = Field(
-        default=10.0,
+        default=DEFAULT_TIMEOUT,
         description="Timeout in seconds for the webhook request",
     )
 
@@ -1815,6 +1824,10 @@ class WeComCustomerServiceSyncNode(TaskNode):
         default=1000,
         description="Maximum number of messages to fetch (1-1000)",
     )
+    timeout: float | None = Field(
+        default=DEFAULT_TIMEOUT,
+        description="Timeout in seconds for the sync request",
+    )
 
     @staticmethod
     def _build_agent_messages(
@@ -1889,7 +1902,7 @@ class WeComCustomerServiceSyncNode(TaskNode):
             base_payload["token"] = kf_token
 
         redis_client = _create_cs_redis_client()
-        client = httpx.AsyncClient(timeout=10.0)
+        client = httpx.AsyncClient(timeout=self.timeout)
         try:
             sync_result = await _pull_cs_pages(
                 client, redis_client, url, params, base_payload, self.cursor
@@ -1978,6 +1991,10 @@ class WeComCustomerServiceSendNode(TaskNode):
         default=False,
         description="Raise ValueError when send fails instead of returning is_error",
     )
+    timeout: float | None = Field(
+        default=DEFAULT_TIMEOUT,
+        description="Timeout in seconds for the send request",
+    )
 
     def _error_result(
         self,
@@ -2014,7 +2031,7 @@ class WeComCustomerServiceSendNode(TaskNode):
         url = "https://qyapi.weixin.qq.com/cgi-bin/kf/send_msg"
         params: dict[str, str] = {"access_token": access_token}
 
-        client = httpx.AsyncClient(timeout=10.0)
+        client = httpx.AsyncClient(timeout=self.timeout)
         try:
             response = await client.post(url, params=params, json=payload)
             response.raise_for_status()

--- a/tests/nodes/test_storage_graph_store.py
+++ b/tests/nodes/test_storage_graph_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 import pytest
 from langchain_core.runnables import RunnableConfig
 from orcheo.graph.state import State
@@ -139,6 +139,11 @@ class TestExtractPayload:
         assert result["version"] == 0
         assert result["messages"] == []
 
+    def test_invalid_types_get_sanitized_defaults(self) -> None:
+        item = MockItem({"version": "1", "messages": {"role": "user"}})
+        result = GraphStoreAppendMessageNode._extract_payload(item)
+        assert result == {"version": 0, "messages": []}
+
 
 # ---------------------------------------------------------------------------
 # GraphStoreAppendMessageNode._namespace_tuple() tests
@@ -207,6 +212,20 @@ async def test_unresolved_template_in_key_returns_false() -> None:
     state = State({"results": {}})
     result = await node.run(state, _config_with_store(store))
     assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_non_string_key_coerces_to_string() -> None:
+    store = MockStore(existing_item=None)
+    node = GraphStoreAppendMessageNode(name="t", key="placeholder", content="digest")
+    node.key = cast(Any, 123)
+    state = State({"results": {}})
+
+    result = await node.run(state, _config_with_store(store))
+
+    assert result == {"history_written": True}
+    _, key, _ = store.put_calls[0]
+    assert key == "123"
 
 
 @pytest.mark.asyncio
@@ -282,3 +301,18 @@ async def test_aput_exception_returns_false() -> None:
     state = State({"results": {}})
     result = await node.run(state, _config_with_store(store))
     assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_invalid_existing_payload_types_do_not_fail() -> None:
+    existing = MockItem({"version": "4", "messages": "bad"})
+    store = MockStore(existing_item=existing)
+    node = GraphStoreAppendMessageNode(name="t", key="k", content="msg")
+    state = State({"results": {}})
+
+    result = await node.run(state, _config_with_store(store))
+
+    assert result == {"history_written": True}
+    _, _, payload = store.put_calls[0]
+    assert payload["version"] == 1
+    assert payload["messages"] == [{"role": "assistant", "content": "msg"}]

--- a/tests/nodes/test_storage_graph_store.py
+++ b/tests/nodes/test_storage_graph_store.py
@@ -1,0 +1,284 @@
+"""Tests for get_graph_store() and GraphStoreAppendMessageNode."""
+
+from __future__ import annotations
+from types import SimpleNamespace
+from typing import Any
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.state import State
+from orcheo.nodes.storage import GraphStoreAppendMessageNode, get_graph_store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockStore:
+    """Minimal async store for testing."""
+
+    def __init__(
+        self,
+        existing_item: Any = None,
+        *,
+        aget_error: bool = False,
+        aput_error: bool = False,
+    ) -> None:
+        self.existing_item = existing_item
+        self.aget_error = aget_error
+        self.aput_error = aput_error
+        self.put_calls: list[tuple[tuple[str, ...], str, dict[str, Any]]] = []
+
+    async def aget(self, namespace: tuple[str, ...], key: str) -> Any:
+        if self.aget_error:
+            raise RuntimeError("store read error")
+        return self.existing_item
+
+    async def aput(
+        self, namespace: tuple[str, ...], key: str, value: dict[str, Any]
+    ) -> None:
+        if self.aput_error:
+            raise RuntimeError("store write error")
+        self.put_calls.append((namespace, key, value))
+
+
+class MockItem:
+    """Mimics a LangGraph store Item with a .value attribute."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+def _config_with_store(store: Any) -> RunnableConfig:
+    return RunnableConfig(configurable={"__pregel_store": store})
+
+
+# ---------------------------------------------------------------------------
+# get_graph_store() tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetGraphStore:
+    def test_returns_none_for_none_config(self) -> None:
+        assert get_graph_store(None) is None
+
+    def test_returns_none_for_non_mapping_configurable(self) -> None:
+        assert get_graph_store({"configurable": "bad"}) is None
+
+    def test_returns_none_when_nothing_available(self) -> None:
+        assert get_graph_store({"configurable": {}}) is None
+
+    def test_finds_store_in_runtime_mapping(self) -> None:
+        sentinel = object()
+        config = {"configurable": {"__pregel_runtime": {"store": sentinel}}}
+        assert get_graph_store(config) is sentinel
+
+    def test_finds_store_via_runtime_attribute(self) -> None:
+        sentinel = object()
+        runtime = SimpleNamespace(store=sentinel)
+        config = {"configurable": {"__pregel_runtime": runtime}}
+        assert get_graph_store(config) is sentinel
+
+    def test_falls_back_to_pregel_store(self) -> None:
+        sentinel = object()
+        config = {"configurable": {"__pregel_store": sentinel}}
+        assert get_graph_store(config) is sentinel
+
+    def test_skips_none_runtime_store_and_falls_back(self) -> None:
+        sentinel = object()
+        config = {
+            "configurable": {
+                "__pregel_runtime": {"store": None},
+                "__pregel_store": sentinel,
+            }
+        }
+        assert get_graph_store(config) is sentinel
+
+    def test_runtime_mapping_takes_priority_over_pregel_store(self) -> None:
+        runtime_store = object()
+        fallback_store = object()
+        config = {
+            "configurable": {
+                "__pregel_runtime": {"store": runtime_store},
+                "__pregel_store": fallback_store,
+            }
+        }
+        assert get_graph_store(config) is runtime_store
+
+
+# ---------------------------------------------------------------------------
+# GraphStoreAppendMessageNode._extract_payload() tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPayload:
+    def test_none_item_returns_fresh_payload(self) -> None:
+        result = GraphStoreAppendMessageNode._extract_payload(None)
+        assert result == {"version": 0, "messages": []}
+
+    def test_item_with_attribute_value(self) -> None:
+        item = MockItem({"version": 5, "messages": [{"role": "user", "content": "hi"}]})
+        result = GraphStoreAppendMessageNode._extract_payload(item)
+        assert result["version"] == 5
+        assert len(result["messages"]) == 1
+
+    def test_item_with_mapping_value(self) -> None:
+        item = {"value": {"version": 2, "messages": []}}
+        result = GraphStoreAppendMessageNode._extract_payload(item)
+        assert result["version"] == 2
+        assert result["messages"] == []
+
+    def test_non_dict_value_returns_fresh_payload(self) -> None:
+        item = MockItem("not a dict")
+        result = GraphStoreAppendMessageNode._extract_payload(item)
+        assert result == {"version": 0, "messages": []}
+
+    def test_missing_keys_get_defaults(self) -> None:
+        item = MockItem({})
+        result = GraphStoreAppendMessageNode._extract_payload(item)
+        assert result["version"] == 0
+        assert result["messages"] == []
+
+
+# ---------------------------------------------------------------------------
+# GraphStoreAppendMessageNode._namespace_tuple() tests
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceTuple:
+    def test_default_namespace(self) -> None:
+        node = GraphStoreAppendMessageNode(name="t", key="k", content="c")
+        assert node._namespace_tuple() == ("agent_chat_history",)
+
+    def test_custom_namespace(self) -> None:
+        node = GraphStoreAppendMessageNode(
+            name="t", key="k", content="c", namespace=["custom", "ns"]
+        )
+        assert node._namespace_tuple() == ("custom", "ns")
+
+    def test_filters_blanks(self) -> None:
+        node = GraphStoreAppendMessageNode(
+            name="t", key="k", content="c", namespace=["", " ", "valid"]
+        )
+        assert node._namespace_tuple() == ("valid",)
+
+    def test_empty_namespace_defaults(self) -> None:
+        node = GraphStoreAppendMessageNode(name="t", key="k", content="c", namespace=[])
+        assert node._namespace_tuple() == ("agent_chat_history",)
+
+
+# ---------------------------------------------------------------------------
+# GraphStoreAppendMessageNode.run() tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_store_returns_false() -> None:
+    node = GraphStoreAppendMessageNode(name="t", key="some_key", content="hello")
+    state = State({"results": {}})
+    result = await node.run(state, RunnableConfig())
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_empty_key_returns_false() -> None:
+    store = MockStore()
+    node = GraphStoreAppendMessageNode(name="t", key="", content="hello")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_empty_content_returns_false() -> None:
+    store = MockStore()
+    node = GraphStoreAppendMessageNode(name="t", key="some_key", content="")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_unresolved_template_in_key_returns_false() -> None:
+    store = MockStore()
+    node = GraphStoreAppendMessageNode(
+        name="t", key="telegram:{{unresolved}}", content="hello"
+    )
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_creates_new_entry() -> None:
+    store = MockStore(existing_item=None)
+    node = GraphStoreAppendMessageNode(name="t", key="telegram:123", content="digest")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+
+    assert result == {"history_written": True}
+    assert len(store.put_calls) == 1
+    ns, key, payload = store.put_calls[0]
+    assert ns == ("agent_chat_history",)
+    assert key == "telegram:123"
+    assert payload["version"] == 1
+    assert payload["messages"] == [{"role": "assistant", "content": "digest"}]
+
+
+@pytest.mark.asyncio
+async def test_appends_to_existing_entry() -> None:
+    existing = MockItem({"version": 3, "messages": [{"role": "user", "content": "hi"}]})
+    store = MockStore(existing_item=existing)
+    node = GraphStoreAppendMessageNode(name="t", key="telegram:456", content="news")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+
+    assert result == {"history_written": True}
+    ns, key, payload = store.put_calls[0]
+    assert payload["version"] == 4
+    assert len(payload["messages"]) == 2
+    assert payload["messages"][0] == {"role": "user", "content": "hi"}
+    assert payload["messages"][1] == {"role": "assistant", "content": "news"}
+
+
+@pytest.mark.asyncio
+async def test_custom_role() -> None:
+    store = MockStore(existing_item=None)
+    node = GraphStoreAppendMessageNode(name="t", key="k", content="msg", role="user")
+    state = State({"results": {}})
+    await node.run(state, _config_with_store(store))
+
+    _, _, payload = store.put_calls[0]
+    assert payload["messages"][0]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_custom_namespace() -> None:
+    store = MockStore(existing_item=None)
+    node = GraphStoreAppendMessageNode(
+        name="t", key="k", content="msg", namespace=["my_ns"]
+    )
+    state = State({"results": {}})
+    await node.run(state, _config_with_store(store))
+
+    ns, _, _ = store.put_calls[0]
+    assert ns == ("my_ns",)
+
+
+@pytest.mark.asyncio
+async def test_aget_exception_returns_false() -> None:
+    store = MockStore(aget_error=True)
+    node = GraphStoreAppendMessageNode(name="t", key="k", content="msg")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+    assert len(store.put_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_aput_exception_returns_false() -> None:
+    store = MockStore(aput_error=True)
+    node = GraphStoreAppendMessageNode(name="t", key="k", content="msg")
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}

--- a/tests/nodes/test_storage_graph_store.py
+++ b/tests/nodes/test_storage_graph_store.py
@@ -229,6 +229,26 @@ async def test_non_string_key_coerces_to_string() -> None:
 
 
 @pytest.mark.asyncio
+async def test_none_key_returns_false() -> None:
+    store = MockStore()
+    node = GraphStoreAppendMessageNode(name="t", key="placeholder", content="hello")
+    node.key = cast(Any, None)
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
+async def test_non_coercible_key_returns_false() -> None:
+    store = MockStore()
+    node = GraphStoreAppendMessageNode(name="t", key="placeholder", content="hello")
+    node.key = cast(Any, ["not", "a", "string"])
+    state = State({"results": {}})
+    result = await node.run(state, _config_with_store(store))
+    assert result == {"history_written": False}
+
+
+@pytest.mark.asyncio
 async def test_creates_new_entry() -> None:
     store = MockStore(existing_item=None)
     node = GraphStoreAppendMessageNode(name="t", key="telegram:123", content="digest")


### PR DESCRIPTION
## Summary

This PR adds graph-store write support for chat history and cleans up graph-store access across nodes.

### Main changes

- Add `get_graph_store()` in `src/orcheo/nodes/storage.py` to centralize LangGraph store resolution from runtime config.
- Add `GraphStoreAppendMessageNode`, a new storage node that:
  - resolves a graph store from config,
  - appends a `{role, content}` message to a namespaced history entry,
  - increments a simple `version` counter,
  - handles missing stores, invalid keys, empty content, and store read/write failures safely by returning `history_written: False`.
- Export `GraphStoreAppendMessageNode` and `get_graph_store` from `src/orcheo/nodes/__init__.py`.
- Refactor `AgentNode` in `src/orcheo/nodes/ai.py` to reuse the shared `get_graph_store()` helper instead of keeping a duplicate implementation.

### WeCom updates

- Introduce a shared `DEFAULT_TIMEOUT` constant in `src/orcheo/nodes/wecom.py`.
- Add configurable `timeout` fields to several WeCom nodes and use them when creating `httpx.AsyncClient` instances, instead of hardcoding `10.0` seconds:
  - `WeComAccessTokenNode`
  - `WeComSendMessageNode`
  - `WeComGroupPushNode`
  - `WeComCustomerServiceSyncNode`
  - `WeComCustomerServiceSendNode`
  - `WeComAIBotResponseNode`

### Test coverage

- Add `tests/nodes/test_storage_graph_store.py` covering:
  - graph store resolution precedence and fallbacks,
  - payload extraction behavior,
  - namespace normalization,
  - successful append flows for new and existing entries,
  - failure cases for missing store, invalid input, and store exceptions.
