### PR TITLE
Add third-party ChatKit JWT embedding docs and SDK human CLI alias

### DIFF
--- a/docs/authentication_guide.md
+++ b/docs/authentication_guide.md
@@ -483,6 +483,7 @@ Scopes define fine-grained permissions for authenticated identities:
 | `vault:write` | Manage credentials in vault |
 | `admin:tokens:read` | View service tokens |
 | `admin:tokens:write` | Create, rotate, and revoke service tokens |
+| `chatkit:session` | Issue short-lived ChatKit session JWTs via `POST /api/chatkit/session` |
 
 ### Checking Scopes in Code
 

--- a/docs/chatkit_integration/webpage_embedding_guide.md
+++ b/docs/chatkit_integration/webpage_embedding_guide.md
@@ -147,7 +147,245 @@ copy/paste or customize.
 - **Bubble never opens** – check the console for errors and verify the page
   called `chatkit.setOptions` after the custom element loaded.
 
+## Embedding on a Third-Party Website with JWT Tokens
+
+The steps above work for **public** (published) workflows where no login is required.
+If you want to embed ChatKit on an external website while keeping the workflow private
+— or when the 3rd-party site cannot share cookies with your Canvas origin — use
+**short-lived session JWTs** instead.  The pattern is:
+
+```mermaid
+sequenceDiagram
+    participant P as 3rd-party page
+    participant S as Your server (token proxy)
+    participant O as Orcheo backend
+
+    P->>S: POST /chatkit-token
+    S->>O: POST /api/chatkit/session
+    note over S,O: Authorization: Bearer service-token
+    O-->>S: { client_secret, expires_at }
+    S-->>P: { token, expires_at }
+    P->>O: openai-chatkit requests
+    note over P,O: Authorization: Bearer token
+```
+
+### Step 1 — Create a service token with `chatkit:session` scope
+
+Orcheo's `POST /api/chatkit/session` endpoint requires the caller to hold the
+`chatkit:session` scope.  Create a dedicated service token for your embedding
+proxy:
+
+```bash
+# Point the CLI at your Orcheo backend
+export ORCHEO_API_URL="https://orcheo.example.com"
+export ORCHEO_SERVICE_TOKEN="<your-admin-or-bootstrap-token>"
+
+orcheo token create \
+  --id chatkit-embed-proxy \
+  --scope chatkit:session
+```
+
+> **Token is shown only once.** Copy the secret immediately and store it in your
+> secret manager (AWS Secrets Manager, Vault, 1Password, etc.).  The token only
+> needs the `chatkit:session` scope — no broader access is required.
+
+Verify the token was created:
+
+```bash
+orcheo token list
+# ID                  SCOPES             STATUS
+# chatkit-embed-proxy chatkit:session    active
+```
+
+To rotate the token later (e.g. on a 90-day schedule):
+
+```bash
+orcheo token rotate chatkit-embed-proxy --overlap 600
+```
+
+### Step 2 — Serve a token-vending endpoint from your server
+
+Your server-side proxy exchanges the service token for a short-lived ChatKit JWT
+(`client_secret`).  **Never expose the service token to the browser.**
+
+=== "Python (FastAPI)"
+
+    ```python
+    import httpx
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app = FastAPI()
+
+    # Allow only the domains that host the embedded widget
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["https://your-website.example.com"],
+        allow_methods=["POST"],
+    )
+
+    ORCHEO_BACKEND = "https://orcheo.example.com"
+    ORCHEO_SERVICE_TOKEN = "your-chatkit-embed-proxy-secret"  # from env in practice
+
+    @app.post("/chatkit-token")
+    async def get_chatkit_token(workflow_id: str):
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{ORCHEO_BACKEND}/api/chatkit/session",
+                headers={"Authorization": f"Bearer {ORCHEO_SERVICE_TOKEN}"},
+                json={"workflow_id": workflow_id},
+            )
+            resp.raise_for_status()
+            return resp.json()  # { "client_secret": "...", "expires_at": "..." }
+    ```
+
+=== "JavaScript (Express)"
+
+    ```js
+    import express from "express";
+    import cors from "cors";
+
+    const app = express();
+
+    const ORCHEO_BACKEND = "https://orcheo.example.com";
+    const ORCHEO_SERVICE_TOKEN = process.env.ORCHEO_SERVICE_TOKEN;
+
+    // Allow only the domains that host the embedded widget
+    app.use(cors({ origin: "https://your-website.example.com", methods: ["POST"] }));
+    app.use(express.json());
+
+    app.post("/chatkit-token", async (req, res) => {
+      const { workflow_id } = req.query;
+      const response = await fetch(`${ORCHEO_BACKEND}/api/chatkit/session`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${ORCHEO_SERVICE_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ workflow_id }),
+      });
+      if (!response.ok) {
+        return res.status(response.status).json(await response.json());
+      }
+      res.json(await response.json()); // { client_secret, expires_at }
+    });
+
+    app.listen(3000);
+    ```
+
+The `client_secret` JWT has a short TTL (default 300 s, tunable via
+`CHATKIT_TOKEN_TTL_SECONDS` on the Orcheo backend).  The embed refreshes it
+automatically before it expires.
+
+### Step 3 — Embed the widget with JWT authentication
+
+Add the same `<openai-chatkit>` web component as for public embeds, but inject
+an `Authorization: Bearer` header via the custom `fetch` wrapper.  The token
+is transparently refreshed before each near-expiry request.
+
+```html
+<!-- 1. Load the ChatKit bundle -->
+<script
+  async
+  src="https://orcheo.example.com/api/chatkit/assets/chatkit.js"
+  crossorigin="anonymous"
+></script>
+
+<!-- 2. Widget container -->
+<openai-chatkit></openai-chatkit>
+
+<script type="module">
+  const WORKFLOW_ID  = "wf_your_workflow_id";
+  const BACKEND      = "https://orcheo.example.com";
+  const TOKEN_URL    = "https://your-server.example.com/chatkit-token";
+  const DOMAIN_KEY   = window.ORCHEO_CHATKIT_DOMAIN_KEY || "domain_pk_localhost_dev";
+
+  // --- Token management ---
+  let session = { token: null, expiresAt: new Date(0) };
+
+  async function refreshToken() {
+    const res = await fetch(`${TOKEN_URL}?workflow_id=${WORKFLOW_ID}`, {
+      method: "POST",
+    });
+    if (!res.ok) throw new Error(`Token fetch failed: ${res.status}`);
+    const { client_secret, expires_at } = await res.json();
+    session = { token: client_secret, expiresAt: new Date(expires_at) };
+  }
+
+  async function getToken() {
+    // Refresh if within 30 s of expiry
+    if (Date.now() > session.expiresAt - 30_000) {
+      await refreshToken();
+    }
+    return session.token;
+  }
+
+  // --- Custom fetch that injects Authorization + workflow_id ---
+  const fetchWithJwt = async (input, init = {}) => {
+    const token   = await getToken();
+    const headers = new Headers(init.headers || {});
+    headers.set("Authorization", `Bearer ${token}`);
+
+    // Inject workflow_id into the request body
+    const bodyStr = typeof init.body === "string" ? init.body : null;
+    const body    = bodyStr ? JSON.parse(bodyStr) : {};
+    body.workflow_id ??= WORKFLOW_ID;
+    headers.set("Content-Type", "application/json");
+
+    return fetch(input ?? `${BACKEND}/api/chatkit`, {
+      ...init,
+      headers,
+      body: JSON.stringify(body),
+    });
+  };
+
+  // --- Wire up the widget ---
+  const chatkit = document.querySelector("openai-chatkit");
+
+  const configure = () =>
+    chatkit.setOptions({
+      api: {
+        url: `${BACKEND}/api/chatkit`,
+        domainKey: DOMAIN_KEY,
+        fetch: fetchWithJwt,
+      },
+      header:   { enabled: true, title: { text: "Support Assistant" } },
+      history:  { enabled: true },
+      composer: { placeholder: "Ask a question…" },
+    });
+
+  if (customElements.get("openai-chatkit")) {
+    configure();
+  } else {
+    customElements.whenDefined("openai-chatkit").then(configure);
+  }
+</script>
+```
+
+### Differences from the public embed
+
+| | Public embed | JWT embed |
+|---|---|---|
+| Workflow visibility | `is_public = true` required | Private workflows supported |
+| Auth mechanism | Cookies (`credentials: "include"`) | `Authorization: Bearer <token>` |
+| Session source | None | `POST /api/chatkit/session` via your proxy |
+| Service token scope needed | None | `chatkit:session` |
+| Token TTL | N/A | 300 s default; auto-refreshed by the widget |
+
+### Troubleshooting JWT embeds
+
+- **401 on `/api/chatkit/session`** – confirm your service token has the
+  `chatkit:session` scope (`orcheo token show chatkit-embed-proxy`).
+- **401 on `/api/chatkit`** – the `client_secret` JWT may have expired without
+  being refreshed; check the 30-second refresh window in `getToken()`.
+- **CORS errors on your token proxy** – add the 3rd-party origin to
+  `allow_origins` in your proxy server and to `ORCHEO_CORS_ALLOW_ORIGINS` on
+  the Orcheo backend.
+- **`CHATKIT_TOKEN_SIGNING_KEY` not set** – the session endpoint returns 500
+  if this key is missing; see `docs/environment_variables.md`.
+
 ## References
 - Working demo: `examples/chatkit-orcheo.html`
 - Backend contract: `apps/backend/src/orcheo_backend/app/routers/chatkit.py`
 - Canvas embedding code: `apps/canvas/src/features/chatkit/components/public-chat-widget.tsx`
+- Authentication guide: `docs/authentication_guide.md`

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 ]
 
 [project.scripts]
+horcheo = "orcheo_sdk.cli.main:run_human"
 orcheo = "orcheo_sdk.cli.main:run"
 orcheo-human = "orcheo_sdk.cli.main:run_human"
 


### PR DESCRIPTION
## Summary

This PR expands the ChatKit embedding documentation for third-party websites and updates the SDK package metadata to expose an additional human-oriented CLI command alias.

## Changes

- Add a new JWT-based third-party embedding section to `docs/chatkit_integration/webpage_embedding_guide.md`, including:
  - the end-to-end session-token flow
  - instructions for creating a service token with `chatkit:session`
  - example token-vending proxy implementations in FastAPI and Express
  - a browser embed example that injects bearer tokens and refreshes them before expiry
  - a comparison of public embeds vs JWT-authenticated embeds
  - JWT-specific troubleshooting guidance
- Update `docs/authentication_guide.md` to document the `chatkit:session` scope and its use for `POST /api/chatkit/session`
- Add `horcheo` as an SDK console script alias for the human CLI entrypoint in `packages/sdk/pyproject.toml`

## Testing

- Not run (docs change plus package script metadata update)
