### PR TITLE
feat(sdk): add Docker auto-install + daemon access checks in setup

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -157,7 +157,7 @@ def _attempt_docker_autoinstall(*, console: Console) -> bool:
             _run_privileged_command(
                 ["usermod", "-aG", "docker", username], console=console
             )
-    except typer.BadParameter as exc:
+    except (typer.BadParameter, FileNotFoundError) as exc:
         console.print(
             "[yellow]Automatic Docker installation failed: "
             f"{exc}. Continuing without starting the stack.[/yellow]"

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -1,8 +1,10 @@
 """Guided setup and upgrade command for the Orcheo stack."""
 
 from __future__ import annotations
+import getpass
 import json
 import os
+import platform
 import re
 import secrets
 import shutil
@@ -67,6 +69,108 @@ def _run_command(command: list[str], *, console: Console) -> None:
 
 def _has_binary(name: str) -> bool:
     return shutil.which(name) is not None
+
+
+def _read_os_release() -> dict[str, str]:
+    os_release = Path("/etc/os-release")
+    if not os_release.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for line in os_release.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, raw_value = stripped.split("=", maxsplit=1)
+        values[key] = _normalize_dotenv_value(raw_value) or ""
+    return values
+
+
+def _is_supported_docker_autoinstall_linux() -> bool:
+    if platform.system() != "Linux":
+        return False
+
+    os_release = _read_os_release()
+    distro_id = os_release.get("ID", "").lower()
+    distro_like = os_release.get("ID_LIKE", "").lower().split()
+    if distro_id in {"ubuntu", "debian"}:
+        return True
+    return any(token in {"ubuntu", "debian"} for token in distro_like)
+
+
+def _run_privileged_command(command: list[str], *, console: Console) -> None:
+    if os.geteuid() == 0:
+        _run_command(command, console=console)
+        return
+    if not _has_binary("sudo"):
+        raise typer.BadParameter(
+            "Automatic Docker installation requires root privileges or sudo."
+        )
+    _run_command(["sudo", *command], console=console)
+
+
+def _current_username() -> str | None:
+    username = _normalize_optional_value(os.getenv("SUDO_USER"))
+    if username:
+        return username
+    return _normalize_optional_value(getpass.getuser())
+
+
+def _current_shell_has_docker_access() -> bool:
+    if not _has_binary("docker"):
+        return False
+    result = subprocess.run(
+        ["docker", "info"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _attempt_docker_autoinstall(*, console: Console) -> bool:
+    if not _is_supported_docker_autoinstall_linux():
+        return False
+    if not _has_binary("apt-get"):
+        console.print(
+            "[yellow]Automatic Docker installation currently supports "
+            "apt-based Ubuntu/Debian systems.[/yellow]"
+        )
+        return False
+
+    console.print(
+        "[cyan]Docker is missing. Attempting automatic installation on "
+        "Ubuntu/Debian...[/cyan]"
+    )
+    try:
+        _run_privileged_command(["apt-get", "update"], console=console)
+        _run_privileged_command(
+            ["apt-get", "install", "-y", "docker.io", "docker-compose-v2"],
+            console=console,
+        )
+        _run_privileged_command(
+            ["systemctl", "enable", "--now", "docker"], console=console
+        )
+
+        username = _current_username()
+        if username:
+            _run_privileged_command(
+                ["usermod", "-aG", "docker", username], console=console
+            )
+    except typer.BadParameter as exc:
+        console.print(
+            "[yellow]Automatic Docker installation failed: "
+            f"{exc}. Continuing without starting the stack.[/yellow]"
+        )
+        return False
+
+    if not _has_binary("docker"):
+        console.print(
+            "[yellow]Docker installation completed but the docker binary is still "
+            "not available in PATH.[/yellow]"
+        )
+        return False
+    return True
 
 
 def _resolve_mode(mode: SetupMode | None, *, yes: bool) -> SetupMode:
@@ -675,18 +779,27 @@ def execute_setup(
 
     if config.start_stack and not _has_binary("docker"):
         if config.install_docker_if_missing:
-            console.print(
-                "[yellow]Docker is missing and automatic installation is not "
-                "available yet. Continuing without starting the stack. "
-                "Install Docker Desktop (https://docs.docker.com/get-docker/) "
-                "and rerun with --start-stack.[/yellow]"
-            )
-            config.start_stack = False
+            if not _attempt_docker_autoinstall(console=console):
+                console.print(
+                    "[yellow]Docker is missing and automatic installation could "
+                    "not complete. Continuing without starting the stack. "
+                    "Install Docker (https://docs.docker.com/get-docker/) and "
+                    "rerun with --start-stack.[/yellow]"
+                )
+                config.start_stack = False
         else:
             raise typer.BadParameter(
                 "Docker is required to start the stack, and you chose "
                 "--skip-docker-install. Install Docker and rerun setup."
             )
+
+    if config.start_stack and not _current_shell_has_docker_access():
+        console.print(
+            "[yellow]Docker is installed, but this shell cannot access the daemon "
+            "yet. Run `newgrp docker` or re-login, then rerun with "
+            "--start-stack.[/yellow]"
+        )
+        config.start_stack = False
 
     if config.start_stack and _has_binary("docker"):
         compose_args = [

--- a/packages/sdk/src/orcheo_sdk/cli/setup.py
+++ b/packages/sdk/src/orcheo_sdk/cli/setup.py
@@ -39,6 +39,7 @@ _STACK_ASSET_FILES = (
     "chatkit_widgets/Multi-choice Selector.widget",
 )
 _CHATKIT_DOMAIN_KEY_PLACEHOLDER = "domain_pk_replace_me"
+_OS_RELEASE_KEY_PATTERN = re.compile(r"^[A-Z0-9_]+$")
 
 
 @dataclass(slots=True)
@@ -76,13 +77,23 @@ def _read_os_release() -> dict[str, str]:
     if not os_release.exists():
         return {}
 
+    try:
+        lines = os_release.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return {}
+
     values: dict[str, str] = {}
-    for line in os_release.read_text(encoding="utf-8").splitlines():
+    for line in lines:
         stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
+        if not stripped or stripped.startswith("#"):
             continue
-        key, raw_value = stripped.split("=", maxsplit=1)
-        values[key] = _normalize_dotenv_value(raw_value) or ""
+        key, separator, raw_value = stripped.partition("=")
+        if separator != "=":
+            continue
+        normalized_key = key.strip()
+        if not _OS_RELEASE_KEY_PATTERN.fullmatch(normalized_key):
+            continue
+        values[normalized_key] = _normalize_dotenv_value(raw_value) or ""
     return values
 
 
@@ -113,7 +124,10 @@ def _current_username() -> str | None:
     username = _normalize_optional_value(os.getenv("SUDO_USER"))
     if username:
         return username
-    return _normalize_optional_value(getpass.getuser())
+    try:
+        return _normalize_optional_value(getpass.getuser())
+    except (KeyError, OSError, ImportError):
+        return None
 
 
 def _current_shell_has_docker_access() -> bool:

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -878,6 +878,15 @@ def test_attempt_docker_autoinstall_paths(
     )
     assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is False
 
+    monkeypatch.setattr(
+        setup_mod,
+        "_run_privileged_command",
+        lambda command, *, console: (_ for _ in ()).throw(
+            FileNotFoundError("systemctl")
+        ),
+    )
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is False
+
 
 def test_resolve_backend_url_install_yes_uses_default() -> None:
     from orcheo_sdk.cli import setup as setup_mod

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -127,8 +127,10 @@ def _patch_common(
     base_url: str = "https://example.test/assets",
     assets: dict[str, bytes] | None = None,
     has_docker: bool = True,
+    docker_access: bool = True,
     commands: list[list[str]] | None = None,
     health_ok: bool = True,
+    docker_autoinstall_success: bool | None = None,
 ) -> None:
     """Wire up common monkeypatches for execute_setup tests."""
     resolved_assets = assets or _default_assets()
@@ -149,6 +151,15 @@ def _patch_common(
         "orcheo_sdk.cli.setup._poll_backend_health",
         lambda backend_url, *, console: health_ok,
     )
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.setup._current_shell_has_docker_access",
+        lambda: docker_access,
+    )
+    if docker_autoinstall_success is not None:
+        monkeypatch.setattr(
+            "orcheo_sdk.cli.setup._attempt_docker_autoinstall",
+            lambda *, console: docker_autoinstall_success,
+        )
 
     def _urlopen(url: str, timeout: int) -> _Response:
         del timeout
@@ -586,7 +597,12 @@ def test_execute_setup_skips_stack_start_when_docker_missing_and_install_enabled
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    _patch_common(monkeypatch, stack_dir=stack_dir, has_docker=False)
+    _patch_common(
+        monkeypatch,
+        stack_dir=stack_dir,
+        has_docker=False,
+        docker_autoinstall_success=False,
+    )
 
     config = _setup_config()
     config.install_docker_if_missing = True
@@ -594,7 +610,63 @@ def test_execute_setup_skips_stack_start_when_docker_missing_and_install_enabled
     execute_setup(config, console=console)
 
     assert config.start_stack is False
-    assert "automatic installation is not available yet" in console.export_text()
+    assert "automatic installation could not complete" in console.export_text()
+
+
+def test_execute_setup_autoinstalls_docker_then_starts_stack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    commands: list[list[str]] = []
+    _patch_common(monkeypatch, stack_dir=stack_dir, commands=commands, has_docker=False)
+
+    from orcheo_sdk.cli import setup as setup_mod
+
+    docker_state = {"installed": False}
+    monkeypatch.setattr(
+        setup_mod,
+        "_has_binary",
+        lambda name: docker_state["installed"] and name == "docker",
+    )
+
+    def _autoinstall(*, console: Console) -> bool:
+        del console
+        docker_state["installed"] = True
+        return True
+
+    monkeypatch.setattr(setup_mod, "_attempt_docker_autoinstall", _autoinstall)
+    monkeypatch.setattr(setup_mod, "_current_shell_has_docker_access", lambda: True)
+
+    config = _setup_config()
+    execute_setup(config, console=Console(record=True))
+
+    assert config.start_stack is True
+    assert commands[0][-1] == "pull"
+    assert commands[1][-2:] == ["up", "-d"]
+
+
+def test_execute_setup_skips_stack_when_docker_daemon_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stack_dir = tmp_path / "stack"
+    commands: list[list[str]] = []
+    _patch_common(
+        monkeypatch,
+        stack_dir=stack_dir,
+        commands=commands,
+        has_docker=True,
+        docker_access=False,
+    )
+
+    config = _setup_config()
+    console = Console(record=True)
+    execute_setup(config, console=console)
+
+    assert config.start_stack is False
+    assert commands == []
+    assert "cannot access the daemon yet" in console.export_text()
 
 
 def test_execute_setup_raises_when_docker_missing_and_install_disabled(
@@ -734,6 +806,77 @@ def test_setup_api_key_and_optional_normalization(
     assert setup_mod._resolve_chatkit_domain_key("  key ", yes=True) == "key"
     monkeypatch.setattr(setup_mod.typer, "prompt", lambda *args, **kwargs: "  ")
     assert setup_mod._resolve_chatkit_domain_key(None, yes=False) is None
+
+
+def test_supported_docker_autoinstall_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orcheo_sdk.cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+    assert setup_mod._is_supported_docker_autoinstall_linux() is False
+
+    monkeypatch.setattr(setup_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(setup_mod, "_read_os_release", lambda: {"ID": "ubuntu"})
+    assert setup_mod._is_supported_docker_autoinstall_linux() is True
+
+    monkeypatch.setattr(
+        setup_mod,
+        "_read_os_release",
+        lambda: {"ID": "linuxmint", "ID_LIKE": "ubuntu debian"},
+    )
+    assert setup_mod._is_supported_docker_autoinstall_linux() is True
+
+    monkeypatch.setattr(
+        setup_mod,
+        "_read_os_release",
+        lambda: {"ID": "fedora", "ID_LIKE": "rhel"},
+    )
+    assert setup_mod._is_supported_docker_autoinstall_linux() is False
+
+
+def test_attempt_docker_autoinstall_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orcheo_sdk.cli import setup as setup_mod
+
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: False
+    )
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is False
+
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(
+        setup_mod, "_has_binary", lambda name: name in {"docker", "sudo"}
+    )
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is False
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        setup_mod, "_has_binary", lambda name: name in {"apt-get", "docker", "sudo"}
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_run_privileged_command",
+        lambda command, *, console: commands.append(command),
+    )
+    monkeypatch.setattr(setup_mod, "_current_username", lambda: "alice")
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is True
+    assert commands == [
+        ["apt-get", "update"],
+        ["apt-get", "install", "-y", "docker.io", "docker-compose-v2"],
+        ["systemctl", "enable", "--now", "docker"],
+        ["usermod", "-aG", "docker", "alice"],
+    ]
+
+    monkeypatch.setattr(
+        setup_mod,
+        "_run_privileged_command",
+        lambda command, *, console: (_ for _ in ()).throw(typer.BadParameter("boom")),
+    )
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True)) is False
 
 
 def test_resolve_backend_url_install_yes_uses_default() -> None:

--- a/tests/sdk/test_cli_setup_stack_assets.py
+++ b/tests/sdk/test_cli_setup_stack_assets.py
@@ -835,6 +835,53 @@ def test_supported_docker_autoinstall_detection(
     assert setup_mod._is_supported_docker_autoinstall_linux() is False
 
 
+def test_read_os_release_handles_read_errors_and_malformed_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orcheo_sdk.cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod.Path, "exists", lambda self: True)
+
+    def _raise_read_error(_self: Path, *, encoding: str = "utf-8") -> str:
+        del encoding
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(setup_mod.Path, "read_text", _raise_read_error)
+    assert setup_mod._read_os_release() == {}
+
+    monkeypatch.setattr(
+        setup_mod.Path,
+        "read_text",
+        lambda _self, *, encoding="utf-8": (
+            "ID=ubuntu\n"
+            "#comment\n"
+            "BROKEN\n"
+            'ID_LIKE="debian ubuntu"\n'
+            "bad-key=ignored\n"
+            "   =missing\n"
+        ),
+    )
+    assert setup_mod._read_os_release() == {
+        "ID": "ubuntu",
+        "ID_LIKE": "debian ubuntu",
+    }
+
+
+def test_current_username_handles_lookup_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orcheo_sdk.cli import setup as setup_mod
+
+    monkeypatch.delenv("SUDO_USER", raising=False)
+    monkeypatch.setattr(
+        setup_mod.getpass, "getuser", lambda: (_ for _ in ()).throw(OSError)
+    )
+    assert setup_mod._current_username() is None
+
+    monkeypatch.setenv("SUDO_USER", "root-user")
+    assert setup_mod._current_username() == "root-user"
+
+
 def test_attempt_docker_autoinstall_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/sdk/test_cli_setup_utils.py
+++ b/tests/sdk/test_cli_setup_utils.py
@@ -1,0 +1,148 @@
+"""Tests for CLI setup helper utilities."""
+
+from __future__ import annotations
+import pytest
+import typer
+from rich.console import Console
+from orcheo_sdk.cli import setup as setup_mod
+
+
+class _MissingOsReleasePath:
+    """Fake Path that always reports /etc/os-release as missing."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def exists(self) -> bool:
+        return False
+
+    def read_text(self, *, encoding: str) -> str:
+        raise AssertionError("read_text should not be called when path is absent")
+
+
+def test_read_os_release_missing_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(setup_mod, "Path", _MissingOsReleasePath)
+    assert setup_mod._read_os_release() == {}
+
+
+def test_run_privileged_command_runs_without_sudo_when_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod.os, "geteuid", lambda: 0)
+    recorded: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, console: Console) -> None:
+        recorded.append(command)
+
+    monkeypatch.setattr(setup_mod, "_run_command", _fake_run)
+    setup_mod._run_privileged_command(["/bin/true"], console=Console(record=True))
+    assert recorded == [["/bin/true"]]
+
+
+def test_run_privileged_command_rejects_without_sudo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda _: False)
+    with pytest.raises(typer.BadParameter):
+        setup_mod._run_privileged_command(["/bin/true"], console=Console(record=True))
+
+
+def test_run_privileged_command_prefixes_with_sudo_when_needed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: name == "sudo")
+    recorded: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, console: Console) -> None:
+        recorded.append(command)
+
+    monkeypatch.setattr(setup_mod, "_run_command", _fake_run)
+    setup_mod._run_privileged_command(["/bin/true"], console=Console(record=True))
+    assert recorded == [["sudo", "/bin/true"]]
+
+
+def test_current_shell_has_docker_access_false_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: False)
+    assert not setup_mod._current_shell_has_docker_access()
+
+
+def test_current_shell_has_docker_access_true_when_docker_info_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda name: True)
+
+    class _Result:
+        returncode = 0
+
+    monkeypatch.setattr(
+        setup_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: _Result(),
+    )
+    assert setup_mod._current_shell_has_docker_access()
+
+
+def test_attempt_docker_autoinstall_runs_commands_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_has_binary",
+        lambda name: name in {"apt-get", "docker"},
+    )
+    calls: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, console: Console) -> None:
+        calls.append(command)
+
+    monkeypatch.setattr(setup_mod, "_run_privileged_command", _fake_run)
+    monkeypatch.setattr(setup_mod, "_current_username", lambda: "alice")
+
+    assert setup_mod._attempt_docker_autoinstall(console=Console(record=True))
+    assert calls[:3] == [
+        ["apt-get", "update"],
+        ["apt-get", "install", "-y", "docker.io", "docker-compose-v2"],
+        ["systemctl", "enable", "--now", "docker"],
+    ]
+    assert calls[3] == ["usermod", "-aG", "docker", "alice"]
+
+
+def test_attempt_docker_autoinstall_handles_privileged_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+    monkeypatch.setattr(setup_mod, "_has_binary", lambda _: True)
+
+    def _fake_run(*args: object, **kwargs: object) -> None:
+        raise typer.BadParameter("boom")
+
+    monkeypatch.setattr(setup_mod, "_run_privileged_command", _fake_run)
+    assert not setup_mod._attempt_docker_autoinstall(console=Console(record=True))
+
+
+def test_attempt_docker_autoinstall_returns_false_when_docker_still_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        setup_mod, "_is_supported_docker_autoinstall_linux", lambda: True
+    )
+
+    def _fake_has_binary(name: str) -> bool:
+        return name == "apt-get"
+
+    monkeypatch.setattr(setup_mod, "_has_binary", _fake_has_binary)
+    monkeypatch.setattr(
+        setup_mod, "_run_privileged_command", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(setup_mod, "_current_username", lambda: None)
+
+    assert not setup_mod._attempt_docker_autoinstall(console=Console(record=True))


### PR DESCRIPTION
## Summary
This PR improves `orcheo setup` behavior when `--start-stack` is enabled but Docker is missing or not yet usable in the current shell.

## Main changes
- Added Docker auto-install support for apt-based Linux distributions (Ubuntu/Debian and compatible `ID_LIKE` distros).
- Implemented OS detection via `/etc/os-release` and a guard that only attempts auto-install on supported Linux environments.
- Added privileged command execution helper (`sudo` or root) for installation steps.
- Added auto-install workflow to:
  - `apt-get update`
  - install `docker.io` and `docker-compose-v2`
  - enable/start Docker with `systemctl`
  - add current user to the `docker` group
- Updated setup flow so that when auto-install fails, setup continues but disables stack startup with a clearer warning.
- Added a post-install/runtime access check (`docker info`) to detect when Docker is installed but daemon access is unavailable in the current shell.
  - In that case, setup now skips stack startup and instructs the user to run `newgrp docker` or re-login.

## Tests
- Expanded `tests/sdk/test_cli_setup_stack_assets.py` to cover:
  - failed auto-install fallback messaging
  - successful auto-install followed by stack start
  - daemon-unavailable path that skips stack startup
  - distro support detection logic
  - auto-install command sequence and error paths
- Updated shared test patch helper to support Docker access and auto-install simulation.
