### PR TITLE
Fix PostgreSQL pool config defaults and normalization

### DIFF
--- a/src/orcheo/config/app_settings.py
+++ b/src/orcheo/config/app_settings.py
@@ -235,11 +235,10 @@ class AppSettings(BaseModel):
     def _coerce_widget_action_types(cls, value: object) -> set[str]:
         return cls._coerce_widget_set(value, "CHATKIT_WIDGET_ACTION_TYPES")
 
-    @field_validator("postgres_pool_min_size", "postgres_pool_max_size", mode="before")
-    @classmethod
-    def _coerce_postgres_pool_int(cls, value: object) -> int:
+    @staticmethod
+    def _coerce_postgres_pool_int(value: object, default_key: str) -> int:
         if value is None:
-            return 1
+            return cast(int, _DEFAULTS[default_key])
         if isinstance(value, int):
             return value
         try:
@@ -248,11 +247,10 @@ class AppSettings(BaseModel):
             msg = "PostgreSQL pool size must be a positive integer."
             raise ValueError(msg) from exc
 
-    @field_validator("postgres_pool_timeout", "postgres_pool_max_idle", mode="before")
-    @classmethod
-    def _coerce_postgres_pool_float(cls, value: object) -> float:
+    @staticmethod
+    def _coerce_postgres_pool_float(value: object, default_key: str) -> float:
         if value is None:
-            return 30.0
+            return cast(float, _DEFAULTS[default_key])
         if isinstance(value, int | float):
             return float(value)
         try:
@@ -260,6 +258,26 @@ class AppSettings(BaseModel):
         except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
             msg = "PostgreSQL pool timeout must be a positive number."
             raise ValueError(msg) from exc
+
+    @field_validator("postgres_pool_min_size", mode="before")
+    @classmethod
+    def _coerce_postgres_pool_min_size(cls, value: object) -> int:
+        return cls._coerce_postgres_pool_int(value, "POSTGRES_POOL_MIN_SIZE")
+
+    @field_validator("postgres_pool_max_size", mode="before")
+    @classmethod
+    def _coerce_postgres_pool_max_size(cls, value: object) -> int:
+        return cls._coerce_postgres_pool_int(value, "POSTGRES_POOL_MAX_SIZE")
+
+    @field_validator("postgres_pool_timeout", mode="before")
+    @classmethod
+    def _coerce_postgres_pool_timeout(cls, value: object) -> float:
+        return cls._coerce_postgres_pool_float(value, "POSTGRES_POOL_TIMEOUT")
+
+    @field_validator("postgres_pool_max_idle", mode="before")
+    @classmethod
+    def _coerce_postgres_pool_max_idle(cls, value: object) -> float:
+        return cls._coerce_postgres_pool_float(value, "POSTGRES_POOL_MAX_IDLE")
 
     @field_validator("port", mode="before")
     @classmethod

--- a/src/orcheo/config/loader.py
+++ b/src/orcheo/config/loader.py
@@ -58,6 +58,18 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
                 "CHATKIT_RETENTION_DAYS", _DEFAULTS["CHATKIT_RETENTION_DAYS"]
             ),
             postgres_dsn=source.get("POSTGRES_DSN"),
+            postgres_pool_min_size=source.get(
+                "POSTGRES_POOL_MIN_SIZE", _DEFAULTS["POSTGRES_POOL_MIN_SIZE"]
+            ),
+            postgres_pool_max_size=source.get(
+                "POSTGRES_POOL_MAX_SIZE", _DEFAULTS["POSTGRES_POOL_MAX_SIZE"]
+            ),
+            postgres_pool_timeout=source.get(
+                "POSTGRES_POOL_TIMEOUT", _DEFAULTS["POSTGRES_POOL_TIMEOUT"]
+            ),
+            postgres_pool_max_idle=source.get(
+                "POSTGRES_POOL_MAX_IDLE", _DEFAULTS["POSTGRES_POOL_MAX_IDLE"]
+            ),
             host=source.get("HOST", _DEFAULTS["HOST"]),
             port=source.get("PORT", _DEFAULTS["PORT"]),
             vault=VaultSettings(
@@ -133,6 +145,10 @@ def _normalize_settings(source: Dynaconf) -> Dynaconf:
         "CHATKIT_WIDGET_ACTION_TYPES", sorted(settings.chatkit_widget_action_types)
     )
     normalized.set("POSTGRES_DSN", settings.postgres_dsn)
+    normalized.set("POSTGRES_POOL_MIN_SIZE", settings.postgres_pool_min_size)
+    normalized.set("POSTGRES_POOL_MAX_SIZE", settings.postgres_pool_max_size)
+    normalized.set("POSTGRES_POOL_TIMEOUT", settings.postgres_pool_timeout)
+    normalized.set("POSTGRES_POOL_MAX_IDLE", settings.postgres_pool_max_idle)
     normalized.set("HOST", settings.host)
     normalized.set("PORT", settings.port)
     normalized.set("VAULT_BACKEND", settings.vault.backend)

--- a/tests/config/test_app_settings.py
+++ b/tests/config/test_app_settings.py
@@ -42,24 +42,28 @@ def test_coerce_widget_set_reverts_to_defaults_for_empty_collections() -> None:
 
 def test_coerce_postgres_pool_int_defaults_and_valid_values() -> None:
     """Test _coerce_postgres_pool_int handles various input types."""
