### PR TITLE
Harden stack deployment by prebuilding and releasing a dedicated Canvas image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,19 +196,17 @@ jobs:
         with:
           packages-dir: ${{ steps.package.outputs.dist_dir }}
 
-  stack-release:
+  stack-image-metadata:
     needs: [lint, coverage]
     if: "startsWith(github.ref, 'refs/tags/stack-v')"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      stack_repo: ${{ steps.meta.outputs.stack_repo }}
+      canvas_repo: ${{ steps.meta.outputs.canvas_repo }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Determine stack image metadata
-        id: stack
+      - name: Determine image metadata
+        id: meta
         run: |
           tag="${GITHUB_REF_NAME}"
           version="${tag#stack-v}"
@@ -216,9 +214,20 @@ jobs:
             echo "Invalid stack tag: $tag" >&2
             exit 1
           fi
-          image_repo=$(printf '%s' "ghcr.io/${GITHUB_REPOSITORY_OWNER}/orcheo-stack" | tr '[:upper:]' '[:lower:]')
+          owner_lc=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "image_repo=${image_repo}" >> "$GITHUB_OUTPUT"
+          echo "stack_repo=ghcr.io/${owner_lc}/orcheo-stack" >> "$GITHUB_OUTPUT"
+          echo "canvas_repo=ghcr.io/${owner_lc}/orcheo-canvas" >> "$GITHUB_OUTPUT"
+
+  stack-release:
+    needs: [stack-image-metadata]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -238,8 +247,39 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ steps.stack.outputs.image_repo }}:${{ steps.stack.outputs.version }}
-            ${{ steps.stack.outputs.image_repo }}:latest
+            ${{ needs.stack-image-metadata.outputs.stack_repo }}:${{ needs.stack-image-metadata.outputs.version }}
+            ${{ needs.stack-image-metadata.outputs.stack_repo }}:latest
+
+  canvas-image-release:
+    needs: [stack-image-metadata]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push canvas image
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/stack
+          file: deploy/stack/Dockerfile.canvas
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ needs.stack-image-metadata.outputs.canvas_repo }}:${{ needs.stack-image-metadata.outputs.version }}
+            ${{ needs.stack-image-metadata.outputs.canvas_repo }}:latest
 
   canvas:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/deploy/stack/Dockerfile.canvas
+++ b/deploy/stack/Dockerfile.canvas
@@ -1,0 +1,40 @@
+# Stage 1: Build the canvas app with placeholder values
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# Install orcheo-canvas from npm
+RUN npm init -y \
+    && npm install --silent orcheo-canvas@latest
+
+# Set placeholder values for all VITE_ vars so they get baked into the JS
+# bundle. At container startup, an entrypoint script replaces these
+# placeholders with real environment variable values.
+ENV VITE_ORCHEO_BACKEND_URL=__VITE_ORCHEO_BACKEND_URL__ \
+    VITE_ORCHEO_AUTH_ISSUER=__VITE_ORCHEO_AUTH_ISSUER__ \
+    VITE_ORCHEO_AUTH_CLIENT_ID=__VITE_ORCHEO_AUTH_CLIENT_ID__ \
+    VITE_ORCHEO_AUTH_REDIRECT_URI=__VITE_ORCHEO_AUTH_REDIRECT_URI__ \
+    VITE_ORCHEO_AUTH_SCOPES=__VITE_ORCHEO_AUTH_SCOPES__ \
+    VITE_ORCHEO_AUTH_AUDIENCE=__VITE_ORCHEO_AUTH_AUDIENCE__ \
+    VITE_ORCHEO_AUTH_ORGANIZATION=__VITE_ORCHEO_AUTH_ORGANIZATION__ \
+    VITE_ORCHEO_AUTH_PROVIDER_PARAM=__VITE_ORCHEO_AUTH_PROVIDER_PARAM__ \
+    VITE_ORCHEO_AUTH_PROVIDER_GOOGLE=__VITE_ORCHEO_AUTH_PROVIDER_GOOGLE__ \
+    VITE_ORCHEO_AUTH_PROVIDER_GITHUB=__VITE_ORCHEO_AUTH_PROVIDER_GITHUB__ \
+    VITE_ORCHEO_CHATKIT_DOMAIN_KEY=__VITE_ORCHEO_CHATKIT_DOMAIN_KEY__
+
+RUN npm --prefix node_modules/orcheo-canvas run build
+
+# Stage 2: Serve with nginx
+FROM nginx:alpine
+
+RUN apk add --no-cache bash
+
+# Copy the built assets
+COPY --from=build /app/node_modules/orcheo-canvas/dist /usr/share/nginx/html
+
+# Copy nginx config and entrypoint
+COPY nginx-canvas.conf /etc/nginx/conf.d/default.conf
+COPY canvas-entrypoint.sh /docker-entrypoint.d/40-canvas-env.sh
+RUN chmod +x /docker-entrypoint.d/40-canvas-env.sh
+
+EXPOSE 5173