-    # None defaults to 1
-    assert AppSettings._coerce_postgres_pool_int(None) == 1
-    # Integer values pass through
-    assert AppSettings._coerce_postgres_pool_int(5) == 5
-    # String integers are converted
-    assert AppSettings._coerce_postgres_pool_int("10") == 10
+    assert AppSettings._coerce_postgres_pool_int(None, "POSTGRES_POOL_MIN_SIZE") == 1
+    assert AppSettings._coerce_postgres_pool_int(None, "POSTGRES_POOL_MAX_SIZE") == 10
+    assert AppSettings._coerce_postgres_pool_int(5, "POSTGRES_POOL_MIN_SIZE") == 5
+    assert AppSettings._coerce_postgres_pool_int("10", "POSTGRES_POOL_MAX_SIZE") == 10
 
 
 def test_coerce_postgres_pool_float_defaults_and_valid_values() -> None:
     """Test _coerce_postgres_pool_float handles various input types."""
-    # None defaults to 30.0
-    assert AppSettings._coerce_postgres_pool_float(None) == 30.0
-    # Integer values are converted to float
-    assert AppSettings._coerce_postgres_pool_float(60) == 60.0
-    # Float values pass through
-    assert AppSettings._coerce_postgres_pool_float(45.5) == 45.5
-    # String numbers are converted
-    assert AppSettings._coerce_postgres_pool_float("120.5") == 120.5
+    assert (
+        AppSettings._coerce_postgres_pool_float(None, "POSTGRES_POOL_TIMEOUT") == 30.0
+    )
+    assert (
+        AppSettings._coerce_postgres_pool_float(None, "POSTGRES_POOL_MAX_IDLE") == 300.0
+    )
+    assert AppSettings._coerce_postgres_pool_float(60, "POSTGRES_POOL_TIMEOUT") == 60.0
+    assert (
+        AppSettings._coerce_postgres_pool_float(45.5, "POSTGRES_POOL_MAX_IDLE") == 45.5
+    )
+    assert (
+        AppSettings._coerce_postgres_pool_float("120.5", "POSTGRES_POOL_TIMEOUT")
+        == 120.5
+    )
 
 
 def test_coerce_graph_store_backend_defaults_and_valid_values() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,6 +54,10 @@ def test_settings_defaults(
     assert settings.graph_store_sqlite_path == str(_DEFAULTS["GRAPH_STORE_SQLITE_PATH"])
     assert settings.chatkit_backend == "sqlite"
     assert settings.chatkit_sqlite_path == "~/.orcheo/chatkit.sqlite"
+    assert settings.postgres_pool_min_size == 1
+    assert settings.postgres_pool_max_size == 10
+    assert settings.postgres_pool_timeout == 30.0
+    assert settings.postgres_pool_max_idle == 300.0
     assert settings.host == "0.0.0.0"
     assert settings.port == 8000
     assert settings.vault_backend == "file"
@@ -163,6 +167,22 @@ def test_postgres_graph_store_requires_dsn(monkeypatch: pytest.MonkeyPatch) -> N
     settings = config.get_settings(refresh=True)
     assert settings.graph_store_backend == "postgres"
     assert settings.postgres_dsn == "postgresql://example"
+
+
+def test_postgres_pool_settings_are_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Postgres pool settings should be available on normalized settings."""
+
+    monkeypatch.setenv("ORCHEO_POSTGRES_POOL_MIN_SIZE", "2")
+    monkeypatch.setenv("ORCHEO_POSTGRES_POOL_MAX_SIZE", "9")
+    monkeypatch.setenv("ORCHEO_POSTGRES_POOL_TIMEOUT", "12")
+    monkeypatch.setenv("ORCHEO_POSTGRES_POOL_MAX_IDLE", "60")
+
+    settings = config.get_settings(refresh=True)
+
+    assert settings.postgres_pool_min_size == 2
+    assert settings.postgres_pool_max_size == 9
+    assert settings.postgres_pool_timeout == 12.0
+    assert settings.postgres_pool_max_idle == 60.0
 
 
 def test_graph_store_sqlite_path_must_be_absolute(


### PR DESCRIPTION
## Summary

This PR fixes PostgreSQL pool configuration handling so the normalized app settings expose all pool fields and each field falls back to its correct default value.

## Main Changes

- Split PostgreSQL pool coercion so each field uses its own default key instead of sharing a single fallback.
- Fix the default behavior for:
  - `POSTGRES_POOL_MAX_SIZE` to use its intended default (`10`) instead of the min-size fallback.
  - `POSTGRES_POOL_MAX_IDLE` to use its intended default (`300.0`) instead of the timeout fallback.
- Pass PostgreSQL pool settings through the config normalization layer in `src/orcheo/config/loader.py`.
- Write the normalized PostgreSQL pool settings back onto the Dynaconf settings object so they are available via `config.get_settings()`.

## Tests

- Updated unit tests for the PostgreSQL pool coercion helpers to verify per-field defaults and value parsing.
- Added config tests to verify:
  - default PostgreSQL pool settings are present on loaded settings
  - environment overrides for PostgreSQL pool settings are loaded correctly

## Impact

After this change, PostgreSQL pool sizing and timeout settings are consistently available from the app config and no longer silently fall back to the wrong defaults.