--- a/deploy/stack/canvas-entrypoint.sh
+++ b/deploy/stack/canvas-entrypoint.sh
@@ -4,6 +4,14 @@
 
 HTML_DIR="/usr/share/nginx/html"
 
+escape_sed_replacement() {
+  local raw_value="$1"
+  raw_value="${raw_value//\\/\\\\}"
+  raw_value="${raw_value//&/\\&}"
+  raw_value="${raw_value//|/\\|}"
+  printf '%s' "$raw_value"
+}
+
 # List of VITE_ variables and their placeholder strings
 VARS=(
   "VITE_ORCHEO_BACKEND_URL"
@@ -21,10 +29,15 @@ VARS=(
 
 for VAR in "${VARS[@]}"; do
   PLACEHOLDER="__${VAR}__"
-  VALUE="${!VAR}"
-  if [ -n "$VALUE" ]; then
+  VALUE="${!VAR-}"
+  ESCAPED_VALUE="$(escape_sed_replacement "$VALUE")"
+
+  if [ -z "$VALUE" ]; then
+    echo "canvas-env: injecting empty value for $VAR"
+  else
     echo "canvas-env: injecting $VAR"
-    find "$HTML_DIR" -type f \( -name '*.js' -o -name '*.html' \) \
-      -exec sed -i "s|${PLACEHOLDER}|${VALUE}|g" {} +
   fi
+
+  find "$HTML_DIR" -type f \( -name '*.js' -o -name '*.html' \) \
+    -exec sed -i "s|${PLACEHOLDER}|${ESCAPED_VALUE}|g" {} +
 done

--- a/deploy/stack/canvas-entrypoint.sh
+++ b/deploy/stack/canvas-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Replace build-time placeholder strings with runtime environment variable values.
+# This runs at container startup via nginx's /docker-entrypoint.d/ mechanism.
+
+HTML_DIR="/usr/share/nginx/html"
+
+# List of VITE_ variables and their placeholder strings
+VARS=(
+  "VITE_ORCHEO_BACKEND_URL"
+  "VITE_ORCHEO_AUTH_ISSUER"
+  "VITE_ORCHEO_AUTH_CLIENT_ID"
+  "VITE_ORCHEO_AUTH_REDIRECT_URI"
+  "VITE_ORCHEO_AUTH_SCOPES"
+  "VITE_ORCHEO_AUTH_AUDIENCE"
+  "VITE_ORCHEO_AUTH_ORGANIZATION"
+  "VITE_ORCHEO_AUTH_PROVIDER_PARAM"
+  "VITE_ORCHEO_AUTH_PROVIDER_GOOGLE"
+  "VITE_ORCHEO_AUTH_PROVIDER_GITHUB"
+  "VITE_ORCHEO_CHATKIT_DOMAIN_KEY"
+)
+
+for VAR in "${VARS[@]}"; do
+  PLACEHOLDER="__${VAR}__"
+  VALUE="${!VAR}"
+  if [ -n "$VALUE" ]; then
+    echo "canvas-env: injecting $VAR"
+    find "$HTML_DIR" -type f \( -name '*.js' -o -name '*.html' \) \
+      -exec sed -i "s|${PLACEHOLDER}|${VALUE}|g" {} +
+  fi
+done

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -126,13 +126,10 @@ services:
       sh -c 'python -m celery -A orcheo_backend.worker.celery_app beat --loglevel=info -s "$$CELERY_BEAT_SCHEDULE_FILE"'
 
   canvas:
-    image: node:20-alpine
-    working_dir: /app
+    image: ${ORCHEO_CANVAS_IMAGE:-ghcr.io/shaojiejiang/orcheo-canvas:latest}
     env_file: .env
     ports:
       - "5173:5173"
-    volumes:
-      - canvas_node_modules:/app/node_modules
     environment:
       VITE_ORCHEO_BACKEND_URL: ${VITE_ORCHEO_BACKEND_URL:-http://localhost:8000}
       VITE_ORCHEO_AUTH_ISSUER: ${VITE_ORCHEO_AUTH_ISSUER:-}
@@ -145,26 +142,16 @@ services:
       VITE_ORCHEO_AUTH_PROVIDER_GOOGLE: ${VITE_ORCHEO_AUTH_PROVIDER_GOOGLE:-}
       VITE_ORCHEO_AUTH_PROVIDER_GITHUB: ${VITE_ORCHEO_AUTH_PROVIDER_GITHUB:-}
       VITE_ORCHEO_CHATKIT_DOMAIN_KEY: ${VITE_ORCHEO_CHATKIT_DOMAIN_KEY:?set VITE_ORCHEO_CHATKIT_DOMAIN_KEY}
-      VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-localhost}
-      VITE_DISABLE_HMR: ${VITE_DISABLE_HMR:-true}
     depends_on:
       - backend
-    command: >
-      sh -c "npm config set update-notifier false
-      && npm config set fund false
-      && npm config set audit false
-      && npm init -y >/dev/null
-      && npm install --silent orcheo-canvas@latest
-      && npm --prefix node_modules/orcheo-canvas run dev -- --host 0.0.0.0"
     healthcheck:
-      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:5173/', r => { r.resume(); process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1))\""]
-      interval: 15s
+      test: ["CMD-SHELL", "curl -f http://localhost:5173/ || exit 1"]
+      interval: 10s
       timeout: 5s
-      retries: 20
-      start_period: 180s
+      retries: 5
+      start_period: 10s
 
 volumes:
   postgres_data:
   redis_data:
   orcheo_data:
-  canvas_node_modules:

--- a/deploy/stack/nginx-canvas.conf
+++ b/deploy/stack/nginx-canvas.conf
@@ -1,0 +1,23 @@
+server {
+    listen 5173;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback: serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Do not cache index.html (so new deploys take effect)
+    location = /index.html {
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+}


### PR DESCRIPTION
## Summary
This PR hardens stack deployment by moving Canvas from a runtime-installed dev server to a prebuilt, releasable container image with runtime env injection.

## Main changes

### CI/CD (`.github/workflows/ci.yml`)
- Split image metadata extraction into a dedicated `stack-image-metadata` job.
- Reworked `stack-release` to consume shared metadata outputs.
- Added a new `canvas-image-release` job to build and push a Canvas image to GHCR.
- Both stack and canvas image pushes are multi-arch (`linux/amd64`, `linux/arm64`) and tagged with both version and `latest`.

### New Canvas image build/runtime files
- Added `deploy/stack/Dockerfile.canvas`:
  - Builds `orcheo-canvas` in a Node build stage.
  - Bakes placeholder `VITE_*` values into assets at build time.
  - Serves static assets via nginx in final stage.
- Added `deploy/stack/canvas-entrypoint.sh`:
  - Replaces placeholder `VITE_*` tokens in built JS/HTML with runtime env values on container startup.
- Added `deploy/stack/nginx-canvas.conf`:
  - SPA fallback routing (`try_files ... /index.html`).
  - Long-lived cache for static assets.
  - No-cache policy for `index.html`.

### Docker Compose updates (`deploy/stack/docker-compose.yml`)
- Changed `canvas` service from `node:20-alpine` + runtime npm install/dev command to a prebuilt image:
  - `image: ${ORCHEO_CANVAS_IMAGE:-ghcr.io/shaojiejiang/orcheo-canvas:latest}`
- Removed Node-specific runtime setup (`working_dir`, `volumes`, install/run `command`, `canvas_node_modules` volume).
- Kept `VITE_*` env vars for runtime injection.
- Simplified healthcheck to `curl -f http://localhost:5173/` with shorter startup/interval settings.

## Impact
- Faster and more deterministic Canvas startup.
- Cleaner separation of build vs runtime concerns.
- Production-friendly static serving for Canvas while preserving runtime configurability via env vars.
