### PR TITLE
Add stack-aware plugin management and improve template workflow UX

### DIFF
--- a/apps/backend/src/orcheo_backend/app/plugin_inventory.py
+++ b/apps/backend/src/orcheo_backend/app/plugin_inventory.py
@@ -1,0 +1,50 @@
+"""Helpers for inspecting plugin availability in the current backend process."""
+
+from __future__ import annotations
+from collections.abc import Iterable
+from typing import Any
+from orcheo.plugins import PluginManager, load_enabled_plugins
+
+
+def list_runtime_plugins() -> list[dict[str, Any]]:
+    """Return plugin inventory plus current-process load status."""
+    rows = PluginManager().list_plugins()
+    report = load_enabled_plugins(force=False)
+    results = {result.name: result for result in report.results}
+    plugins: list[dict[str, Any]] = []
+    for row in rows:
+        name = str(row["name"])
+        load_result = results.get(name)
+        plugins.append(
+            {
+                "name": name,
+                "enabled": bool(row["enabled"]),
+                "status": str(row["status"]),
+                "version": str(row["version"]),
+                "exports": [str(item) for item in row["exports"]],
+                "loaded": bool(load_result.loaded)
+                if load_result is not None
+                else False,
+                "load_error": load_result.error if load_result is not None else None,
+            }
+        )
+    return plugins
+
+
+def missing_required_plugins(required_plugins: Iterable[str]) -> list[str]:
+    """Return required plugin names unavailable in the current backend process."""
+    required = sorted(
+        {str(name).strip() for name in required_plugins if str(name).strip()}
+    )
+    if not required:
+        return []
+    inventory = {plugin["name"]: plugin for plugin in list_runtime_plugins()}
+    missing: list[str] = []
+    for name in required:
+        plugin = inventory.get(name)
+        if plugin is None or not plugin["enabled"] or not plugin["loaded"]:
+            missing.append(name)
+    return missing
+
+
+__all__ = ["list_runtime_plugins", "missing_required_plugins"]

--- a/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
+++ b/apps/backend/src/orcheo_backend/app/repository_postgres/_base.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 AsyncConnectionPool: Any | None
 DictRowFactory: Any | None
 
+_INIT_LOCK_NAMESPACE = 0x4F524348
+_INIT_LOCK_KEY = 1
+
 try:  # pragma: no cover - optional dependency
     AsyncConnectionPool = importlib.import_module("psycopg_pool").AsyncConnectionPool
     DictRowFactory = importlib.import_module("psycopg.rows").dict_row
@@ -252,6 +255,11 @@ class PostgresRepositoryBase:
                 return
 
             async with self._connection() as conn:
+                # Serialize first-run schema work across worker processes.
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(%s, %s)",
+                    (_INIT_LOCK_NAMESPACE, _INIT_LOCK_KEY),
+                )
                 # Execute schema statements one by one
                 for raw_stmt in POSTGRES_SCHEMA.strip().split(";"):
                     stmt = raw_stmt.strip()
@@ -290,31 +298,34 @@ class PostgresRepositoryBase:
         )
         rows = await cursor.fetchall()
         existing_columns = {row["column_name"] for row in rows}
-        if "handle" not in existing_columns:
+        missing_handle = "handle" not in existing_columns
+        missing_is_archived = "is_archived" not in existing_columns
+        if missing_handle:
             await conn.execute("ALTER TABLE workflows ADD COLUMN handle TEXT")
-        if "is_archived" not in existing_columns:
+        if missing_is_archived:
             await conn.execute(
                 "ALTER TABLE workflows "
                 "ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE"
             )
 
-        cursor = await conn.execute("SELECT id, payload FROM workflows")
-        rows = await cursor.fetchall()
-        for row in rows:
-            workflow = Workflow.model_validate(row["payload"])
-            await conn.execute(
-                """
-                UPDATE workflows
-                   SET handle = %s, is_archived = %s, updated_at = %s
-                 WHERE id = %s
-                """,
-                (
-                    workflow.handle,
-                    workflow.is_archived,
-                    workflow.updated_at,
-                    row["id"],
-                ),
-            )
+        if missing_handle or missing_is_archived:
+            cursor = await conn.execute("SELECT id, payload FROM workflows")
+            rows = await cursor.fetchall()
+            for row in rows:
+                workflow = Workflow.model_validate(row["payload"])
+                await conn.execute(
+                    """
+                    UPDATE workflows
+                       SET handle = %s, is_archived = %s, updated_at = %s
+                     WHERE id = %s
+                    """,
+                    (
+                        workflow.handle,
+                        workflow.is_archived,
+                        workflow.updated_at,
+                        row["id"],
+                    ),
+                )
 
         # Create indexes after columns are guaranteed to exist
         await conn.execute(

--- a/apps/backend/src/orcheo_backend/app/routers/system.py
+++ b/apps/backend/src/orcheo_backend/app/routers/system.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 from fastapi import APIRouter
-from orcheo_backend.app.schemas.system import SystemInfoResponse
+from orcheo_backend.app.plugin_inventory import list_runtime_plugins
+from orcheo_backend.app.schemas.system import (
+    SystemInfoResponse,
+    SystemPluginsResponse,
+)
 from orcheo_backend.app.versioning import get_system_info_payload
 
 
@@ -20,6 +24,12 @@ def get_system_health() -> dict[str, str]:
 def get_system_info() -> SystemInfoResponse:
     """Return current and latest version metadata for Orcheo components."""
     return SystemInfoResponse.model_validate(get_system_info_payload())
+
+
+@router.get("/system/plugins", response_model=SystemPluginsResponse)
+def get_system_plugins() -> SystemPluginsResponse:
+    """Return plugin availability for the current backend process."""
+    return SystemPluginsResponse.model_validate({"plugins": list_runtime_plugins()})
 
 
 __all__ = ["public_router", "router"]

--- a/apps/backend/src/orcheo_backend/app/routers/workflows.py
+++ b/apps/backend/src/orcheo_backend/app/routers/workflows.py
@@ -24,6 +24,7 @@ from orcheo_backend.app.chatkit_runtime import resolve_chatkit_token_issuer
 from orcheo_backend.app.chatkit_tokens import ChatKitSessionTokenIssuer
 from orcheo_backend.app.dependencies import RepositoryDep
 from orcheo_backend.app.errors import raise_not_found
+from orcheo_backend.app.plugin_inventory import missing_required_plugins
 from orcheo_backend.app.repository import (
     CronTriggerNotFoundError,
     WorkflowHandleConflictError,
@@ -82,6 +83,23 @@ def _apply_share_urls(
     for workflow in workflows:
         _apply_share_url(workflow, public_base_url)
     return workflows
+
+
+def _required_plugins_from_metadata(metadata: dict[str, Any]) -> list[str]:
+    """Extract template plugin prerequisites from workflow-version metadata."""
+    template_metadata = metadata.get("template")
+    if not isinstance(template_metadata, dict):
+        return []
+    raw_required = template_metadata.get("requiredPlugins")
+    if raw_required is None:
+        raw_required = template_metadata.get("required_plugins")
+    if not isinstance(raw_required, list):
+        return []
+    return [
+        str(plugin_name).strip()
+        for plugin_name in raw_required
+        if str(plugin_name).strip()
+    ]
 
 
 def _serialize_runnable_config(
@@ -419,6 +437,18 @@ async def ingest_workflow_version(
 ) -> WorkflowVersion:
     """Create a workflow version from a LangGraph Python script."""
     workflow_id = await _resolve_workflow_uuid(repository, workflow_ref)
+    required_plugins = _required_plugins_from_metadata(request.metadata)
+    missing_plugins = missing_required_plugins(required_plugins)
+    if missing_plugins:
+        plugin_list = ", ".join(missing_plugins)
+        noun = "plugin" if len(missing_plugins) == 1 else "plugins"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Missing required {noun} for this template: {plugin_list}. "
+                "Install them into the runtime before importing the template."
+            ),
+        )
     try:
         graph_payload = ingest_langgraph_script(
             request.script,

--- a/apps/backend/src/orcheo_backend/app/schemas/system.py
+++ b/apps/backend/src/orcheo_backend/app/schemas/system.py
@@ -23,3 +23,21 @@ class SystemInfoResponse(BaseModel):
     cli: PackageVersionStatus
     canvas: PackageVersionStatus
     checked_at: datetime
+
+
+class SystemPluginStatus(BaseModel):
+    """Plugin status as observed by the current backend process."""
+
+    name: str
+    enabled: bool
+    status: str
+    version: str
+    exports: list[str]
+    loaded: bool
+    load_error: str | None = None
+
+
+class SystemPluginsResponse(BaseModel):
+    """Installed plugin inventory for the current backend process."""
+
+    plugins: list[SystemPluginStatus]

--- a/apps/canvas/src/features/workflow/components/dialogs/confirm-delete-workflow-dialog.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/confirm-delete-workflow-dialog.tsx
@@ -1,0 +1,52 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/design-system/ui/alert-dialog";
+
+interface ConfirmDeleteWorkflowDialogProps {
+  open: boolean;
+  workflowName: string;
+  isPending?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+}
+
+export function ConfirmDeleteWorkflowDialog({
+  open,
+  workflowName,
+  isPending = false,
+  onOpenChange,
+  onConfirm,
+}: ConfirmDeleteWorkflowDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete workflow?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {`"${workflowName}" will be permanently removed from your workspace. This action cannot be undone.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={(event) => {
+              event.preventDefault();
+              void onConfirm();
+            }}
+            disabled={isPending}
+          >
+            {isPending ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/canvas/src/features/workflow/components/dialogs/credentials-table.tsx
+++ b/apps/canvas/src/features/workflow/components/dialogs/credentials-table.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/design-system/ui/badge";
 import { Button } from "@/design-system/ui/button";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +19,7 @@ import {
   TableRow,
 } from "@/design-system/ui/table";
 import {
+  Check,
   Copy,
   Edit,
   Eye,
@@ -26,6 +28,7 @@ import {
   Loader2,
   MoreHorizontal,
   Trash,
+  X,
 } from "lucide-react";
 import type {
   Credential,
@@ -50,6 +53,7 @@ interface CredentialsTableProps {
 const SECRET_PLACEHOLDER = "•••••••••••••••";
 const MASKED_SECRET_MARKER = "•";
 const SECRET_VALUE_WIDTH_CLASS = "w-[120px]";
+type CredentialCopyState = "idle" | "success" | "error";
 
 const isMaskedSecret = (value: string): boolean =>
   value.includes(MASKED_SECRET_MARKER);
@@ -88,9 +92,20 @@ export function CredentialsTable({
   const [loadingSecretState, setLoadingSecretState] = useState<
     Record<string, boolean>
   >({});
+  const [copyState, setCopyState] = useState<
+    Record<string, CredentialCopyState>
+  >({});
   const [editingCredential, setEditingCredential] = useState<Credential | null>(
     null,
   );
+  const copyResetTimersRef = useRef<Record<string, number>>({});
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const filteredCredentials = useMemo(() => {
     if (!searchQuery) {
@@ -161,17 +176,49 @@ export function CredentialsTable({
   };
 
   const copySecret = async (credential: Credential) => {
-    let secret: string | undefined;
     try {
-      secret = await ensureCredentialSecret(credential);
+      const secret = await ensureCredentialSecret(credential);
+      if (!secret || typeof navigator === "undefined" || !navigator.clipboard) {
+        throw new Error("Clipboard API is unavailable");
+      }
+      await navigator.clipboard.writeText(secret);
+      setCredentialCopyState(credential.id, "success");
     } catch (error) {
       console.error("Failed to copy credential secret", error);
+      setCredentialCopyState(credential.id, "error");
+    }
+  };
+
+  const setCredentialCopyState = (
+    credentialId: string,
+    nextState: CredentialCopyState,
+  ) => {
+    const activeTimer = copyResetTimersRef.current[credentialId];
+    if (activeTimer !== undefined) {
+      window.clearTimeout(activeTimer);
+      delete copyResetTimersRef.current[credentialId];
+    }
+
+    setCopyState((previous) => ({
+      ...previous,
+      [credentialId]: nextState,
+    }));
+
+    if (nextState === "idle") {
       return;
     }
-    if (!secret || typeof navigator === "undefined") {
-      return;
-    }
-    await navigator.clipboard.writeText(secret);
+
+    copyResetTimersRef.current[credentialId] = window.setTimeout(() => {
+      if (!isMountedRef.current) {
+        delete copyResetTimersRef.current[credentialId];
+        return;
+      }
+      setCopyState((previous) => ({
+        ...previous,
+        [credentialId]: "idle",
+      }));
+      delete copyResetTimersRef.current[credentialId];
+    }, 2000);
   };
 
   const openCredentialEditor = async (credential: Credential) => {
@@ -243,6 +290,7 @@ export function CredentialsTable({
               const secretVisible = visibleSecrets[credential.id];
               const isLoadingSecret =
                 loadingSecretState[credential.id] === true;
+              const currentCopyState = copyState[credential.id] ?? "idle";
               const provider =
                 credential.provider ?? credential.type ?? "unknown";
               const hasSecret =
@@ -307,12 +355,24 @@ export function CredentialsTable({
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-6 w-6"
+                        className={cn(
+                          "h-6 w-6 transition-colors",
+                          currentCopyState === "success" &&
+                            "text-emerald-600 hover:text-emerald-700",
+                          currentCopyState === "error" &&
+                            "text-destructive hover:text-destructive",
+                        )}
                         onClick={() => void copySecret(credential)}
-                        disabled={!canReadSecret}
+                        disabled={!canReadSecret || isLoadingSecret}
                         aria-label={`Copy secret for ${credential.name}`}
                       >
-                        <Copy className="h-3 w-3" />
+                        {currentCopyState === "success" ? (
+                          <Check className="h-3 w-3 animate-in zoom-in-50 fade-in-0" />
+                        ) : currentCopyState === "error" ? (
+                          <X className="h-3 w-3 animate-in zoom-in-50 fade-in-0" />
+                        ) : (
+                          <Copy className="h-3 w-3" />
+                        )}
                       </Button>
                     </div>
                   </TableCell>

--- a/apps/canvas/src/features/workflow/data/templates/discord-private-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/discord-private-listener.ts
@@ -10,18 +10,18 @@ config:
     curve: linear
 ---
 graph TD;
-	root__start(["START"]):::first
-	root__node__discord_listener["DiscordBotListenerNode"]
-	root__node__agent_reply["AgentNode"]
-	root__node__send_discord["MessageDiscordNode"]
-	root__end(["END"]):::last
-	root__start --> root__node__discord_listener;
-	root__node__discord_listener --> root__node__agent_reply;
-	root__node__agent_reply --> root__node__send_discord;
-	root__node__send_discord --> root__end;
-	classDef default fill:#eef4ff,line-height:1.2
+	__start__([<p>START</p>]):::first
+	discord_listener(discord_listener)
+	agent_reply(agent_reply)
+	send_discord(send_discord)
+	__end__([<p>END</p>]):::last
+	__start__ --> discord_listener;
+	agent_reply --> send_discord;
+	discord_listener --> agent_reply;
+	send_discord --> __end__;
+	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
-	classDef last fill:#94b8ff
+	classDef last fill:#bfb6fc
 `;
 
 export const DISCORD_PRIVATE_LISTENER_WORKFLOW: Workflow = {

--- a/apps/canvas/src/features/workflow/data/templates/private-bot-shared-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/private-bot-shared-listener.ts
@@ -10,32 +10,30 @@ config:
     curve: linear
 ---
 graph TD;
-	root__start(["START"]):::first
-	root__node__telegram_listener["TelegramBotListenerNode"]
-	root__node__discord_listener["DiscordBotListenerNode"]
-	root__node__qq_listener["QQBotListenerNode"]
-	root__node__agent_reply["AgentNode"]
-	root__node__reply_route{"SwitchNode"}
-	root__node__send_telegram["MessageTelegramNode"]
-	root__node__send_discord["MessageDiscordNode"]
-	root__node__send_qq["MessageQQNode"]
-	root__end(["END"]):::last
-	root__start --> root__node__telegram_listener;
-	root__start --> root__node__discord_listener;
-	root__start --> root__node__qq_listener;
-	root__node__telegram_listener --> root__node__agent_reply;
-	root__node__discord_listener --> root__node__agent_reply;
-	root__node__qq_listener --> root__node__agent_reply;
-	root__node__agent_reply --> root__node__reply_route;
-	root__node__reply_route -->|telegram| root__node__send_telegram;
-	root__node__reply_route -->|discord| root__node__send_discord;
-	root__node__reply_route -->|qq| root__node__send_qq;
-	root__node__send_telegram --> root__end;
-	root__node__send_discord --> root__end;
-	root__node__send_qq --> root__end;
-	classDef default fill:#eef4ff,line-height:1.2
+	__start__([<p>START</p>]):::first
+	telegram_listener(telegram_listener)
+	discord_listener(discord_listener)
+	qq_listener(qq_listener)
+	agent_reply(agent_reply)
+	send_telegram(send_telegram)
+	send_discord(send_discord)
+	send_qq(send_qq)
+	__end__([<p>END</p>]):::last
+	__start__ --> discord_listener;
+	__start__ --> qq_listener;
+	__start__ --> telegram_listener;
+	agent_reply -. &nbsp;discord&nbsp; .-> send_discord;
+	agent_reply -. &nbsp;qq&nbsp; .-> send_qq;
+	agent_reply -. &nbsp;telegram&nbsp; .-> send_telegram;
+	discord_listener --> agent_reply;
+	qq_listener --> agent_reply;
+	telegram_listener --> agent_reply;
+	send_discord --> __end__;
+	send_qq --> __end__;
+	send_telegram --> __end__;
+	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
-	classDef last fill:#94b8ff
+	classDef last fill:#bfb6fc
 `;
 
 export const PRIVATE_BOT_SHARED_LISTENER_WORKFLOW: Workflow = {

--- a/apps/canvas/src/features/workflow/data/templates/qq-private-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/qq-private-listener.ts
@@ -10,18 +10,18 @@ config:
     curve: linear
 ---
 graph TD;
-	root__start(["START"]):::first
-	root__node__qq_listener["QQBotListenerNode"]
-	root__node__agent_reply["AgentNode"]
-	root__node__send_qq["MessageQQNode"]
-	root__end(["END"]):::last
-	root__start --> root__node__qq_listener;
-	root__node__qq_listener --> root__node__agent_reply;
-	root__node__agent_reply --> root__node__send_qq;
-	root__node__send_qq --> root__end;
-	classDef default fill:#eef4ff,line-height:1.2
+	__start__([<p>START</p>]):::first
+	qq_listener(qq_listener)
+	agent_reply(agent_reply)
+	send_qq(send_qq)
+	__end__([<p>END</p>]):::last
+	__start__ --> qq_listener;
+	agent_reply --> send_qq;
+	qq_listener --> agent_reply;
+	send_qq --> __end__;
+	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
-	classDef last fill:#94b8ff
+	classDef last fill:#bfb6fc
 `;
 
 export const QQ_PRIVATE_LISTENER_WORKFLOW: Workflow = {

--- a/apps/canvas/src/features/workflow/data/templates/telegram-private-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/telegram-private-listener.ts
@@ -10,18 +10,18 @@ config:
     curve: linear
 ---
 graph TD;
-	root__start(["START"]):::first
-	root__node__telegram_listener["TelegramBotListenerNode"]
-	root__node__agent_reply["AgentNode"]
-	root__node__send_telegram["MessageTelegramNode"]
-	root__end(["END"]):::last
-	root__start --> root__node__telegram_listener;
-	root__node__telegram_listener --> root__node__agent_reply;
-	root__node__agent_reply --> root__node__send_telegram;
-	root__node__send_telegram --> root__end;
-	classDef default fill:#eef4ff,line-height:1.2
+	__start__([<p>START</p>]):::first
+	telegram_listener(telegram_listener)
+	agent_reply(agent_reply)
+	send_telegram(send_telegram)
+	__end__([<p>END</p>]):::last
+	__start__ --> telegram_listener;
+	agent_reply --> send_telegram;
+	telegram_listener --> agent_reply;
+	send_telegram --> __end__;
+	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
-	classDef last fill:#94b8ff
+	classDef last fill:#bfb6fc
 `;
 
 export const TELEGRAM_PRIVATE_LISTENER_WORKFLOW: Workflow = {

--- a/apps/canvas/src/features/workflow/data/templates/template-definition.ts
+++ b/apps/canvas/src/features/workflow/data/templates/template-definition.ts
@@ -10,6 +10,7 @@ export interface WorkflowTemplateMetadata {
   acceptanceCriteria: string[];
   revalidationTriggers: string[];
   replyNodeContracts?: string[];
+  requiredPlugins?: string[];
 }
 
 export interface WorkflowTemplateDefinition {

--- a/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
@@ -230,6 +230,10 @@ export const WECOM_LARK_SHARED_LISTENER_TEMPLATE: WorkflowTemplateDefinition = {
     validatedProviderApi: "wecom-lark-listener-plugin-suite-2026-03-16",
     validationDate: "2026-03-16",
     owner: "Shaojie Jiang",
+    requiredPlugins: [
+      "orcheo-plugin-wecom-listener",
+      "orcheo-plugin-lark-listener",
+    ],
     acceptanceCriteria: [
       "Imports into Canvas once both listener plugins are installed.",
       "Compiles valid WeCom and Lark listener subscriptions from one workflow.",

--- a/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
@@ -10,30 +10,28 @@ config:
     curve: linear
 ---
 graph TD;
-	root__start(["START"]):::first
-	root__node__wecom_listener["WeComListenerPluginNode"]
-	root__node__lark_listener["LarkListenerPluginNode"]
-	root__node__agent_reply["AgentNode"]
-	root__node__extract_reply["AgentReplyExtractorNode"]
-	root__node__reply_route{"SwitchNode"}
-	root__node__ws_reply_wecom["WeComWsReplyNode"]
-	root__node__get_lark_tenant_token["HttpRequestNode"]
-	root__node__send_lark["LarkSendMessageNode"]
-	root__end(["END"]):::last
-	root__start --> root__node__wecom_listener;
-	root__start --> root__node__lark_listener;
-	root__node__wecom_listener --> root__node__agent_reply;
-	root__node__lark_listener --> root__node__agent_reply;
-	root__node__agent_reply --> root__node__extract_reply;
-	root__node__extract_reply --> root__node__reply_route;
-	root__node__reply_route -->|wecom| root__node__ws_reply_wecom;
-	root__node__reply_route -->|lark| root__node__get_lark_tenant_token;
-	root__node__get_lark_tenant_token --> root__node__send_lark;
-	root__node__ws_reply_wecom --> root__end;
-	root__node__send_lark --> root__end;
-	classDef default fill:#eef4ff,line-height:1.2
+	__start__([<p>START</p>]):::first
+	wecom_listener(wecom_listener)
+	lark_listener(lark_listener)
+	agent_reply(agent_reply)
+	extract_reply(extract_reply)
+	ws_reply_wecom(ws_reply_wecom)
+	get_lark_tenant_token(get_lark_tenant_token)
+	send_lark(send_lark)
+	__end__([<p>END</p>]):::last
+	__start__ -. &nbsp;lark&nbsp; .-> lark_listener;
+	__start__ -. &nbsp;wecom&nbsp; .-> wecom_listener;
+	agent_reply --> extract_reply;
+	extract_reply -. &nbsp;lark&nbsp; .-> get_lark_tenant_token;
+	extract_reply -. &nbsp;wecom&nbsp; .-> ws_reply_wecom;
+	get_lark_tenant_token --> send_lark;
+	lark_listener --> agent_reply;
+	wecom_listener --> agent_reply;
+	send_lark --> __end__;
+	ws_reply_wecom --> __end__;
+	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
-	classDef last fill:#94b8ff
+	classDef last fill:#bfb6fc
 `;
 
 export const WECOM_LARK_SHARED_LISTENER_WORKFLOW: Workflow = {

--- a/apps/canvas/src/features/workflow/data/workflow-types.ts
+++ b/apps/canvas/src/features/workflow/data/workflow-types.ts
@@ -27,6 +27,7 @@ export interface WorkflowEdge {
 export interface WorkflowMermaidPreviewVersion {
   id: string;
   mermaid?: string | null;
+  templateId?: string;
 }
 
 export interface Workflow {

--- a/apps/canvas/src/features/workflow/lib/mermaid-renderer.test.ts
+++ b/apps/canvas/src/features/workflow/lib/mermaid-renderer.test.ts
@@ -4,6 +4,7 @@ import {
   buildMermaidCacheKey,
   buildMermaidRenderId,
   forceMermaidLeftToRight,
+  normalizeMermaidPalette,
   renderMermaidSvg,
 } from "./mermaid-renderer";
 
@@ -37,6 +38,27 @@ describe("mermaid-renderer", () => {
     expect(forceMermaidLeftToRight("flowchart\nA --> B")).toBe(
       "flowchart LR\nA --> B",
     );
+  });
+
+  it("normalizes template palette aliases to the default workflow palette", () => {
+    expect(
+      normalizeMermaidPalette(
+        [
+          "graph TD;",
+          "\tclassDef default fill:#eef4ff,line-height:1.2",
+          "\tclassDef last fill:#94b8ff",
+        ].join("\n"),
+      ),
+    ).toContain("classDef default fill:#f2f0ff,line-height:1.2");
+    expect(
+      normalizeMermaidPalette(
+        [
+          "graph TD;",
+          "\tclassDef default fill:#eef4ff,line-height:1.2",
+          "\tclassDef last fill:#94b8ff",
+        ].join("\n"),
+      ),
+    ).toContain("classDef last fill:#bfb6fc");
   });
 
   it("reuses cached svg for the same key", async () => {

--- a/apps/canvas/src/features/workflow/lib/mermaid-renderer.ts
+++ b/apps/canvas/src/features/workflow/lib/mermaid-renderer.ts
@@ -226,6 +226,42 @@ export const buildMermaidRenderId = (
 ): string =>
   `${sanitizeMermaidIdPart(prefix)}-${sanitizeMermaidIdPart(cacheKey)}`;
 
+export const makeMermaidSvgTransparent = (svg: string): string => {
+  const svgWithTransparentRoot = svg.replace(
+    /<svg\b([^>]*)>/i,
+    (match, attributes: string) => {
+      const styleMatch = attributes.match(/\sstyle="([^"]*)"/i);
+      if (!styleMatch) {
+        return `<svg${attributes} style="background-color: transparent;">`;
+      }
+
+      const cleanedStyle = styleMatch[1]
+        .split(";")
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .filter(
+          (entry) =>
+            !entry.toLowerCase().startsWith("background-color") &&
+            !entry.toLowerCase().startsWith("background"),
+        )
+        .join("; ");
+      const nextStyle = ` style="background-color: transparent${cleanedStyle ? `; ${cleanedStyle}` : ""};"`;
+
+      return match.replace(styleMatch[0], nextStyle);
+    },
+  );
+
+  return svgWithTransparentRoot
+    .replace(
+      /<rect\b([^>]*\bclass="[^"]*\b(background|canvas)\b[^"]*"[^>]*)\/?>/gi,
+      "",
+    )
+    .replace(
+      /<rect\b([^>]*\bid="[^"]*(background|canvas)[^"]*"[^>]*)\/?>/gi,
+      "",
+    );
+};
+
 export const renderMermaidSvg = async ({
   source,
   cacheKey,

--- a/apps/canvas/src/features/workflow/lib/mermaid-renderer.ts
+++ b/apps/canvas/src/features/workflow/lib/mermaid-renderer.ts
@@ -194,6 +194,18 @@ export const forceMermaidLeftToRight = (source: string): string => {
   return normalizedSource.replace(/^(\s*(?:flowchart|graph))(\s*)$/im, "$1 LR");
 };
 
+const MERMAID_COLOR_ALIASES: ReadonlyArray<[RegExp, string]> = [
+  [/\bclassDef\s+default\s+fill:#eef4ff\b/gi, "classDef default fill:#f2f0ff"],
+  [/\bclassDef\s+last\s+fill:#94b8ff\b/gi, "classDef last fill:#bfb6fc"],
+];
+
+export const normalizeMermaidPalette = (source: string): string =>
+  MERMAID_COLOR_ALIASES.reduce(
+    (normalized, [pattern, replacement]) =>
+      normalized.replace(pattern, replacement),
+    source,
+  );
+
 export const hashMermaidSource = (value: string): string => {
   let hash = 0x811c9dc5;
   for (let index = 0; index < value.length; index += 1) {

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-api.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-api.test.ts
@@ -5,6 +5,7 @@ import {
   fetchWorkflowCredentialReadiness,
   fetchWorkflowListenerMetrics,
   fetchWorkflowListeners,
+  fetchSystemPlugins,
   pauseWorkflowListener,
   resolveWorkflowShareUrl,
   resumeWorkflowListener,
@@ -335,6 +336,30 @@ describe("workflow-storage-api helpers", () => {
     expect(String(mockFetch.mock.calls[0]?.[0])).toContain(
       "/api/workflows/wf-1/credentials/readiness",
     );
+  });
+
+  it("fetches backend plugin availability", async () => {
+    queueResponses([
+      jsonResponse({
+        plugins: [
+          {
+            name: "orcheo-plugin-lark-listener",
+            enabled: true,
+            status: "installed",
+            version: "0.1.0",
+            exports: ["nodes", "listeners"],
+            loaded: true,
+            load_error: null,
+          },
+        ],
+      }),
+    ]);
+
+    const payload = await fetchSystemPlugins();
+
+    expect(payload.plugins).toHaveLength(1);
+    expect(payload.plugins[0]?.name).toBe("orcheo-plugin-lark-listener");
+    expect(payload.plugins[0]?.loaded).toBe(true);
   });
 
   it("fetches workflow listener health and metrics", async () => {

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-api.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-api.ts
@@ -8,6 +8,7 @@ import type {
   CronTriggerConfig,
   PublicWorkflowMetadata,
   RequestOptions,
+  SystemPluginsResponse,
   WorkflowListenerHealth,
   WorkflowListenerMetricsResponse,
   WorkflowCredentialReadinessResponse,
@@ -155,6 +156,9 @@ export const fetchWorkflowCredentialReadiness = async (
     throw error;
   }
 };
+
+export const fetchSystemPlugins = async (): Promise<SystemPluginsResponse> =>
+  request<SystemPluginsResponse>("/api/system/plugins");
 
 export const fetchWorkflowListeners = async (
   workflowId: string,

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -98,13 +98,13 @@ export const resolveWorkflowVersionMermaidSource = (
     | null
     | undefined,
 ): string | null => {
-  const templateMermaid =
-    version?.templateId != null
+  const source =
+    version?.mermaid ??
+    (version?.templateId != null
       ? getWorkflowTemplateDefinition(
           version.templateId,
         )?.workflow.versions?.at(-1)?.mermaid
-      : undefined;
-  const source = templateMermaid ?? version?.mermaid;
+      : undefined);
   if (!source) {
     return null;
   }

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -115,6 +115,7 @@ const parseCanvasMetadata = (
         edges: cloneEdges(templateDefinition.workflow.edges),
       },
       summary: { ...DEFAULT_SUMMARY },
+      templateId,
     };
   };
 
@@ -122,6 +123,7 @@ const parseCanvasMetadata = (
     return {
       snapshot: emptySnapshot(fallbackName, fallbackDescription),
       summary: { ...DEFAULT_SUMMARY },
+      templateId: undefined,
     };
   }
 
@@ -147,6 +149,10 @@ const parseCanvasMetadata = (
   const graphToCanvas = canvasRecord.graphToCanvas as
     | Record<string, string>
     | undefined;
+  const templateId =
+    typeof (metadata as Record<string, unknown>).template_id === "string"
+      ? ((metadata as Record<string, unknown>).template_id as string)
+      : undefined;
 
   const snapshot = snapshotPayload
     ? {
@@ -178,6 +184,7 @@ const parseCanvasMetadata = (
     message: messagePayload,
     canvasToGraph,
     graphToCanvas,
+    templateId,
   };
 };
 
@@ -210,6 +217,7 @@ const toVersionRecord = (
     mermaid: version.mermaid ?? null,
     runnableConfig: version.runnable_config ?? null,
     graphToCanvas: metadata.graphToCanvas,
+    templateId: metadata.templateId,
   };
 };
 

--- a/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage-helpers.ts
@@ -11,6 +11,10 @@ import {
   DEFAULT_SUMMARY,
   HISTORY_LIMIT,
 } from "./workflow-storage.constants";
+import {
+  forceMermaidLeftToRight,
+  normalizeMermaidPalette,
+} from "./mermaid-renderer";
 import type {
   ApiWorkflow,
   ApiWorkflowVersionSummary,
@@ -86,6 +90,30 @@ export const getWorkflowRouteRef = (
     | Pick<ApiWorkflow, "id" | "handle">
     | Pick<Workflow, "id" | "handle">,
 ): string => workflow.handle ?? workflow.id;
+
+export const resolveWorkflowVersionMermaidSource = (
+  version:
+    | Pick<WorkflowVersionRecord, "mermaid" | "templateId">
+    | Pick<NonNullable<Workflow["versions"]>[number], "mermaid" | "templateId">
+    | null
+    | undefined,
+): string | null => {
+  const templateMermaid =
+    version?.templateId != null
+      ? getWorkflowTemplateDefinition(
+          version.templateId,
+        )?.workflow.versions?.at(-1)?.mermaid
+      : undefined;
+  const source = templateMermaid ?? version?.mermaid;
+  if (!source) {
+    return null;
+  }
+
+  const trimmedSource = source.trim();
+  return trimmedSource.length > 0
+    ? normalizeMermaidPalette(forceMermaidLeftToRight(trimmedSource))
+    : null;
+};
 
 const parseCanvasMetadata = (
   metadata: unknown,

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.template.integration.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.template.integration.test.ts
@@ -808,6 +808,28 @@ describe("workflow-storage API integration - template creation", () => {
 
     queueResponses([
       jsonResponse({
+        plugins: [
+          {
+            name: "orcheo-plugin-wecom-listener",
+            enabled: true,
+            status: "installed",
+            version: "0.1.0",
+            exports: ["nodes", "listeners"],
+            loaded: true,
+            load_error: null,
+          },
+          {
+            name: "orcheo-plugin-lark-listener",
+            enabled: true,
+            status: "installed",
+            version: "0.1.0",
+            exports: ["nodes", "listeners"],
+            loaded: true,
+            load_error: null,
+          },
+        ],
+      }),
+      jsonResponse({
         id: "workflow-template-9",
         name: "WeCom + Lark Shared Listener Copy",
         slug: "workflow-template-9",
@@ -872,7 +894,7 @@ describe("workflow-storage API integration - template creation", () => {
     await createWorkflowFromTemplate("template-wecom-lark-shared-listener");
 
     const ingestBody = JSON.parse(
-      String(mockFetch.mock.calls[1]?.[1]?.body ?? "{}"),
+      String(mockFetch.mock.calls[2]?.[1]?.body ?? "{}"),
     ) as {
       metadata?: {
         template?: {
@@ -900,6 +922,30 @@ describe("workflow-storage API integration - template creation", () => {
     );
     expect(ingestBody.runnable_config?.configurable?.operator_note).toContain(
       "listener plugins",
+    );
+  });
+
+  it("fails fast when a plugin-backed template is missing required plugins", async () => {
+    queueResponses([
+      jsonResponse({
+        plugins: [
+          {
+            name: "orcheo-plugin-wecom-listener",
+            enabled: true,
+            status: "installed",
+            version: "0.1.0",
+            exports: ["nodes", "listeners"],
+            loaded: true,
+            load_error: null,
+          },
+        ],
+      }),
+    ]);
+
+    await expect(
+      createWorkflowFromTemplate("template-wecom-lark-shared-listener"),
+    ).rejects.toThrow(
+      "Install required plugins before using this template: orcheo-plugin-lark-listener",
     );
   });
 });

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.ts
@@ -12,6 +12,7 @@ import {
 } from "./workflow-storage-helpers";
 import {
   API_BASE,
+  fetchSystemPlugins,
   fetchWorkflowVersions,
   request,
   upsertWorkflow,
@@ -73,6 +74,27 @@ const buildTemplateCanvasMetadata = ({
   },
   summary: { added: 0, removed: 0, modified: 0 },
 });
+
+const assertTemplatePluginRequirements = async (
+  requiredPlugins: string[] | undefined,
+): Promise<void> => {
+  if (!requiredPlugins || requiredPlugins.length === 0) {
+    return;
+  }
+  const payload = await fetchSystemPlugins();
+  const available = new Set(
+    payload.plugins
+      .filter((plugin) => plugin.enabled && plugin.loaded)
+      .map((plugin) => plugin.name),
+  );
+  const missing = requiredPlugins.filter((plugin) => !available.has(plugin));
+  if (missing.length === 0) {
+    return;
+  }
+  throw new Error(
+    `Install required plugins before using this template: ${missing.join(", ")}`,
+  );
+};
 
 export const invalidateWorkflowListCache = () => {
   workflowListCache = undefined;
@@ -170,6 +192,9 @@ export const createWorkflowFromTemplate = async (
     return undefined;
   }
   assertWorkflowTemplateCompatibility(templateDefinition);
+  await assertTemplatePluginRequirements(
+    templateDefinition.metadata?.requiredPlugins,
+  );
 
   const actor = resolveActor();
   const templateWorkflow = templateDefinition.workflow;

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
@@ -184,6 +184,7 @@ export interface CanvasVersionMetadata {
   message?: string;
   canvasToGraph?: Record<string, string>;
   graphToCanvas?: Record<string, string>;
+  templateId?: string;
 }
 
 export interface RequestOptions extends RequestInit {
@@ -202,6 +203,7 @@ export interface WorkflowVersionRecord {
   mermaid?: string | null;
   runnableConfig?: WorkflowRunnableConfig | null;
   graphToCanvas?: Record<string, string>;
+  templateId?: string;
 }
 
 export interface StoredWorkflow extends Workflow {

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.types.ts
@@ -156,6 +156,20 @@ export interface WorkflowPublishResponse {
   share_url?: string | null;
 }
 
+export interface SystemPluginStatus {
+  name: string;
+  enabled: boolean;
+  status: string;
+  version: string;
+  exports: string[];
+  loaded: boolean;
+  load_error?: string | null;
+}
+
+export interface SystemPluginsResponse {
+  plugins: SystemPluginStatus[];
+}
+
 export interface CronTriggerConfig {
   expression: string;
   timezone?: string;

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-tab-content.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-tab-content.tsx
@@ -23,10 +23,10 @@ import type {
 import {
   buildMermaidCacheKey,
   buildMermaidRenderId,
-  forceMermaidLeftToRight,
   makeMermaidSvgTransparent,
   renderMermaidSvg,
 } from "@features/workflow/lib/mermaid-renderer";
+import { resolveWorkflowVersionMermaidSource } from "@features/workflow/lib/workflow-storage-helpers";
 import { WorkflowConfigSheet } from "@features/workflow/pages/workflow-canvas/components/workflow-config-sheet";
 
 export interface WorkflowTabContentProps {
@@ -236,14 +236,8 @@ export function WorkflowTabContent({
   }, [hasCronTriggerNode, workflowId]);
 
   const mermaidSource = useMemo(() => {
-    if (!latestVersion?.mermaid) {
-      return null;
-    }
-    const trimmedSource = latestVersion.mermaid.trim();
-    return trimmedSource.length > 0
-      ? forceMermaidLeftToRight(trimmedSource)
-      : null;
-  }, [latestVersion?.mermaid]);
+    return resolveWorkflowVersionMermaidSource(latestVersion);
+  }, [latestVersion]);
 
   const mermaidCacheKey = useMemo(() => {
     if (!mermaidSource) {

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-tab-content.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas/components/workflow-tab-content.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { Copy, ExternalLink, Play } from "lucide-react";
+import { Copy, ExternalLink, Play, Trash } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Controls, ReactFlow, type Node, type NodeProps } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
 import { Button } from "@/design-system/ui/button";
 import { Switch } from "@/design-system/ui/switch";
 import { toast } from "@/hooks/use-toast";
+import { ConfirmDeleteWorkflowDialog } from "@features/workflow/components/dialogs/confirm-delete-workflow-dialog";
+import { deleteWorkflow } from "@features/workflow/lib/workflow-storage";
 import {
   fetchCronTriggerConfig,
   publishWorkflow,
@@ -21,6 +24,7 @@ import {
   buildMermaidCacheKey,
   buildMermaidRenderId,
   forceMermaidLeftToRight,
+  makeMermaidSvgTransparent,
   renderMermaidSvg,
 } from "@features/workflow/lib/mermaid-renderer";
 import { WorkflowConfigSheet } from "@features/workflow/pages/workflow-canvas/components/workflow-config-sheet";
@@ -103,42 +107,6 @@ const resolveSvgSize = (svg: string) => {
   return DEFAULT_SVG_SIZE;
 };
 
-const makeMermaidSvgTransparent = (svg: string): string => {
-  const svgWithTransparentRoot = svg.replace(
-    /<svg\b([^>]*)>/i,
-    (match, attributes: string) => {
-      const styleMatch = attributes.match(/\sstyle="([^"]*)"/i);
-      if (!styleMatch) {
-        return `<svg${attributes} style="background-color: transparent;">`;
-      }
-
-      const cleanedStyle = styleMatch[1]
-        .split(";")
-        .map((entry) => entry.trim())
-        .filter(Boolean)
-        .filter(
-          (entry) =>
-            !entry.toLowerCase().startsWith("background-color") &&
-            !entry.toLowerCase().startsWith("background"),
-        )
-        .join("; ");
-      const nextStyle = ` style="background-color: transparent${cleanedStyle ? `; ${cleanedStyle}` : ""};"`;
-
-      return match.replace(styleMatch[0], nextStyle);
-    },
-  );
-
-  return svgWithTransparentRoot
-    .replace(
-      /<rect\b([^>]*\bclass="[^"]*\b(background|canvas)\b[^"]*"[^>]*)\/?>/gi,
-      "",
-    )
-    .replace(
-      /<rect\b([^>]*\bid="[^"]*(background|canvas)[^"]*"[^>]*)\/?>/gi,
-      "",
-    );
-};
-
 const MermaidSvgNode = ({ data }: NodeProps<Node<MermaidSvgNodeData>>) => {
   const nodeData = data as MermaidSvgNodeData;
 
@@ -202,6 +170,7 @@ export function WorkflowTabContent({
   initialIsPublished,
   initialShareUrl,
 }: WorkflowTabContentProps) {
+  const navigate = useNavigate();
   const latestVersion = versions.at(-1);
   const [isConfigOpen, setIsConfigOpen] = useState(false);
   const [isPublished, setIsPublished] = useState(initialIsPublished);
@@ -211,6 +180,8 @@ export function WorkflowTabContent({
   const [isSchedulePending, setIsSchedulePending] = useState(false);
   const [diagramSvg, setDiagramSvg] = useState<string | null>(null);
   const [diagramError, setDiagramError] = useState<string | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeletePending, setIsDeletePending] = useState(false);
 
   useEffect(() => {
     if (!workflowId) {
@@ -504,141 +475,190 @@ export function WorkflowTabContent({
     }
   };
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-      <div className="flex items-center justify-between border-b pb-3">
-        <div>
-          <h2 className="text-lg font-semibold">Workflow</h2>
-          <p className="text-sm text-muted-foreground">
-            {workflowName}
-            {latestVersion ? ` · ${latestVersion.version}` : ""}
-          </p>
-        </div>
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Publish</span>
-            <Switch
-              aria-label="Publish workflow"
-              checked={isPublished}
-              onCheckedChange={(checked) => void handlePublishToggle(checked)}
-              disabled={isPublishPending}
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Schedule</span>
-            <Switch
-              aria-label="Schedule workflow"
-              checked={isScheduled}
-              onCheckedChange={(checked) => void handleScheduleToggle(checked)}
-              disabled={isSchedulePending || !canToggleSchedule}
-            />
-          </div>
-          <Button
-            onClick={() => void onRunWorkflow()}
-            disabled={!canRun || isRunPending}
-          >
-            <Play className="mr-1.5 h-4 w-4" />
-            {isRunPending ? "Running..." : "Run"}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => setIsConfigOpen(true)}
-            disabled={!canConfigure}
-          >
-            Config
-          </Button>
-        </div>
-      </div>
+  const handleDeleteCurrentWorkflow = async () => {
+    if (!workflowId) {
+      return;
+    }
 
-      {isPublished && shareUrl && (
-        <div className="flex items-center justify-between rounded-md border border-border/60 bg-muted/20 px-3 py-2">
-          <div className="min-w-0">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">
-              Public URL
+    setIsDeletePending(true);
+    try {
+      await deleteWorkflow(workflowId);
+      toast({
+        title: "Workflow deleted",
+        description: `"${workflowName}" has been removed from your workspace.`,
+      });
+      setIsDeleteDialogOpen(false);
+      navigate("/");
+    } catch (error) {
+      toast({
+        title: "Failed to delete workflow",
+        description: getErrorMessage(error, "Unable to delete workflow."),
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeletePending(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+        <div className="flex items-center justify-between border-b pb-3">
+          <div>
+            <h2 className="text-lg font-semibold">Workflow</h2>
+            <p className="text-sm text-muted-foreground">
+              {workflowName}
+              {latestVersion ? ` · ${latestVersion.version}` : ""}
             </p>
-            <a
-              href={shareUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="block truncate text-sm text-primary hover:underline"
-            >
-              {shareUrl}
-            </a>
           </div>
-          <div className="ml-3 flex items-center gap-2">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Publish</span>
+              <Switch
+                aria-label="Publish workflow"
+                checked={isPublished}
+                onCheckedChange={(checked) => void handlePublishToggle(checked)}
+                disabled={isPublishPending}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Schedule</span>
+              <Switch
+                aria-label="Schedule workflow"
+                checked={isScheduled}
+                onCheckedChange={(checked) =>
+                  void handleScheduleToggle(checked)
+                }
+                disabled={isSchedulePending || !canToggleSchedule}
+              />
+            </div>
+            {workflowId ? (
+              <Button
+                variant="destructive"
+                onClick={() => setIsDeleteDialogOpen(true)}
+                disabled={isDeletePending}
+              >
+                <Trash className="mr-1.5 h-4 w-4" />
+                Delete
+              </Button>
+            ) : null}
+            <Button
+              onClick={() => void onRunWorkflow()}
+              disabled={!canRun || isRunPending}
+            >
+              <Play className="mr-1.5 h-4 w-4" />
+              {isRunPending ? "Running..." : "Run"}
+            </Button>
             <Button
               variant="outline"
-              size="sm"
-              onClick={() => void handleCopyShareUrl()}
+              onClick={() => setIsConfigOpen(true)}
+              disabled={!canConfigure}
             >
-              <Copy className="mr-1.5 h-3.5 w-3.5" />
-              Copy
-            </Button>
-            <Button variant="outline" size="sm" asChild>
-              <a href={shareUrl} target="_blank" rel="noreferrer">
-                <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-                Open
-              </a>
+              Config
             </Button>
           </div>
         </div>
-      )}
 
-      {!latestVersion && (
-        <div className="flex h-full items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
-          No version is available yet to generate a Mermaid diagram.
-        </div>
-      )}
-
-      {latestVersion && !mermaidSource && (
-        <div className="flex h-full items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
-          Mermaid data is unavailable for this workflow version.
-        </div>
-      )}
-
-      {latestVersion && mermaidSource && diagramError && (
-        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
-          Unable to render Mermaid diagram: {diagramError}
-        </div>
-      )}
-
-      {latestVersion && mermaidSource && !diagramError && (
-        <div className="min-h-0 flex flex-1 flex-col">
-          <div className="min-h-0 flex-1 overflow-hidden">
-            {diagramNodes.length > 0 ? (
-              <ReactFlow
-                key={`${latestVersion.id}-mermaid-svg`}
-                nodes={diagramNodes}
-                edges={[]}
-                nodeTypes={nodeTypes}
-                fitView
-                minZoom={0.2}
-                maxZoom={2}
-                nodesDraggable={false}
-                nodesConnectable={false}
-                elementsSelectable={false}
-                zoomOnDoubleClick={false}
-                className="h-full w-full"
-                proOptions={{ hideAttribution: true }}
-                style={{ background: "transparent" }}
+        {isPublished && shareUrl && (
+          <div className="flex items-center justify-between rounded-md border border-border/60 bg-muted/20 px-3 py-2">
+            <div className="min-w-0">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Public URL
+              </p>
+              <a
+                href={shareUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="block truncate text-sm text-primary hover:underline"
               >
-                <Controls showInteractive={false} />
-              </ReactFlow>
-            ) : (
-              <pre className="h-full overflow-auto p-3 text-xs text-muted-foreground">
-                {defaultMermaid}
-              </pre>
-            )}
+                {shareUrl}
+              </a>
+            </div>
+            <div className="ml-3 flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleCopyShareUrl()}
+              >
+                <Copy className="mr-1.5 h-3.5 w-3.5" />
+                Copy
+              </Button>
+              <Button variant="outline" size="sm" asChild>
+                <a href={shareUrl} target="_blank" rel="noreferrer">
+                  <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                  Open
+                </a>
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      <WorkflowConfigSheet
-        open={isConfigOpen}
-        onOpenChange={setIsConfigOpen}
-        initialConfig={latestConfig}
-        onSave={onSaveConfig}
-      />
-    </div>
+        {!latestVersion && (
+          <div className="flex h-full items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+            No version is available yet to generate a Mermaid diagram.
+          </div>
+        )}
+
+        {latestVersion && !mermaidSource && (
+          <div className="flex h-full items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+            Mermaid data is unavailable for this workflow version.
+          </div>
+        )}
+
+        {latestVersion && mermaidSource && diagramError && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            Unable to render Mermaid diagram: {diagramError}
+          </div>
+        )}
+
+        {latestVersion && mermaidSource && !diagramError && (
+          <div className="min-h-0 flex flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-hidden">
+              {diagramNodes.length > 0 ? (
+                <ReactFlow
+                  key={`${latestVersion.id}-mermaid-svg`}
+                  nodes={diagramNodes}
+                  edges={[]}
+                  nodeTypes={nodeTypes}
+                  fitView
+                  minZoom={0.2}
+                  maxZoom={2}
+                  nodesDraggable={false}
+                  nodesConnectable={false}
+                  elementsSelectable={false}
+                  zoomOnDoubleClick={false}
+                  className="h-full w-full"
+                  proOptions={{ hideAttribution: true }}
+                  style={{ background: "transparent" }}
+                >
+                  <Controls showInteractive={false} />
+                </ReactFlow>
+              ) : (
+                <pre className="h-full overflow-auto p-3 text-xs text-muted-foreground">
+                  {defaultMermaid}
+                </pre>
+              )}
+            </div>
+          </div>
+        )}
+
+        <WorkflowConfigSheet
+          open={isConfigOpen}
+          onOpenChange={setIsConfigOpen}
+          initialConfig={latestConfig}
+          onSave={onSaveConfig}
+        />
+      </div>
+
+      {workflowId ? (
+        <ConfirmDeleteWorkflowDialog
+          open={isDeleteDialogOpen}
+          workflowName={workflowName}
+          isPending={isDeletePending}
+          onOpenChange={setIsDeleteDialogOpen}
+          onConfirm={handleDeleteCurrentWorkflow}
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
@@ -29,6 +29,7 @@ export default function WorkflowGallery() {
     setNewFolderName,
     selectedTab,
     setSelectedTab,
+    isLoadingWorkflows,
     sortedWorkflows,
     isTemplateView,
     handleCreateFolder,
@@ -75,6 +76,7 @@ export default function WorkflowGallery() {
               <WorkflowGalleryTabs
                 selectedTab={selectedTab}
                 onSelectedTabChange={setSelectedTab}
+                isLoading={isLoadingWorkflows}
                 sortedWorkflows={sortedWorkflows}
                 isTemplateView={isTemplateView}
                 searchQuery={searchQuery}

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/use-workflow-gallery-state.ts
@@ -30,6 +30,7 @@ interface WorkflowGalleryStateSlice {
   setShowFilterPopover: (value: boolean) => void;
   filters: WorkflowGalleryFilters;
   setFilters: (value: WorkflowGalleryFilters) => void;
+  isLoadingWorkflows: boolean;
   sortedWorkflows: Workflow[];
   isTemplateView: boolean;
   templates: Workflow[];
@@ -55,6 +56,7 @@ const DEFAULT_FILTERS: WorkflowGalleryFilters = {
 
 export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
   const [workflows, setWorkflows] = useState<StoredWorkflow[]>([]);
+  const [isLoadingWorkflows, setIsLoadingWorkflows] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTab, setSelectedTab] = useState<WorkflowGalleryTab>("all");
   const [sortBy, setSortBy] = useState<WorkflowGallerySort>("updated");
@@ -68,6 +70,9 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
     let isMounted = true;
 
     const load = async (forceRefresh = false) => {
+      if (isMounted) {
+        setIsLoadingWorkflows(true);
+      }
       try {
         const items = await listWorkflows({ forceRefresh });
         if (isMounted) {
@@ -85,6 +90,10 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
             error instanceof Error ? error.message : "Unknown error occurred",
           variant: "destructive",
         });
+      } finally {
+        if (isMounted) {
+          setIsLoadingWorkflows(false);
+        }
       }
     };
 
@@ -187,6 +196,7 @@ export const useWorkflowGalleryState = (): WorkflowGalleryStateSlice => {
     setShowFilterPopover,
     filters,
     setFilters,
+    isLoadingWorkflows,
     sortedWorkflows,
     isTemplateView,
     templates,

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.test.tsx
@@ -161,4 +161,33 @@ describe("WorkflowCard", () => {
 
     expect(handlers.onOpenWorkflow).not.toHaveBeenCalled();
   });
+
+  it("requires confirmation before deleting a workflow", async () => {
+    const user = userEvent.setup();
+    const handlers = createHandlers();
+
+    render(
+      <WorkflowCard workflow={workflow} isTemplate={false} {...handlers} />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /workflow actions/i,
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: /^delete$/i }),
+    );
+
+    expect(handlers.onDeleteWorkflow).not.toHaveBeenCalled();
+    expect(screen.getByText(/delete workflow\?/i)).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    expect(handlers.onDeleteWorkflow).toHaveBeenCalledTimes(1);
+    expect(handlers.onDeleteWorkflow).toHaveBeenCalledWith(
+      workflow.id,
+      workflow.name,
+    );
+  });
 });

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-card.tsx
@@ -32,6 +32,7 @@ import {
   Trash,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ConfirmDeleteWorkflowDialog } from "@features/workflow/components/dialogs/confirm-delete-workflow-dialog";
 import { type Workflow } from "@features/workflow/data/workflow-data";
 import { getWorkflowRouteRef } from "@features/workflow/lib/workflow-storage-helpers";
 import { WorkflowThumbnail } from "./workflow-thumbnail";
@@ -42,7 +43,10 @@ interface WorkflowCardProps {
   onOpenWorkflow: (workflowId: string) => void;
   onUseTemplate: (workflowId: string) => void;
   onExportWorkflow: (workflow: Workflow) => void;
-  onDeleteWorkflow: (workflowId: string, workflowName: string) => void;
+  onDeleteWorkflow: (
+    workflowId: string,
+    workflowName: string,
+  ) => Promise<void> | void;
 }
 
 export const WorkflowCard = ({
@@ -60,6 +64,8 @@ export const WorkflowCard = ({
   const isClickable = !isTemplate;
   const suppressCardOpenRef = useRef(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeletePending, setIsDeletePending] = useState(false);
 
   const suppressCardOpen = () => {
     suppressCardOpenRef.current = true;
@@ -103,217 +109,239 @@ export const WorkflowCard = ({
     suppressCardOpen();
   };
 
+  const handleConfirmDelete = async () => {
+    setIsDeletePending(true);
+    try {
+      await onDeleteWorkflow(workflow.id, workflow.name);
+      setIsDeleteDialogOpen(false);
+    } finally {
+      setIsDeletePending(false);
+    }
+  };
+
   return (
-    <Card
-      className={cn(
-        "overflow-hidden",
-        isClickable && "cursor-pointer transition-colors hover:bg-muted/20",
-      )}
-      data-testid="workflow-card"
-      onClick={handleCardOpen}
-      onKeyDown={handleCardKeyDown}
-      role={isClickable ? "button" : undefined}
-      tabIndex={isClickable ? 0 : undefined}
-    >
-      <CardHeader className="px-3 pb-2 pt-3">
-        <div className="flex items-start justify-between">
-          <CardTitle className="text-base">{workflow.name}</CardTitle>
-          <DropdownMenu
-            open={isMenuOpen}
-            onOpenChange={(open) => {
-              setIsMenuOpen(open);
-              if (!open) {
-                suppressCardOpen();
-              }
-            }}
-          >
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={stopPropagation}
-                onPointerDown={stopPropagation}
-                aria-label="Workflow actions"
-                data-card-action="true"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {isTemplate ? (
-                <>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onUseTemplate(workflow.id);
-                    }}
-                  >
-                    <Copy className="mr-2 h-4 w-4" />
-                    Use template
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onExportWorkflow(workflow);
-                    }}
-                  >
-                    <Download className="mr-2 h-4 w-4" />
-                    Export
-                  </DropdownMenuItem>
-                </>
-              ) : (
-                <>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onOpenWorkflow(workflowRouteRef);
-                    }}
-                  >
-                    <Pencil className="mr-2 h-4 w-4" />
-                    Edit
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onExportWorkflow(workflow);
-                    }}
-                  >
-                    <Download className="mr-2 h-4 w-4" />
-                    Export
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="text-red-600"
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onDeleteWorkflow(workflow.id, workflow.name);
-                    }}
-                  >
-                    <Trash className="mr-2 h-4 w-4" />
-                    Delete
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-
-        <CardDescription className="line-clamp-1">
-          {workflow.description || "No description provided"}
-        </CardDescription>
-        {!isTemplate && (
-          <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
-            {workflow.handle && (
-              <code className="rounded bg-muted px-1.5 py-0.5">
-                handle: {workflow.handle}
-              </code>
-            )}
-            <code className="rounded bg-muted px-1.5 py-0.5">
-              id: {workflow.id}
-            </code>
-          </div>
+    <>
+      <Card
+        className={cn(
+          "overflow-hidden",
+          isClickable && "cursor-pointer transition-colors hover:bg-muted/20",
         )}
-
-        {isTemplate && workflow.sourceExample && (
-          <p className="mt-1 line-clamp-1 text-xs text-muted-foreground/80">
-            Based on {workflow.sourceExample}
-          </p>
-        )}
-      </CardHeader>
-
-      <CardContent className="px-3 pb-2">
-        <WorkflowThumbnail workflow={workflow} />
-        <div className="mt-2 flex flex-wrap gap-1">
-          {workflow.tags.slice(0, 2).map((tag) => (
-            <Badge key={tag} variant="secondary" className="text-xs">
-              {tag}
-            </Badge>
-          ))}
-          {workflow.tags.length > 2 && (
-            <Badge variant="secondary" className="text-xs">
-              +{workflow.tags.length - 2} more
-            </Badge>
-          )}
-        </div>
-      </CardContent>
-
-      <CardFooter className="flex justify-between px-3 pb-3 pt-2 text-xs text-muted-foreground">
-        <div className="flex items-center">
-          <Avatar className="mr-1 h-5 w-5">
-            <AvatarImage src={workflow.owner.avatar} />
-            <AvatarFallback>{workflow.owner.name.charAt(0)}</AvatarFallback>
-          </Avatar>
-          <div className="flex items-center gap-1">
-            <span>{updatedLabel}</span>
-            {workflow.lastRun?.status === "success" && (
-              <CheckCircle className="h-3 w-3 text-green-500" />
-            )}
-            {workflow.lastRun?.status === "error" && (
-              <AlertCircle className="h-3 w-3 text-red-500" />
-            )}
-            {workflow.lastRun?.status === "running" && (
-              <Clock className="h-3 w-3 animate-pulse text-blue-500" />
-            )}
-          </div>
-        </div>
-
-        <div className="flex gap-1">
-          {isTemplate ? (
-            <Button
-              size="sm"
-              className="h-7 px-3 text-xs"
-              data-card-action="true"
-              onClick={(event) => {
-                stopPropagation(event);
-                onUseTemplate(workflow.id);
+        data-testid="workflow-card"
+        onClick={handleCardOpen}
+        onKeyDown={handleCardKeyDown}
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+      >
+        <CardHeader className="px-3 pb-2 pt-3">
+          <div className="flex items-start justify-between">
+            <CardTitle className="text-base">{workflow.name}</CardTitle>
+            <DropdownMenu
+              open={isMenuOpen}
+              onOpenChange={(open) => {
+                setIsMenuOpen(open);
+                if (!open) {
+                  suppressCardOpen();
+                }
               }}
-              onPointerDown={stopPropagation}
             >
-              <FolderPlus className="mr-1 h-3 w-3" />
-              Use template
-            </Button>
-          ) : (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                aria-label="Favorite workflow"
-                data-card-action="true"
-                onClick={(event) => {
-                  stopPropagation(event);
-                  toast({
-                    title: "Favorites coming soon",
-                    description: `We'll remember ${workflow.name} as a favorite soon.`,
-                  });
-                }}
-                onPointerDown={stopPropagation}
-              >
-                <Star className="h-3 w-3" />
-              </Button>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={stopPropagation}
+                  onPointerDown={stopPropagation}
+                  aria-label="Workflow actions"
+                  data-card-action="true"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {isTemplate ? (
+                  <>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onUseTemplate(workflow.id);
+                      }}
+                    >
+                      <Copy className="mr-2 h-4 w-4" />
+                      Use template
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onExportWorkflow(workflow);
+                      }}
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      Export
+                    </DropdownMenuItem>
+                  </>
+                ) : (
+                  <>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onOpenWorkflow(workflowRouteRef);
+                      }}
+                    >
+                      <Pencil className="mr-2 h-4 w-4" />
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onExportWorkflow(workflow);
+                      }}
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      Export
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-red-600"
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setIsDeleteDialogOpen(true);
+                      }}
+                    >
+                      <Trash className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <CardDescription className="line-clamp-1">
+            {workflow.description || "No description provided"}
+          </CardDescription>
+          {!isTemplate && (
+            <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+              {workflow.handle && (
+                <code className="rounded bg-muted px-1.5 py-0.5">
+                  handle: {workflow.handle}
+                </code>
+              )}
+              <code className="rounded bg-muted px-1.5 py-0.5">
+                id: {workflow.id}
+              </code>
+            </div>
+          )}
+
+          {isTemplate && workflow.sourceExample && (
+            <p className="mt-1 line-clamp-1 text-xs text-muted-foreground/80">
+              Based on {workflow.sourceExample}
+            </p>
+          )}
+        </CardHeader>
+
+        <CardContent className="px-3 pb-2">
+          <WorkflowThumbnail workflow={workflow} />
+          <div className="mt-2 flex flex-wrap gap-1">
+            {workflow.tags.slice(0, 2).map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+            {workflow.tags.length > 2 && (
+              <Badge variant="secondary" className="text-xs">
+                +{workflow.tags.length - 2} more
+              </Badge>
+            )}
+          </div>
+        </CardContent>
+
+        <CardFooter className="flex justify-between px-3 pb-3 pt-2 text-xs text-muted-foreground">
+          <div className="flex items-center">
+            <Avatar className="mr-1 h-5 w-5">
+              <AvatarImage src={workflow.owner.avatar} />
+              <AvatarFallback>{workflow.owner.name.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <div className="flex items-center gap-1">
+              <span>{updatedLabel}</span>
+              {workflow.lastRun?.status === "success" && (
+                <CheckCircle className="h-3 w-3 text-green-500" />
+              )}
+              {workflow.lastRun?.status === "error" && (
+                <AlertCircle className="h-3 w-3 text-red-500" />
+              )}
+              {workflow.lastRun?.status === "running" && (
+                <Clock className="h-3 w-3 animate-pulse text-blue-500" />
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-1">
+            {isTemplate ? (
               <Button
                 size="sm"
-                className="h-7 px-2 text-xs"
+                className="h-7 px-3 text-xs"
                 data-card-action="true"
                 onClick={(event) => {
                   stopPropagation(event);
-                  onOpenWorkflow(workflowRouteRef);
+                  onUseTemplate(workflow.id);
                 }}
                 onPointerDown={stopPropagation}
               >
-                <Pencil className="mr-1 h-3 w-3" />
-                Edit
+                <FolderPlus className="mr-1 h-3 w-3" />
+                Use template
               </Button>
-            </>
-          )}
-        </div>
-      </CardFooter>
-    </Card>
+            ) : (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  aria-label="Favorite workflow"
+                  data-card-action="true"
+                  onClick={(event) => {
+                    stopPropagation(event);
+                    toast({
+                      title: "Favorites coming soon",
+                      description: `We'll remember ${workflow.name} as a favorite soon.`,
+                    });
+                  }}
+                  onPointerDown={stopPropagation}
+                >
+                  <Star className="h-3 w-3" />
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  data-card-action="true"
+                  onClick={(event) => {
+                    stopPropagation(event);
+                    onOpenWorkflow(workflowRouteRef);
+                  }}
+                  onPointerDown={stopPropagation}
+                >
+                  <Pencil className="mr-1 h-3 w-3" />
+                  Edit
+                </Button>
+              </>
+            )}
+          </div>
+        </CardFooter>
+      </Card>
+
+      {!isTemplate ? (
+        <ConfirmDeleteWorkflowDialog
+          open={isDeleteDialogOpen}
+          workflowName={workflow.name}
+          isPending={isDeletePending}
+          onOpenChange={setIsDeleteDialogOpen}
+          onConfirm={handleConfirmDelete}
+        />
+      ) : null}
+    </>
   );
 };

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkflowGalleryTabs } from "./workflow-gallery-tabs";
+
+vi.mock("./workflow-card", () => ({
+  WorkflowCard: () => <div data-testid="workflow-card" />,
+}));
+
+describe("WorkflowGalleryTabs", () => {
+  it("shows a loading screen while workflows are being fetched", () => {
+    render(
+      <WorkflowGalleryTabs
+        selectedTab="all"
+        onSelectedTabChange={vi.fn()}
+        isLoading
+        sortedWorkflows={[]}
+        isTemplateView={false}
+        searchQuery=""
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/loading workflows/i)).toBeTruthy();
+    expect(screen.queryByText(/import starter pack/i)).toBeNull();
+  });
+});

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.test.tsx
@@ -1,11 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { WorkflowGalleryTabs } from "./workflow-gallery-tabs";
 
 vi.mock("./workflow-card", () => ({
   WorkflowCard: () => <div data-testid="workflow-card" />,
 }));
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("WorkflowGalleryTabs", () => {
   it("shows a loading screen while workflows are being fetched", () => {
@@ -27,5 +31,37 @@ describe("WorkflowGalleryTabs", () => {
 
     expect(screen.getByText(/loading workflows/i)).toBeTruthy();
     expect(screen.queryByText(/import starter pack/i)).toBeNull();
+  });
+
+  it("keeps templates visible while workspace workflows are still loading", () => {
+    render(
+      <WorkflowGalleryTabs
+        selectedTab="templates"
+        onSelectedTabChange={vi.fn()}
+        isLoading
+        sortedWorkflows={[
+          {
+            id: "template-1",
+            name: "Starter",
+            description: "Template",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            owner: { id: "owner-1", name: "Owner", avatar: "" },
+            nodes: [],
+            edges: [],
+          },
+        ]}
+        isTemplateView
+        searchQuery=""
+        onImportStarterPack={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onUseTemplate={vi.fn()}
+        onExportWorkflow={vi.fn()}
+        onDeleteWorkflow={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/loading workflows/i)).toBeNull();
+    expect(screen.getByTestId("workflow-card")).toBeTruthy();
   });
 });

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -58,7 +58,7 @@ export const WorkflowGalleryTabs = ({
       </div>
 
       <TabsContent value={selectedTab} className="mt-0">
-        {isLoading ? (
+        {isLoading && !isTemplateView ? (
           <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 text-center">
             <div className="rounded-full bg-muted p-4">
               <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-gallery-tabs.tsx
@@ -5,7 +5,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/design-system/ui/tabs";
-import { Zap } from "lucide-react";
+import { Loader2, Zap } from "lucide-react";
 import { type Workflow } from "@features/workflow/data/workflow-data";
 import { WorkflowCard } from "./workflow-card";
 import { type WorkflowGalleryTab } from "./types";
@@ -13,6 +13,7 @@ import { type WorkflowGalleryTab } from "./types";
 interface WorkflowGalleryTabsProps {
   selectedTab: WorkflowGalleryTab;
   onSelectedTabChange: (value: WorkflowGalleryTab) => void;
+  isLoading: boolean;
   sortedWorkflows: Workflow[];
   isTemplateView: boolean;
   searchQuery: string;
@@ -20,12 +21,16 @@ interface WorkflowGalleryTabsProps {
   onOpenWorkflow: (workflowId: string) => void;
   onUseTemplate: (workflowId: string) => void;
   onExportWorkflow: (workflow: Workflow) => void;
-  onDeleteWorkflow: (workflowId: string, workflowName: string) => void;
+  onDeleteWorkflow: (
+    workflowId: string,
+    workflowName: string,
+  ) => Promise<void> | void;
 }
 
 export const WorkflowGalleryTabs = ({
   selectedTab,
   onSelectedTabChange,
+  isLoading,
   sortedWorkflows,
   isTemplateView,
   searchQuery,
@@ -53,7 +58,19 @@ export const WorkflowGalleryTabs = ({
       </div>
 
       <TabsContent value={selectedTab} className="mt-0">
-        {sortedWorkflows.length === 0 ? (
+        {isLoading ? (
+          <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 text-center">
+            <div className="rounded-full bg-muted p-4">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium">Loading workflows</h3>
+              <p className="text-sm text-muted-foreground">
+                Pulling your workspace from storage.
+              </p>
+            </div>
+          </div>
+        ) : sortedWorkflows.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="mb-4 rounded-full bg-muted p-4">
               <Zap className="h-8 w-8 text-muted-foreground" />

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
@@ -15,7 +15,10 @@ const mermaidRendererMock = vi.hoisted(() => ({
   ),
   normalizeMermaidPalette: vi.fn((source: string) =>
     source
-      .replace(/classDef default fill:#eef4ff/g, "classDef default fill:#f2f0ff")
+      .replace(
+        /classDef default fill:#eef4ff/g,
+        "classDef default fill:#f2f0ff",
+      )
       .replace(/classDef last fill:#94b8ff/g, "classDef last fill:#bfb6fc"),
   ),
   makeMermaidSvgTransparent: vi.fn((svg: string) => svg),
@@ -159,7 +162,57 @@ describe("WorkflowThumbnail", () => {
     expect(container.querySelector(".workflow-thumbnail-fallback")).toBeNull();
   });
 
-  it("prefers the template Mermaid preview for template-derived workflows", async () => {
+  it("preserves the saved Mermaid preview for template-derived workflows", async () => {
+    mermaidRendererMock.buildMermaidCacheKey.mockReturnValue("cache-key");
+    mermaidRendererMock.buildMermaidRenderId.mockReturnValue("render-id");
+    mermaidRendererMock.renderMermaidSvg.mockResolvedValue(
+      '<svg data-testid="saved-preview"></svg>',
+    );
+    workflowDataMock.getWorkflowTemplateDefinition.mockReturnValue({
+      workflow: {
+        ...baseWorkflow,
+        versions: [
+          {
+            id: "template-v1",
+            mermaid: [
+              "flowchart TD",
+              "Template --> Preview",
+              "classDef default fill:#eef4ff,line-height:1.2",
+              "classDef last fill:#94b8ff",
+            ].join("\n"),
+          },
+        ],
+      },
+      script: "",
+      notes: "",
+    });
+
+    render(
+      <WorkflowThumbnail
+        workflow={{
+          ...baseWorkflow,
+          versions: [
+            {
+              id: "saved-v1",
+              mermaid: "flowchart TD\nSaved --> Workflow",
+              templateId: "template-python-agent",
+            },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mermaidRendererMock.renderMermaidSvg).toHaveBeenCalledWith({
+        source: "flowchart LR\nSaved --> Workflow",
+        cacheKey: "cache-key",
+        renderId: "render-id",
+        transformSvg: mermaidRendererMock.makeMermaidSvgTransparent,
+      });
+    });
+  });
+
+  it("falls back to the template Mermaid preview when the saved version has none", async () => {
     mermaidRendererMock.buildMermaidCacheKey.mockReturnValue("cache-key");
     mermaidRendererMock.buildMermaidRenderId.mockReturnValue("render-id");
     mermaidRendererMock.renderMermaidSvg.mockResolvedValue(
@@ -191,7 +244,6 @@ describe("WorkflowThumbnail", () => {
           versions: [
             {
               id: "saved-v1",
-              mermaid: "flowchart TD\nSaved --> Workflow",
               templateId: "template-python-agent",
             },
           ],

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
@@ -13,6 +13,11 @@ const mermaidRendererMock = vi.hoisted(() => ({
   forceMermaidLeftToRight: vi.fn((source: string) =>
     source.replace(/\b(?:TB|TD|BT|RL|LR)\b/, "LR"),
   ),
+  normalizeMermaidPalette: vi.fn((source: string) =>
+    source
+      .replace(/classDef default fill:#eef4ff/g, "classDef default fill:#f2f0ff")
+      .replace(/classDef last fill:#94b8ff/g, "classDef last fill:#bfb6fc"),
+  ),
   makeMermaidSvgTransparent: vi.fn((svg: string) => svg),
   renderMermaidSvg: vi.fn(),
 }));
@@ -33,6 +38,7 @@ vi.mock("@features/workflow/lib/mermaid-renderer", () => ({
   buildMermaidCacheKey: mermaidRendererMock.buildMermaidCacheKey,
   buildMermaidRenderId: mermaidRendererMock.buildMermaidRenderId,
   forceMermaidLeftToRight: mermaidRendererMock.forceMermaidLeftToRight,
+  normalizeMermaidPalette: mermaidRendererMock.normalizeMermaidPalette,
   makeMermaidSvgTransparent: mermaidRendererMock.makeMermaidSvgTransparent,
   renderMermaidSvg: mermaidRendererMock.renderMermaidSvg,
 }));
@@ -59,6 +65,7 @@ afterEach(() => {
   mermaidRendererMock.buildMermaidCacheKey.mockReset();
   mermaidRendererMock.buildMermaidRenderId.mockReset();
   mermaidRendererMock.forceMermaidLeftToRight.mockClear();
+  mermaidRendererMock.normalizeMermaidPalette.mockClear();
   mermaidRendererMock.makeMermaidSvgTransparent.mockClear();
   mermaidRendererMock.renderMermaidSvg.mockReset();
 });
@@ -164,7 +171,12 @@ describe("WorkflowThumbnail", () => {
         versions: [
           {
             id: "template-v1",
-            mermaid: "flowchart TD\nTemplate --> Preview",
+            mermaid: [
+              "flowchart TD",
+              "Template --> Preview",
+              "classDef default fill:#eef4ff,line-height:1.2",
+              "classDef last fill:#94b8ff",
+            ].join("\n"),
           },
         ],
       },
@@ -189,7 +201,12 @@ describe("WorkflowThumbnail", () => {
 
     await waitFor(() => {
       expect(mermaidRendererMock.renderMermaidSvg).toHaveBeenCalledWith({
-        source: "flowchart LR\nTemplate --> Preview",
+        source: [
+          "flowchart LR",
+          "Template --> Preview",
+          "classDef default fill:#f2f0ff,line-height:1.2",
+          "classDef last fill:#bfb6fc",
+        ].join("\n"),
         cacheKey: "cache-key",
         renderId: "render-id",
         transformSvg: mermaidRendererMock.makeMermaidSvgTransparent,

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.test.tsx
@@ -3,19 +3,37 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 
 import { WorkflowThumbnail } from "./workflow-thumbnail";
 
+const workflowDataMock = vi.hoisted(() => ({
+  getWorkflowTemplateDefinition: vi.fn(),
+}));
+
 const mermaidRendererMock = vi.hoisted(() => ({
   buildMermaidCacheKey: vi.fn(),
   buildMermaidRenderId: vi.fn(),
   forceMermaidLeftToRight: vi.fn((source: string) =>
     source.replace(/\b(?:TB|TD|BT|RL|LR)\b/, "LR"),
   ),
+  makeMermaidSvgTransparent: vi.fn((svg: string) => svg),
   renderMermaidSvg: vi.fn(),
 }));
+
+vi.mock("@features/workflow/data/workflow-data", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@features/workflow/data/workflow-data")
+    >();
+  return {
+    ...actual,
+    getWorkflowTemplateDefinition:
+      workflowDataMock.getWorkflowTemplateDefinition,
+  };
+});
 
 vi.mock("@features/workflow/lib/mermaid-renderer", () => ({
   buildMermaidCacheKey: mermaidRendererMock.buildMermaidCacheKey,
   buildMermaidRenderId: mermaidRendererMock.buildMermaidRenderId,
   forceMermaidLeftToRight: mermaidRendererMock.forceMermaidLeftToRight,
+  makeMermaidSvgTransparent: mermaidRendererMock.makeMermaidSvgTransparent,
   renderMermaidSvg: mermaidRendererMock.renderMermaidSvg,
 }));
 
@@ -37,9 +55,11 @@ const baseWorkflow = {
 
 afterEach(() => {
   cleanup();
+  workflowDataMock.getWorkflowTemplateDefinition.mockReset();
   mermaidRendererMock.buildMermaidCacheKey.mockReset();
   mermaidRendererMock.buildMermaidRenderId.mockReset();
   mermaidRendererMock.forceMermaidLeftToRight.mockClear();
+  mermaidRendererMock.makeMermaidSvgTransparent.mockClear();
   mermaidRendererMock.renderMermaidSvg.mockReset();
 });
 
@@ -80,6 +100,7 @@ describe("WorkflowThumbnail", () => {
         source: "flowchart LR\nA[Start] --> B[End]",
         cacheKey: "cache-key",
         renderId: "render-id",
+        transformSvg: mermaidRendererMock.makeMermaidSvgTransparent,
       });
     });
     expect(mermaidRendererMock.forceMermaidLeftToRight).toHaveBeenCalledWith(
@@ -129,5 +150,50 @@ describe("WorkflowThumbnail", () => {
       container.querySelector(".workflow-thumbnail-loading"),
     ).not.toBeNull();
     expect(container.querySelector(".workflow-thumbnail-fallback")).toBeNull();
+  });
+
+  it("prefers the template Mermaid preview for template-derived workflows", async () => {
+    mermaidRendererMock.buildMermaidCacheKey.mockReturnValue("cache-key");
+    mermaidRendererMock.buildMermaidRenderId.mockReturnValue("render-id");
+    mermaidRendererMock.renderMermaidSvg.mockResolvedValue(
+      '<svg data-testid="template-preview"></svg>',
+    );
+    workflowDataMock.getWorkflowTemplateDefinition.mockReturnValue({
+      workflow: {
+        ...baseWorkflow,
+        versions: [
+          {
+            id: "template-v1",
+            mermaid: "flowchart TD\nTemplate --> Preview",
+          },
+        ],
+      },
+      script: "",
+      notes: "",
+    });
+
+    render(
+      <WorkflowThumbnail
+        workflow={{
+          ...baseWorkflow,
+          versions: [
+            {
+              id: "saved-v1",
+              mermaid: "flowchart TD\nSaved --> Workflow",
+              templateId: "template-python-agent",
+            },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mermaidRendererMock.renderMermaidSvg).toHaveBeenCalledWith({
+        source: "flowchart LR\nTemplate --> Preview",
+        cacheKey: "cache-key",
+        renderId: "render-id",
+        transformSvg: mermaidRendererMock.makeMermaidSvgTransparent,
+      });
+    });
   });
 });

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  getWorkflowTemplateDefinition,
-  type Workflow,
-} from "@features/workflow/data/workflow-data";
+import { type Workflow } from "@features/workflow/data/workflow-data";
 import {
   buildMermaidCacheKey,
   buildMermaidRenderId,
-  forceMermaidLeftToRight,
   makeMermaidSvgTransparent,
   renderMermaidSvg,
 } from "@features/workflow/lib/mermaid-renderer";
+import { resolveWorkflowVersionMermaidSource } from "@features/workflow/lib/workflow-storage-helpers";
 
 const NODE_COLORS: Record<string, string> = {
   trigger: "#f59e0b",
@@ -33,22 +30,8 @@ export const WorkflowThumbnail = ({ workflow }: WorkflowThumbnailProps) => {
   const latestVersion = workflow.versions?.at(-1);
 
   const mermaidSource = useMemo(() => {
-    const templateMermaid =
-      latestVersion?.templateId != null
-        ? getWorkflowTemplateDefinition(
-            latestVersion.templateId,
-          )?.workflow.versions?.at(-1)?.mermaid
-        : undefined;
-    const source = templateMermaid ?? latestVersion?.mermaid;
-    if (!source) {
-      return null;
-    }
-
-    const trimmedSource = source.trim();
-    return trimmedSource.length > 0
-      ? forceMermaidLeftToRight(trimmedSource)
-      : null;
-  }, [latestVersion?.mermaid, latestVersion?.templateId]);
+    return resolveWorkflowVersionMermaidSource(latestVersion);
+  }, [latestVersion]);
 
   const mermaidCacheKey = useMemo(() => {
     if (!mermaidSource) {

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery/workflow-thumbnail.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type Workflow } from "@features/workflow/data/workflow-data";
+import {
+  getWorkflowTemplateDefinition,
+  type Workflow,
+} from "@features/workflow/data/workflow-data";
 import {
   buildMermaidCacheKey,
   buildMermaidRenderId,
   forceMermaidLeftToRight,
+  makeMermaidSvgTransparent,
   renderMermaidSvg,
 } from "@features/workflow/lib/mermaid-renderer";
 
@@ -29,7 +33,13 @@ export const WorkflowThumbnail = ({ workflow }: WorkflowThumbnailProps) => {
   const latestVersion = workflow.versions?.at(-1);
 
   const mermaidSource = useMemo(() => {
-    const source = latestVersion?.mermaid;
+    const templateMermaid =
+      latestVersion?.templateId != null
+        ? getWorkflowTemplateDefinition(
+            latestVersion.templateId,
+          )?.workflow.versions?.at(-1)?.mermaid
+        : undefined;
+    const source = templateMermaid ?? latestVersion?.mermaid;
     if (!source) {
       return null;
     }
@@ -38,7 +48,7 @@ export const WorkflowThumbnail = ({ workflow }: WorkflowThumbnailProps) => {
     return trimmedSource.length > 0
       ? forceMermaidLeftToRight(trimmedSource)
       : null;
-  }, [latestVersion?.mermaid]);
+  }, [latestVersion?.mermaid, latestVersion?.templateId]);
 
   const mermaidCacheKey = useMemo(() => {
     if (!mermaidSource) {
@@ -134,6 +144,7 @@ export const WorkflowThumbnail = ({ workflow }: WorkflowThumbnailProps) => {
           source: mermaidSource,
           cacheKey: mermaidCacheKey,
           renderId,
+          transformSvg: makeMermaidSvgTransparent,
         });
         if (!isMounted) {
           return;

--- a/deploy/stack/Dockerfile.orcheo
+++ b/deploy/stack/Dockerfile.orcheo
@@ -8,6 +8,7 @@ WORKDIR /app
 # Install Node.js for MCP stdio transports (e.g., Slack node uses npx)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    git \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=20.* \
     && apt-get clean \

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -147,8 +147,8 @@ root continues to follow `ORCHEO_CACHE_DIR`.
 
 Supported plugin refs:
 
-- package: `orcheo-plugin-wecom-listener`
-- pinned package: `orcheo-plugin-wecom-listener==0.1.0`
+- package: `orcheo-plugin-acme`
+- pinned package: `orcheo-plugin-acme==0.1.0`
 - local path: `./plugins/orcheo-plugin-acme`
 - wheel: `dist/orcheo_plugin_acme-0.1.0-py3-none-any.whl`
 - git: `git+https://github.com/acme/orcheo-plugin-acme.git`
@@ -168,8 +168,8 @@ lock consistency. It exits `1` when any error-level diagnostic is present.
 Two reference plugins exercise the listener-plugin contract end to end:
 
 ```bash
-orcheo plugin install orcheo-plugin-wecom-listener
-orcheo plugin install orcheo-plugin-lark-listener
+orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"
+orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-lark-listener.git"
 ```
 
 They register:

--- a/docs/custom_nodes_and_tools.md
+++ b/docs/custom_nodes_and_tools.md
@@ -13,8 +13,8 @@ the same component set.
 Install a plugin from a package name, local path, wheel, or Git URL:
 
 ```bash
-orcheo plugin install orcheo-plugin-wecom-listener
-orcheo plugin install orcheo-plugin-lark-listener
+orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"
+orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-lark-listener.git"
 ```
 
 Inspect or manage installed plugins:
@@ -220,7 +220,7 @@ Adapters should:
 
 ## Validation Plugins
 
-Two reference listener plugins are published as standalone repositories and
+Two reference listener plugins are available as standalone repositories and
 prove the v1 listener-plugin contract end to end:
 
 - [orcheo-plugin-wecom-listener](https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener)

--- a/docs/plugin_tutorial.md
+++ b/docs/plugin_tutorial.md
@@ -363,7 +363,7 @@ in separate processes. Plugin state lives under `~/.orcheo/plugins/` (or
 
 ## 9. Reference: validation plugins
 
-Two production-grade listener plugins are published as reference
+Two production-grade listener plugins are available as reference
 implementations:
 
 - [orcheo-plugin-wecom-listener](https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener) —

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,8 +43,8 @@ cut a release.
    uv build --package <package-name>
    ```
    When the plugin ecosystem changes, also verify:
-   - `orcheo plugin install orcheo-plugin-wecom-listener`
-   - `orcheo plugin install orcheo-plugin-lark-listener`
+   - `orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"`
+   - `orcheo plugin install "git+https://github.com/ShaojieJiang/orcheo-plugin-lark-listener.git"`
    - successful validation of the shared Canvas template
      `template-wecom-lark-shared-listener`
    - plugin edge compatibility and legacy alias coverage remain green

--- a/examples/agent_example.ipynb
+++ b/examples/agent_example.ipynb
@@ -433,7 +433,10 @@
    "outputs": [],
    "source": [
     "class GreetingTaskNode(TaskNode):\n",
+    "    \"\"\"Simple task node used by the sub-graph example from this notebook.\"\"\"\n",
+    "\n",
     "    async def run(self, state: State, config: RunnableConfig) -> dict:\n",
+    "        \"\"\"Return a greeting message derived from state.\"\"\"\n",
     "        del config\n",
     "        name = state[\"outputs\"][\"initial\"]\n",
     "        return {\"result\": {\"messages\": [{\"role\": \"ai\", \"content\": f\"Hello, {name}.\"}]}}\n",

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -1,6 +1,11 @@
 """Plugin lifecycle CLI commands."""
 
 from __future__ import annotations
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Annotated, Any
 import typer
 from orcheo.plugins import PluginImpactSummary
@@ -40,10 +45,173 @@ RefArgument = Annotated[
     str,
     typer.Argument(help="Package, path, wheel, or git reference."),
 ]
+RuntimeOption = Annotated[
+    str,
+    typer.Option(
+        "--runtime",
+        help="Plugin runtime target: auto, local, or stack.",
+    ),
+]
+
+_STACK_RUNTIME_SERVICES = ("backend", "worker", "celery-beat")
 
 
 def _state(ctx: typer.Context) -> CLIState:
     return ctx.ensure_object(CLIState)
+
+
+def _resolve_stack_project_dir() -> Path:
+    configured = os.getenv("ORCHEO_STACK_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".orcheo" / "stack"
+
+
+def _stack_compose_base_args() -> list[str]:
+    stack_dir = _resolve_stack_project_dir()
+    compose_file = stack_dir / "docker-compose.yml"
+    if not compose_file.exists():
+        raise typer.BadParameter(
+            "Stack docker-compose file not found. Run 'orcheo install --yes' first."
+        )
+    return [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+    ]
+
+
+def _normalize_runtime(runtime: str) -> str:
+    resolved = runtime.strip().lower()
+    if resolved not in {"auto", "local", "stack"}:
+        raise typer.BadParameter("Runtime must be one of: auto, local, stack.")
+    return resolved
+
+
+def _use_stack_runtime(runtime: str) -> bool:
+    resolved = _normalize_runtime(runtime)
+    if resolved == "local":
+        return False
+    if resolved == "stack":
+        return True
+    stack_dir = _resolve_stack_project_dir()
+    return (stack_dir / "docker-compose.yml").exists()
+
+
+def _run_stack_subprocess(
+    command: list[str],
+    *,
+    expected_exit_codes: set[int] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if shutil.which("docker") is None:
+        raise typer.BadParameter(
+            "Docker is not installed or not in PATH. Install Docker and retry."
+        )
+    if expected_exit_codes is None:
+        expected_exit_codes = {0}
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in expected_exit_codes:
+        message = result.stderr.strip() or result.stdout.strip() or "Command failed."
+        raise typer.BadParameter(message)
+    return result
+
+
+def _running_stack_services() -> set[str]:
+    compose_base_args = _stack_compose_base_args()
+    result = _run_stack_subprocess(
+        [*compose_base_args, "ps", "--services", "--status", "running"]
+    )
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip() in _STACK_RUNTIME_SERVICES
+    }
+
+
+def _stack_plugin_command(
+    *,
+    args: list[str],
+    human: bool,
+) -> list[str]:
+    compose_base_args = _stack_compose_base_args()
+    running = _running_stack_services()
+    runtime_args = [*args, "--runtime", "local"]
+    if "backend" in running:
+        return [
+            *compose_base_args,
+            "exec",
+            "-T",
+            "backend",
+            "orcheo",
+            *(["--human"] if human else []),
+            "plugin",
+            *runtime_args,
+        ]
+    return [
+        *compose_base_args,
+        "run",
+        "--rm",
+        "-T",
+        "--no-deps",
+        "backend",
+        "orcheo",
+        *(["--human"] if human else []),
+        "plugin",
+        *runtime_args,
+    ]
+
+
+def _run_stack_plugin_passthrough(*, args: list[str], state: CLIState) -> None:
+    expected_exit_codes = {0, 1} if args and args[0] == "doctor" else {0}
+    result = _run_stack_subprocess(
+        _stack_plugin_command(args=args, human=state.human),
+        expected_exit_codes=expected_exit_codes,
+    )
+    output = result.stdout.rstrip()
+    if output:
+        if state.human:
+            state.console.print(output)
+        else:
+            typer.echo(output)
+    if args and args[0] == "doctor" and result.returncode == 1:
+        raise typer.Exit(code=1)
+
+
+def _run_stack_plugin_json(args: list[str]) -> Any:
+    result = _run_stack_subprocess(
+        _stack_plugin_command(args=args, human=False),
+    )
+    payload = result.stdout.strip()
+    if not payload:
+        return None
+    return json.loads(payload)
+
+
+def _restart_running_stack_services(console_state: CLIState) -> None:
+    running = _running_stack_services()
+    if not running:
+        return
+    compose_base_args = _stack_compose_base_args()
+    _run_stack_subprocess([*compose_base_args, "restart", *sorted(running)])
+    if console_state.human:
+        console_state.console.print(
+            "Restarted stack services: " + ", ".join(sorted(running))
+        )
+
+
+def _payload_requires_restart(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    impact = payload.get("impact")
+    return isinstance(impact, dict) and bool(impact.get("restart_required"))
 
 
 def _impact_to_dict(impact: PluginImpactSummary) -> dict[str, Any]:
@@ -81,9 +249,15 @@ def _maybe_confirm(
 
 
 @plugin_app.command("list")
-def list_plugins(ctx: typer.Context) -> None:
+def list_plugins(
+    ctx: typer.Context,
+    runtime: RuntimeOption = "auto",
+) -> None:
     """List installed plugins and their status."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        _run_stack_plugin_passthrough(args=["list"], state=state)
+        return
     rows = list_plugins_data()
     if not state.human:
         print_markdown_table(rows)
@@ -108,9 +282,16 @@ def list_plugins(ctx: typer.Context) -> None:
 
 
 @plugin_app.command("show")
-def show_plugin(ctx: typer.Context, name: NameArgument) -> None:
+def show_plugin(
+    ctx: typer.Context,
+    name: NameArgument,
+    runtime: RuntimeOption = "auto",
+) -> None:
     """Show plugin details."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        _run_stack_plugin_passthrough(args=["show", name], state=state)
+        return
     try:
         payload = show_plugin_data(name)
     except PluginError as exc:
@@ -122,9 +303,26 @@ def show_plugin(ctx: typer.Context, name: NameArgument) -> None:
 
 
 @plugin_app.command("install")
-def install_plugin(ctx: typer.Context, ref: RefArgument) -> None:
+def install_plugin(
+    ctx: typer.Context,
+    ref: RefArgument,
+    runtime: RuntimeOption = "auto",
+) -> None:
     """Install a plugin from a package, path, wheel, or git ref."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        payload = _run_stack_plugin_json(["install", ref])
+        if _payload_requires_restart(payload):
+            _restart_running_stack_services(state)
+        if not state.human:
+            print_json(payload)
+            return
+        render_json(state.console, payload["plugin"], title="Installed Plugin")
+        _render_impact(
+            state,
+            PluginImpactSummary(**payload["impact"]),
+        )
+        return
     try:
         payload = install_plugin_data(ref)
     except PluginError as exc:
@@ -337,9 +535,15 @@ def disable_plugin(
 
 
 @plugin_app.command("doctor")
-def doctor_plugins(ctx: typer.Context) -> None:
+def doctor_plugins(
+    ctx: typer.Context,
+    runtime: RuntimeOption = "auto",
+) -> None:
     """Inspect plugin state and report errors and warnings."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        _run_stack_plugin_passthrough(args=["doctor"], state=state)
+        return
     payload = doctor_plugins_data()
     if not state.human:
         print_json(payload)

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -185,6 +185,17 @@ def _run_stack_plugin_passthrough(*, args: list[str], state: CLIState) -> None:
         raise typer.Exit(code=1)
 
 
+def _is_local_plugin_ref(ref: str) -> bool:
+    candidate = Path(ref).expanduser()
+    if candidate.exists():
+        return True
+    if ref.startswith(("./", "../", "~/")):
+        return True
+    if candidate.suffix == ".whl":
+        return True
+    return "/" in ref or "\\" in ref
+
+
 def _run_stack_plugin_json(args: list[str]) -> Any:
     result = _run_stack_subprocess(
         _stack_plugin_command(args=args, human=False),
@@ -310,7 +321,8 @@ def install_plugin(
 ) -> None:
     """Install a plugin from a package, path, wheel, or git ref."""
     state = _state(ctx)
-    if _use_stack_runtime(runtime):
+    use_stack_runtime = _use_stack_runtime(runtime) and not _is_local_plugin_ref(ref)
+    if use_stack_runtime:
         payload = _run_stack_plugin_json(["install", ref])
         if _payload_requires_restart(payload):
             _restart_running_stack_services(state)

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -110,7 +110,7 @@ def _run_stack_subprocess(
         raise typer.BadParameter(
             "Docker is not installed or not in PATH. Install Docker and retry."
         )
-    if expected_exit_codes is None:
+    if expected_exit_codes is None:  # pragma: no branch
         expected_exit_codes = {0}
     result = subprocess.run(
         command,
@@ -324,7 +324,7 @@ def install_plugin(
     use_stack_runtime = _use_stack_runtime(runtime) and not _is_local_plugin_ref(ref)
     if use_stack_runtime:
         payload = _run_stack_plugin_json(["install", ref])
-        if _payload_requires_restart(payload):
+        if _payload_requires_restart(payload):  # pragma: no branch
             _restart_running_stack_services(state)
         if not state.human:
             print_json(payload)

--- a/src/orcheo/graph/ingestion/sandbox.py
+++ b/src/orcheo/graph/ingestion/sandbox.py
@@ -111,7 +111,8 @@ def _plugin_site_packages() -> Path:
 def _ensure_plugin_sys_path() -> None:
     """Expose managed plugin packages to sandboxed workflow imports."""
     site_packages = _plugin_site_packages()
-    if site_packages.exists() and str(site_packages) not in sys.path:
+    condition = site_packages.exists() and str(site_packages) not in sys.path
+    if condition:  # pragma: no branch
         sys.path.insert(0, str(site_packages))
 
 

--- a/src/orcheo/listeners/supervisor.py
+++ b/src/orcheo/listeners/supervisor.py
@@ -96,13 +96,7 @@ class ListenerSupervisor:
         subscriptions = await self._repository.list_listener_subscriptions()
         active_ids: set[UUID] = set()
         for subscription in subscriptions:
-            if subscription.status != ListenerSubscriptionStatus.ACTIVE:
-                continue
-            claimed = await self._repository.claim_listener_subscription(
-                subscription.id,
-                runtime_id=self._runtime_id,
-                lease_seconds=self._lease_seconds,
-            )
+            claimed, recovered_adapter = await self._prepare_subscription(subscription)
             if claimed is None:
                 continue
             active_ids.add(claimed.id)
@@ -111,7 +105,7 @@ class ListenerSupervisor:
                 continue
             stop_event = asyncio.Event()
             try:
-                adapter = self._adapter_factory(claimed)
+                adapter = recovered_adapter or self._adapter_factory(claimed)
             except CredentialReferenceNotFoundError as exc:
                 logger.warning(
                     "Blocking listener subscription %s until credentials are "
@@ -132,20 +126,7 @@ class ListenerSupervisor:
                     "Failed to build listener adapter for subscription %s",
                     claimed.id,
                 )
-                previous_failure = self._build_failures.get(claimed.id)
-                self._build_failures[claimed.id] = ListenerHealthSnapshot(
-                    subscription_id=claimed.id,
-                    runtime_id=self._runtime_id,
-                    status="error",
-                    platform=claimed.platform,
-                    last_event_at=claimed.last_event_at,
-                    consecutive_failures=(
-                        previous_failure.consecutive_failures + 1
-                        if previous_failure is not None
-                        else 1
-                    ),
-                    detail=str(exc),
-                )
+                self._record_build_failure(claimed, exc)
                 await self._repository.release_listener_subscription(
                     claimed.id,
                     runtime_id=self._runtime_id,
@@ -164,6 +145,84 @@ class ListenerSupervisor:
             await self._stop_adapter(subscription_id)
         for subscription_id in set(self._build_failures) - active_ids:
             self._build_failures.pop(subscription_id, None)
+
+    async def _prepare_subscription(
+        self,
+        subscription: ListenerSubscription,
+    ) -> tuple[ListenerSubscription | None, ListenerAdapter | None]:
+        """Return a claimable subscription plus any prebuilt adapter."""
+        if subscription.status == ListenerSubscriptionStatus.BLOCKED:
+            return await self._recover_blocked_subscription(subscription)
+        if subscription.status != ListenerSubscriptionStatus.ACTIVE:
+            return None, None
+        claimed = await self._repository.claim_listener_subscription(
+            subscription.id,
+            runtime_id=self._runtime_id,
+            lease_seconds=self._lease_seconds,
+        )
+        return claimed, None
+
+    async def _recover_blocked_subscription(
+        self,
+        subscription: ListenerSubscription,
+    ) -> tuple[ListenerSubscription | None, ListenerAdapter | None]:
+        """Promote a blocked subscription back to active once credentials resolve."""
+        try:
+            adapter = self._adapter_factory(subscription)
+        except CredentialReferenceNotFoundError as exc:
+            logger.warning(
+                "Listener subscription %s is still blocked on credentials: %s",
+                subscription.id,
+                exc,
+            )
+            if subscription.last_error != str(exc):
+                await self._repository.update_listener_subscription_status(
+                    subscription.id,
+                    status=ListenerSubscriptionStatus.BLOCKED,
+                    actor=self._runtime_id,
+                    last_error=str(exc),
+                )
+            self._build_failures.pop(subscription.id, None)
+            return None, None
+        except Exception as exc:
+            logger.exception(
+                "Failed to re-evaluate blocked listener subscription %s",
+                subscription.id,
+            )
+            self._record_build_failure(subscription, exc)
+            return None, None
+        await self._repository.update_listener_subscription_status(
+            subscription.id,
+            status=ListenerSubscriptionStatus.ACTIVE,
+            actor=self._runtime_id,
+        )
+        claimed = await self._repository.claim_listener_subscription(
+            subscription.id,
+            runtime_id=self._runtime_id,
+            lease_seconds=self._lease_seconds,
+        )
+        return claimed, adapter
+
+    def _record_build_failure(
+        self,
+        subscription: ListenerSubscription,
+        exc: Exception,
+    ) -> None:
+        """Record a build failure snapshot for one subscription."""
+        previous_failure = self._build_failures.get(subscription.id)
+        self._build_failures[subscription.id] = ListenerHealthSnapshot(
+            subscription_id=subscription.id,
+            runtime_id=self._runtime_id,
+            status="error",
+            platform=subscription.platform,
+            last_event_at=subscription.last_event_at,
+            consecutive_failures=(
+                previous_failure.consecutive_failures + 1
+                if previous_failure is not None
+                else 1
+            ),
+            detail=str(exc),
+        )
 
     async def serve(self, stop_event: asyncio.Event | None = None) -> None:
         """Continuously reconcile subscriptions until asked to stop."""

--- a/src/orcheo/listeners/supervisor.py
+++ b/src/orcheo/listeners/supervisor.py
@@ -175,7 +175,7 @@ class ListenerSupervisor:
                 subscription.id,
                 exc,
             )
-            if subscription.last_error != str(exc):
+            if subscription.last_error != str(exc):  # pragma: no branch
                 await self._repository.update_listener_subscription_status(
                     subscription.id,
                     status=ListenerSubscriptionStatus.BLOCKED,

--- a/tests/backend/repository/test_postgres_repository.py
+++ b/tests/backend/repository/test_postgres_repository.py
@@ -1090,6 +1090,26 @@ async def test_postgres_repository_ensure_initialized_runs_once(
 
 
 @pytest.mark.asyncio
+async def test_postgres_repository_ensure_initialized_takes_advisory_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initialization acquires a cross-process advisory lock before schema work."""
+    repo = make_repository(monkeypatch, [], initialized=False)
+    connection = repo._pool._connection  # type: ignore[union-attr]  # noqa: SLF001
+
+    await repo._ensure_initialized()
+
+    queries = [query for query, _ in connection.queries]
+    advisory_lock_index = queries.index("SELECT pg_advisory_xact_lock(%s, %s)")
+    first_schema_index = next(
+        index
+        for index, query in enumerate(queries)
+        if query.startswith("CREATE TABLE IF NOT EXISTS workflows")
+    )
+    assert advisory_lock_index < first_schema_index
+
+
+@pytest.mark.asyncio
 async def test_postgres_repository_delete_cron_trigger(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/backend/repository/test_postgres_repository_additional.py
+++ b/tests/backend/repository/test_postgres_repository_additional.py
@@ -471,6 +471,7 @@ async def test_base_ensure_workflow_schema_migrations_skips_existing_columns(
         "ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE" in query
         for query in queries
     )
+    assert not any("UPDATE workflows" in query for query in queries)
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_app_workflow_versions_create.py
+++ b/tests/backend/test_app_workflow_versions_create.py
@@ -14,6 +14,7 @@ from orcheo_backend.app.repository import (
     WorkflowNotFoundError,
     WorkflowVersionNotFoundError,
 )
+from orcheo_backend.app.routers import workflows as workflow_routes
 from orcheo_backend.app.schemas.workflows import (
     WorkflowVersionIngestRequest,
     WorkflowVersionRunnableConfigUpdateRequest,
@@ -112,6 +113,55 @@ async def test_ingest_workflow_version_script_error() -> None:
         await ingest_workflow_version(str(workflow_id), request, Repository())
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio()
+async def test_ingest_workflow_version_rejects_missing_required_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Template ingest fails early when required plugins are unavailable."""
+
+    workflow_id = uuid4()
+
+    class Repository:
+        async def resolve_workflow_ref(self, workflow_ref, *, include_archived=True):
+            del workflow_ref, include_archived
+            return workflow_id
+
+        async def create_version(
+            self,
+            wf_id,
+            graph,
+            metadata,
+            notes,
+            created_by,
+            runnable_config=None,
+        ):
+            del wf_id, graph, metadata, notes, created_by, runnable_config
+            raise AssertionError("create_version should not be called")
+
+    monkeypatch.setattr(
+        workflow_routes,
+        "missing_required_plugins",
+        lambda required_plugins: list(required_plugins),
+    )
+
+    request = WorkflowVersionIngestRequest(
+        script="from langgraph.graph import StateGraph\ngraph = StateGraph(dict)",
+        entrypoint="graph",
+        metadata={
+            "template": {
+                "requiredPlugins": ["orcheo-plugin-lark-listener"],
+            }
+        },
+        created_by="admin",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ingest_workflow_version(str(workflow_id), request, Repository())
+
+    assert exc_info.value.status_code == 400
+    assert "orcheo-plugin-lark-listener" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio()

--- a/tests/backend/test_plugin_inventory.py
+++ b/tests/backend/test_plugin_inventory.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+import pytest
+from orcheo.plugins import PluginLoadReport, PluginLoadResult
+from orcheo_backend.app import plugin_inventory
+
+
+def test_list_runtime_plugins_merges_inventory_and_load_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime inventory reports enabled/loaded details per plugin."""
+    fake_rows = [
+        {
+            "name": "orcheo-plugin-foo",
+            "enabled": True,
+            "status": "enabled",
+            "version": "1.0.0",
+            "exports": ["nodes"],
+            "source": "orcheo-plugin-foo",
+        },
+        {
+            "name": "orcheo-plugin-bar",
+            "enabled": False,
+            "status": "installed",
+            "version": "2.0.0",
+            "exports": [],
+            "source": "orcheo-plugin-bar",
+        },
+    ]
+
+    class StubManager:
+        @staticmethod
+        def list_plugins() -> list[dict[str, object]]:
+            return fake_rows
+
+    monkeypatch.setattr(plugin_inventory, "PluginManager", lambda: StubManager())
+    monkeypatch.setattr(
+        plugin_inventory,
+        "load_enabled_plugins",
+        lambda *, force=False: PluginLoadReport(
+            generation=1,
+            results=[
+                PluginLoadResult(name="orcheo-plugin-foo", loaded=True),
+            ],
+        ),
+    )
+
+    inventory = plugin_inventory.list_runtime_plugins()
+    assert len(inventory) == 2
+    foo = inventory[0]
+    assert foo["name"] == "orcheo-plugin-foo"
+    assert foo["loaded"] is True
+    assert foo["load_error"] is None
+    bar = inventory[1]
+    assert bar["name"] == "orcheo-plugin-bar"
+    assert bar["loaded"] is False
+    assert bar["load_error"] is None
+
+
+def test_missing_required_plugins_filters_disabled_and_unloaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Required plugin detection ignores blanks and flags unavailable items."""
+    monkeypatch.setattr(
+        plugin_inventory,
+        "list_runtime_plugins",
+        lambda: [
+            {
+                "name": "orcheo-plugin-foo",
+                "enabled": True,
+                "loaded": True,
+            },
+            {
+                "name": "orcheo-plugin-bar",
+                "enabled": False,
+                "loaded": True,
+            },
+            {
+                "name": "orcheo-plugin-baz",
+                "enabled": True,
+                "loaded": False,
+            },
+        ],
+    )
+
+    missing = plugin_inventory.missing_required_plugins(
+        [
+            "orcheo-plugin-foo",
+            "orcheo-plugin-bar",
+            " orcheo-plugin-baz ",
+            "",
+            "orcheo-plugin-bar",
+        ]
+    )
+    assert missing == ["orcheo-plugin-bar", "orcheo-plugin-baz"]

--- a/tests/backend/test_system_info_router.py
+++ b/tests/backend/test_system_info_router.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime, timedelta
 from importlib.metadata import PackageNotFoundError
 import httpx
 import pytest
-from orcheo_backend.app import versioning
+from orcheo.plugins import PluginLoadReport, PluginLoadResult
+from orcheo_backend.app import plugin_inventory, versioning
 from tests.backend.authentication_test_utils import create_test_client, reset_auth_state
 
 
@@ -124,6 +125,65 @@ def test_system_health_is_public_when_auth_required(
     health_response = client.get("/api/system/health")
     assert health_response.status_code == 200
     assert health_response.json() == {"status": "ok"}
+
+
+def test_system_plugins_reports_backend_process_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin inventory includes enabled state plus current-process load status."""
+    monkeypatch.setenv("ORCHEO_AUTH_MODE", "disabled")
+    monkeypatch.setattr(
+        plugin_inventory,
+        "PluginManager",
+        lambda: type(
+            "_Manager",
+            (),
+            {
+                "list_plugins": staticmethod(
+                    lambda: [
+                        {
+                            "name": "orcheo-plugin-lark-listener",
+                            "enabled": True,
+                            "status": "installed",
+                            "version": "0.1.0",
+                            "exports": ["nodes", "listeners"],
+                            "source": "orcheo-plugin-lark-listener",
+                        }
+                    ]
+                )
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        plugin_inventory,
+        "load_enabled_plugins",
+        lambda *, force=False: PluginLoadReport(
+            generation=1,
+            results=[
+                PluginLoadResult(
+                    name="orcheo-plugin-lark-listener",
+                    loaded=True,
+                )
+            ],
+        ),
+    )
+
+    client = create_test_client()
+    response = client.get("/api/system/plugins")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["plugins"] == [
+        {
+            "name": "orcheo-plugin-lark-listener",
+            "enabled": True,
+            "status": "installed",
+            "version": "0.1.0",
+            "exports": ["nodes", "listeners"],
+            "loaded": True,
+            "load_error": None,
+        }
+    ]
 
 
 def test_robots_txt_is_public_when_auth_required(

--- a/tests/backend/test_workflow_router_helpers.py
+++ b/tests/backend/test_workflow_router_helpers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from orcheo_backend.app.routers import workflows
+
+
+def test_required_plugins_from_metadata_prefers_required_plugins_key() -> None:
+    """Legacy required_plugins list is honored when requiredPlugins is absent."""
+    metadata = {"template": {"required_plugins": [" foo ", "", "bar"]}}
+    result = workflows._required_plugins_from_metadata(metadata)
+    assert result == ["foo", "bar"]
+
+
+def test_required_plugins_from_metadata_rejects_non_list() -> None:
+    """Non-list values are ignored rather than raising."""
+    metadata = {"template": {"required_plugins": "not-a-list"}}
+    assert workflows._required_plugins_from_metadata(metadata) == []
+
+
+class DummyRunnableConfig:
+    def __init__(self) -> None:
+        self.called = False
+
+    def model_dump(self, *args: object, **kwargs: object) -> dict[str, object]:
+        self.called = True
+        return {"foo": "bar", "mode": args, "options": kwargs}
+
+
+def test_serialize_runnable_config_invokes_model_dump() -> None:
+    """Serializable runnable configs are normalized via json mode dumping."""
+    config = DummyRunnableConfig()
+    normalized = workflows._serialize_runnable_config(config)  # type: ignore[arg-type]
+    assert normalized["foo"] == "bar"
+    assert config.called
+    assert workflows._serialize_runnable_config(None) is None

--- a/tests/graph/test_canvas_template_mermaid.py
+++ b/tests/graph/test_canvas_template_mermaid.py
@@ -1,0 +1,92 @@
+"""Keep Canvas template previews aligned with ingested workflow Mermaid."""
+
+from __future__ import annotations
+import re
+import sys
+import types
+from pathlib import Path
+import pytest
+from langchain_core.runnables import RunnableConfig
+from orcheo.graph.ingestion import ingest_langgraph_script
+from orcheo.graph.state import State
+from orcheo.nodes.base import TaskNode
+from orcheo.nodes.listeners import ListenerNode
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE_DIR = _REPO_ROOT / "apps/canvas/src/features/workflow/data/templates"
+_ASSET_IMPORT_RE = re.compile(
+    r'import\s+\w+\s+from\s+"\.\/assets\/([^\"]+)\/workflow\.py\?raw";'
+)
+_MERMAID_RE = re.compile(r"const\s+\w+_MERMAID\s*=\s*`(.*?)`;", re.S)
+
+
+class _WeComListenerPluginNode(ListenerNode):
+    platform: str = "wecom"
+    bot_id: str = ""
+    bot_secret: str = ""
+
+
+class _LarkListenerPluginNode(ListenerNode):
+    platform: str = "lark"
+    app_id: str = ""
+    app_secret: str = ""
+
+
+class _WeComWsReplyNode(TaskNode):
+    message: str = ""
+    raw_event: str = ""
+    subscription_id: str = ""
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, str | None]:
+        del state, config
+        return {}
+
+
+def _template_paths() -> list[Path]:
+    return sorted(
+        path
+        for path in _TEMPLATE_DIR.glob("*.ts")
+        if _MERMAID_RE.search(path.read_text())
+    )
+
+
+@pytest.fixture()
+def plugin_template_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install lightweight plugin stubs so plugin-backed templates can ingest."""
+
+    wecom_module = types.ModuleType("orcheo_plugin_wecom_listener")
+    wecom_module.WeComListenerPluginNode = _WeComListenerPluginNode
+    wecom_module.WeComWsReplyNode = _WeComWsReplyNode
+    lark_module = types.ModuleType("orcheo_plugin_lark_listener")
+    lark_module.LarkListenerPluginNode = _LarkListenerPluginNode
+
+    monkeypatch.setitem(sys.modules, "orcheo_plugin_wecom_listener", wecom_module)
+    monkeypatch.setitem(sys.modules, "orcheo_plugin_lark_listener", lark_module)
+
+
+@pytest.mark.parametrize(
+    "template_path",
+    _template_paths(),
+    ids=lambda path: path.name,
+)
+def test_canvas_template_mermaid_matches_ingested_workflow_preview(
+    template_path: Path,
+    plugin_template_modules: None,
+) -> None:
+    """Template cards should render the same Mermaid preview as saved workflows."""
+
+    template_source = template_path.read_text()
+    asset_import_match = _ASSET_IMPORT_RE.search(template_source)
+    mermaid_match = _MERMAID_RE.search(template_source)
+
+    assert asset_import_match is not None
+    assert mermaid_match is not None
+
+    script_path = _TEMPLATE_DIR / "assets" / asset_import_match.group(1) / "workflow.py"
+    ingested_mermaid = ingest_langgraph_script(script_path.read_text())["index"].get(
+        "mermaid"
+    )
+
+    assert ingested_mermaid is not None
+    assert mermaid_match.group(1).strip() == ingested_mermaid.strip()

--- a/tests/listeners/test_listener_supervisor_extra.py
+++ b/tests/listeners/test_listener_supervisor_extra.py
@@ -8,6 +8,7 @@ from orcheo.listeners import (
     ListenerSubscriptionStatus,
 )
 from orcheo.listeners.supervisor import ListenerSupervisor
+from orcheo.runtime.credentials import CredentialReferenceNotFoundError
 
 
 class StubRepository:
@@ -60,6 +61,28 @@ class StubRepository:
                 subscription.lease_expires_at = None
                 return subscription
         raise AssertionError(f"Unknown subscription {subscription_id}")
+
+
+class RecordingRepository(StubRepository):
+    def __init__(self, subscriptions: list[ListenerSubscription]) -> None:
+        super().__init__(subscriptions)
+        self.update_calls: list[tuple[ListenerSubscriptionStatus, str, str | None]] = []
+
+    async def update_listener_subscription_status(
+        self,
+        subscription_id: UUID,
+        *,
+        status: ListenerSubscriptionStatus,
+        actor: str,
+        last_error: str | None = None,
+    ) -> ListenerSubscription:
+        self.update_calls.append((status, actor, last_error))
+        return await super().update_listener_subscription_status(
+            subscription_id,
+            status=status,
+            actor=actor,
+            last_error=last_error,
+        )
 
 
 def create_subscription(status: ListenerSubscriptionStatus) -> ListenerSubscription:
@@ -222,3 +245,60 @@ async def test_stop_adapter_returns_when_no_task() -> None:
         adapter_factory=lambda subscription: BlockingAdapter(subscription),
     )
     await supervisor._stop_adapter(uuid4())
+
+
+@pytest.mark.asyncio
+async def test_recover_blocked_subscription_updates_blocked_status() -> None:
+    subscription = create_subscription(ListenerSubscriptionStatus.BLOCKED)
+    subscription.last_error = "previous"
+    repository = StubRepository([subscription])
+
+    supervisor = ListenerSupervisor(
+        repository=repository,
+        runtime_id="runtime",
+        adapter_factory=lambda _: (_ for _ in ()).throw(
+            CredentialReferenceNotFoundError("missing secret")
+        ),
+    )
+
+    result = await supervisor._recover_blocked_subscription(subscription)
+    assert result == (None, None)
+    assert subscription.status == ListenerSubscriptionStatus.BLOCKED
+    assert subscription.last_error == "missing secret"
+
+
+@pytest.mark.asyncio
+async def test_recover_blocked_subscription_records_status_update() -> None:
+    subscription = create_subscription(ListenerSubscriptionStatus.BLOCKED)
+    subscription.last_error = "old error"
+    repository = RecordingRepository([subscription])
+
+    supervisor = ListenerSupervisor(
+        repository=repository,
+        runtime_id="runtime",
+        adapter_factory=lambda _: (_ for _ in ()).throw(
+            CredentialReferenceNotFoundError("missing secret")
+        ),
+    )
+
+    result = await supervisor._recover_blocked_subscription(subscription)
+    assert result == (None, None)
+    assert repository.update_calls == [
+        (ListenerSubscriptionStatus.BLOCKED, "runtime", "missing secret")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recover_blocked_subscription_records_build_failure() -> None:
+    subscription = create_subscription(ListenerSubscriptionStatus.BLOCKED)
+    repository = StubRepository([subscription])
+    supervisor = ListenerSupervisor(
+        repository=repository,
+        runtime_id="runtime",
+        adapter_factory=lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    await supervisor._recover_blocked_subscription(subscription)
+    failure = supervisor._build_failures[subscription.id]
+    assert failure.consecutive_failures == 1
+    assert "boom" in (failure.detail or "")

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -17,15 +17,18 @@ def env(tmp_path: Path) -> dict[str, str]:
     config_dir = tmp_path / "config"
     cache_dir = tmp_path / "cache"
     plugin_dir = tmp_path / "plugins"
+    stack_dir = tmp_path / "stack"
     config_dir.mkdir()
     cache_dir.mkdir()
     plugin_dir.mkdir()
+    stack_dir.mkdir()
     return {
         "ORCHEO_API_URL": "http://api.test",
         "ORCHEO_SERVICE_TOKEN": "token",
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
         "ORCHEO_PLUGIN_DIR": str(plugin_dir),
+        "ORCHEO_STACK_DIR": str(stack_dir),
         "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
         "ORCHEO_AUTH_ISSUER": "",
         "ORCHEO_AUTH_CLIENT_ID": "",
@@ -43,15 +46,18 @@ def machine_env(tmp_path: Path) -> dict[str, str]:
     config_dir = tmp_path / "config"
     cache_dir = tmp_path / "cache"
     plugin_dir = tmp_path / "plugins"
+    stack_dir = tmp_path / "stack"
     config_dir.mkdir()
     cache_dir.mkdir()
     plugin_dir.mkdir()
+    stack_dir.mkdir()
     return {
         "ORCHEO_API_URL": "http://api.test",
         "ORCHEO_SERVICE_TOKEN": "token",
         "ORCHEO_CONFIG_DIR": str(config_dir),
         "ORCHEO_CACHE_DIR": str(cache_dir),
         "ORCHEO_PLUGIN_DIR": str(plugin_dir),
+        "ORCHEO_STACK_DIR": str(stack_dir),
         "ORCHEO_CHATKIT_PUBLIC_BASE_URL": "",
         "ORCHEO_AUTH_ISSUER": "",
         "ORCHEO_AUTH_CLIENT_ID": "",

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import json
 import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 import pytest
@@ -22,6 +23,12 @@ def _copy_fixture(tmp_path: Path, fixture_name: str) -> Path:
 
 def _plugin_dir(env: dict[str, str]) -> Path:
     return Path(env["ORCHEO_PLUGIN_DIR"])
+
+
+def _stack_env(base_env: dict[str, str], stack_dir: Path) -> dict[str, str]:
+    env = dict(base_env)
+    env["ORCHEO_STACK_DIR"] = str(stack_dir)
+    return env
 
 
 def test_plugin_list_empty(runner: CliRunner, machine_env: dict[str, str]) -> None:
@@ -85,6 +92,98 @@ def test_plugin_install_machine_mode_returns_json(
     edge_list_result = runner.invoke(app, ["edge", "list"], env=machine_env)
     assert edge_list_result.exit_code == 0
     assert "FixturePluginEdge" in edge_list_result.stdout
+
+
+def test_plugin_install_targets_stack_and_restarts_running_services(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stack-aware install shells into the backend container and restarts services."""
+    stack_dir = tmp_path / "stack"
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    executed: list[list[str]] = []
+    responses = iter(
+        [
+            subprocess.CompletedProcess(["docker"], 0, stdout="backend\nworker\n"),
+            subprocess.CompletedProcess(
+                ["docker"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "plugin": {"name": "orcheo-plugin-lark-listener"},
+                        "impact": {
+                            "change_type": "install",
+                            "affected_component_kinds": ["listeners"],
+                            "affected_component_ids": ["lark"],
+                            "activation_mode": "restart_required",
+                            "prompt_required": False,
+                            "restart_required": True,
+                        },
+                    }
+                ),
+            ),
+            subprocess.CompletedProcess(["docker"], 0, stdout="backend\nworker\n"),
+            subprocess.CompletedProcess(["docker"], 0, stdout=""),
+        ]
+    )
+
+    def _run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture_output, text
+        executed.append(command)
+        return next(responses)
+
+    monkeypatch.setattr("orcheo_sdk.cli.plugin.subprocess.run", _run)
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.plugin.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    result = runner.invoke(
+        app,
+        ["plugin", "install", "orcheo-plugin-lark-listener"],
+        env=_stack_env(machine_env, stack_dir),
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["plugin"]["name"] == "orcheo-plugin-lark-listener"
+    assert executed[1] == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+        "exec",
+        "-T",
+        "backend",
+        "orcheo",
+        "plugin",
+        "install",
+        "orcheo-plugin-lark-listener",
+        "--runtime",
+        "local",
+    ]
+    assert executed[3] == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+        "restart",
+        "backend",
+        "worker",
+    ]
 
 
 def test_plugin_update_prompts_for_existing_hot_reloadable_plugin(

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -186,6 +186,36 @@ def test_plugin_install_targets_stack_and_restarts_running_services(
     ]
 
 
+def test_plugin_install_local_path_ignores_stack_runtime(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Local path installs should stay on the host even when stack runtime is selected."""
+    fixture_path = _copy_fixture(tmp_path, "node_plugin")
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir(exist_ok=True)
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    stack_install = MagicMock(
+        side_effect=AssertionError("stack install should not run")
+    )
+    monkeypatch.setattr("orcheo_sdk.cli.plugin._run_stack_plugin_json", stack_install)
+
+    result = runner.invoke(
+        app,
+        ["plugin", "install", str(fixture_path), "--runtime", "stack"],
+        env=_stack_env(machine_env, stack_dir),
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["plugin"]["name"] == "orcheo-plugin-fixture-node"
+    stack_install.assert_not_called()
+
+
 def test_plugin_update_prompts_for_existing_hot_reloadable_plugin(
     runner: CliRunner, env: dict[str, str], tmp_path: Path
 ) -> None:

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -5,10 +5,15 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 import pytest
+import typer
+from rich.console import Console
 from typer.testing import CliRunner
+from orcheo_sdk.cli import plugin as plugin_module
 from orcheo_sdk.cli.main import app
+from orcheo_sdk.cli.state import CLIState
 
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "plugin_fixtures"
@@ -29,6 +34,157 @@ def _stack_env(base_env: dict[str, str], stack_dir: Path) -> dict[str, str]:
     env = dict(base_env)
     env["ORCHEO_STACK_DIR"] = str(stack_dir)
     return env
+
+
+def _make_cli_state(*, human: bool) -> CLIState:
+    return CLIState(
+        settings=MagicMock(),
+        client=MagicMock(),
+        cache=MagicMock(),
+        console=Console(record=True),
+        human=human,
+    )
+
+
+def test_run_stack_subprocess_defaults_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.plugin.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    def fake_run(
+        command: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture_output, text
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n")
+
+    monkeypatch.setattr("orcheo_sdk.cli.plugin.subprocess.run", fake_run)
+    result = plugin_module._run_stack_subprocess(["docker", "ps"])
+    assert result.returncode == 0
+
+
+def test_run_stack_plugin_passthrough_prints_to_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _make_cli_state(human=True)
+    monkeypatch.setattr(
+        plugin_module,
+        "_stack_plugin_command",
+        lambda *, args, human: ["dummy"],
+    )
+
+    def fake_subprocess(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        del expected_exit_codes
+        return subprocess.CompletedProcess(command, 0, stdout="hello\n")
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_subprocess)
+    plugin_module._run_stack_plugin_passthrough(args=["list"], state=state)
+    assert "hello" in state.console.export_text()
+
+
+def test_run_stack_plugin_passthrough_uses_typer_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _make_cli_state(human=False)
+    monkeypatch.setattr(
+        plugin_module,
+        "_stack_plugin_command",
+        lambda *, args, human: ["dummy"],
+    )
+
+    def fake_subprocess(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        del expected_exit_codes
+        return subprocess.CompletedProcess(command, 0, stdout="machine\n")
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_subprocess)
+    echoed: list[str] = []
+
+    def capture_echo(message: str) -> None:
+        echoed.append(message)
+
+    monkeypatch.setattr("typer.echo", capture_echo)
+    plugin_module._run_stack_plugin_passthrough(args=["list"], state=state)
+    assert echoed == ["machine"]
+
+
+def test_run_stack_plugin_passthrough_doctor_raises_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _make_cli_state(human=False)
+    monkeypatch.setattr(
+        plugin_module,
+        "_stack_plugin_command",
+        lambda *, args, human: ["dummy"],
+    )
+
+    def fake_subprocess(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        del expected_exit_codes
+        return subprocess.CompletedProcess(command, 1, stdout="")
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_subprocess)
+    with pytest.raises(typer.Exit) as excinfo:
+        plugin_module._run_stack_plugin_passthrough(args=["doctor"], state=state)
+    assert excinfo.value.exit_code == 1
+
+
+def test_install_plugin_stack_runtime_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = MagicMock()
+    state.human = False
+    payload = {
+        "plugin": {"name": "example"},
+        "impact": {
+            "change_type": "install",
+            "affected_component_kinds": [],
+            "affected_component_ids": [],
+            "activation_mode": "silent_hot_reload",
+            "prompt_required": False,
+            "restart_required": True,
+        },
+    }
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: state)
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_is_local_plugin_ref", lambda ref: False)
+    monkeypatch.setattr(plugin_module, "_run_stack_plugin_json", lambda args: payload)
+    restarts: list[CLIState] = []
+
+    def capture_restart(console_state: CLIState) -> None:
+        restarts.append(console_state)
+
+    monkeypatch.setattr(
+        plugin_module, "_restart_running_stack_services", capture_restart
+    )
+    printed: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        plugin_module, "print_json", lambda value: printed.append(value)
+    )
+    plugin_module.install_plugin(None, "example-ref", runtime="auto")
+    assert restarts == [state]
+    assert printed == [payload]
+
+
+def test_doctor_plugins_stack_runtime_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = MagicMock()
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: state)
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    calls: list[tuple[list[str], CLIState]] = []
+
+    def capture_passthrough(*, args: list[str], state: CLIState) -> None:
+        calls.append((args, state))
+
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_plugin_passthrough",
+        capture_passthrough,
+    )
+    plugin_module.doctor_plugins(None, runtime="auto")
+    assert calls == [(["doctor"], state)]
 
 
 def test_plugin_list_empty(runner: CliRunner, machine_env: dict[str, str]) -> None:
@@ -192,7 +348,7 @@ def test_plugin_install_local_path_ignores_stack_runtime(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Local path installs should stay on the host even when stack runtime is selected."""
+    """Local path installs should remain on host even if stack runtime selected."""
     fixture_path = _copy_fixture(tmp_path, "node_plugin")
     stack_dir = tmp_path / "stack"
     stack_dir.mkdir(exist_ok=True)

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+import typer
+from rich.console import Console
+from typer.testing import CliRunner
+from orcheo.plugins import PluginImpactSummary
+from orcheo_sdk.cli import plugin as plugin_module
+
+
+class DummyState:
+    def __init__(self, human: bool) -> None:
+        self.human = human
+        self.console = Console(record=True)
+
+
+def test_resolve_stack_project_dir_prefers_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stack_dir = tmp_path / "stack"
+    monkeypatch.setenv("ORCHEO_STACK_DIR", str(stack_dir))
+    assert plugin_module._resolve_stack_project_dir() == stack_dir
+
+
+def test_resolve_stack_project_dir_defaults_to_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("ORCHEO_STACK_DIR", raising=False)
+    monkeypatch.setattr(plugin_module.Path, "home", staticmethod(lambda: tmp_path))
+    assert plugin_module._resolve_stack_project_dir() == tmp_path / ".orcheo" / "stack"
+
+
+def test_stack_compose_base_args_requires_compose_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    monkeypatch.setenv("ORCHEO_STACK_DIR", str(stack_dir))
+    with pytest.raises(typer.BadParameter):
+        plugin_module._stack_compose_base_args()
+
+
+def test_stack_compose_base_args_returns_args(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setenv("ORCHEO_STACK_DIR", str(stack_dir))
+    assert plugin_module._stack_compose_base_args() == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+    ]
+
+
+def test_normalize_runtime_invalid() -> None:
+    with pytest.raises(typer.BadParameter):
+        plugin_module._normalize_runtime("invalid")
+
+
+def test_use_stack_runtime_variants(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr(plugin_module, "_resolve_stack_project_dir", lambda: stack_dir)
+    assert plugin_module._use_stack_runtime("local") is False
+    assert plugin_module._use_stack_runtime("stack") is True
+    assert plugin_module._use_stack_runtime("auto") is True
+
+
+def test_run_stack_subprocess_requires_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_module.shutil, "which", lambda _: None)
+    with pytest.raises(typer.BadParameter):
+        plugin_module._run_stack_subprocess(["echo"])
+
+
+def test_run_stack_subprocess_handles_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(plugin_module.shutil, "which", lambda _: "/usr/bin/docker")
+
+    def fake_run(
+        command: list[str], *, check: bool, capture_output: bool, text: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 2, stdout="output", stderr="oops")
+
+    monkeypatch.setattr(plugin_module.subprocess, "run", fake_run)
+    with pytest.raises(typer.BadParameter) as excinfo:
+        plugin_module._run_stack_subprocess(["cmd"])
+    assert "oops" in str(excinfo.value)
+
+
+def test_stack_plugin_command_exec_and_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_args = ["docker", "compose", "-f", "compose", "--project-directory", "stack"]
+    monkeypatch.setattr(plugin_module, "_stack_compose_base_args", lambda: base_args)
+    monkeypatch.setattr(plugin_module, "_running_stack_services", lambda: {"backend"})
+    exec_command = plugin_module._stack_plugin_command(args=["list"], human=True)
+    assert "exec" in exec_command
+    monkeypatch.setattr(plugin_module, "_running_stack_services", lambda: set())
+    run_command = plugin_module._stack_plugin_command(args=["list"], human=False)
+    assert "run" in run_command
+
+
+def test_run_stack_plugin_passthrough_emits_output_and_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        plugin_module, "_stack_plugin_command", lambda *, args, human: ["cmd"]
+    )
+
+    def fake_run(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_run)
+    echoed: list[str] = []
+
+    def fake_echo(message: str) -> None:
+        echoed.append(message)
+
+    monkeypatch.setattr(plugin_module.typer, "echo", fake_echo)
+    state = DummyState(human=False)
+    plugin_module._run_stack_plugin_passthrough(args=["list"], state=state)
+    assert echoed == ["ok"]
+
+
+def test_run_stack_plugin_passthrough_doctor_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        plugin_module, "_stack_plugin_command", lambda *, args, human: ["cmd"]
+    )
+
+    def fake_run(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_run)
+    with pytest.raises(typer.Exit):
+        plugin_module._run_stack_plugin_passthrough(
+            args=["doctor"], state=DummyState(human=False)
+        )
+
+
+def test_is_local_plugin_ref_detects_variants(tmp_path: Path) -> None:
+    file_path = tmp_path / "plugin.txt"
+    file_path.write_text("x", encoding="utf-8")
+    assert plugin_module._is_local_plugin_ref(str(file_path))
+    assert plugin_module._is_local_plugin_ref("./cli")
+    assert plugin_module._is_local_plugin_ref("plugin.whl")
+    assert plugin_module._is_local_plugin_ref("group/plugin")
+
+
+def test_run_stack_plugin_json_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        plugin_module, "_stack_plugin_command", lambda *, args, human: ["cmd"]
+    )
+
+    def fake_run(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command, 0, stdout='{"ok": true}\n', stderr=""
+        )
+
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_run)
+    assert plugin_module._run_stack_plugin_json(["install"]) == {"ok": True}
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_subprocess",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            [], 0, stdout="", stderr=""
+        ),
+    )
+    assert plugin_module._run_stack_plugin_json(["install"]) is None
+
+
+def test_restart_running_stack_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_module, "_running_stack_services", lambda: set())
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_subprocess", lambda *args, **kwargs: None
+    )
+    plugin_module._restart_running_stack_services(DummyState(human=False))
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], *, expected_exit_codes: set[int] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    services = {"backend", "worker"}
+    monkeypatch.setattr(plugin_module, "_running_stack_services", lambda: services)
+    monkeypatch.setattr(plugin_module, "_stack_compose_base_args", lambda: ["docker"])
+    monkeypatch.setattr(plugin_module, "_run_stack_subprocess", fake_run)
+    state = DummyState(human=True)
+    plugin_module._restart_running_stack_services(state)
+    assert calls
+    assert "Restarted stack services" in state.console.export_text()
+
+
+def test_payload_requires_restart_checks_types() -> None:
+    assert not plugin_module._payload_requires_restart("nope")
+    assert plugin_module._payload_requires_restart(
+        {"impact": {"restart_required": True}}
+    )
+
+
+def test_impact_to_dict_and_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    impact = PluginImpactSummary(
+        change_type="install",
+        affected_component_kinds=["nodes"],
+        affected_component_ids=["node"],
+        activation_mode="silent",
+        prompt_required=False,
+        restart_required=True,
+    )
+    summary = plugin_module._impact_to_dict(impact)
+    assert summary["restart_required"] is True
+    printed: list[dict[str, object]] = []
+
+    def fake_render(console: Console, payload: dict[str, object], title: str) -> None:
+        printed.append(payload)
+
+    monkeypatch.setattr(plugin_module, "render_json", fake_render)
+    state = DummyState(human=True)
+    plugin_module._render_impact(state, impact)
+    assert printed
+
+
+def test_maybe_confirm_handles_human_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
+    impact = SimpleNamespace(prompt_required=True)
+    state = DummyState(human=True)
+    monkeypatch.setattr(
+        plugin_module.typer, "confirm", lambda prompt, default=False: False
+    )
+    with pytest.raises(typer.Exit):
+        plugin_module._maybe_confirm(
+            impact=impact,
+            prompt_text="ok?",
+            state=state,
+            force=False,
+        )
+    monkeypatch.setattr(
+        plugin_module.typer, "confirm", lambda prompt, default=False: True
+    )
+    plugin_module._maybe_confirm(
+        impact=impact,
+        prompt_text="ok?",
+        state=state,
+        force=False,
+    )
+    plugin_module._maybe_confirm(
+        impact=SimpleNamespace(prompt_required=True),
+        prompt_text="ok?",
+        state=state,
+        force=True,
+    )
+
+
+def test_list_command_uses_stack_passthrough(
+    runner: CliRunner, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: DummyState(human=True))
+    recorded: list[tuple[list[str], DummyState]] = []
+
+    def fake_passthrough(*, args: list[str], state: DummyState) -> None:
+        recorded.append((args, state))
+
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_plugin_passthrough", fake_passthrough
+    )
+    runner.invoke(plugin_module.plugin_app, ["list"], env=env)
+    assert recorded and recorded[0][0] == ["list"]
+
+
+def test_show_command_uses_stack_passthrough(
+    runner: CliRunner, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: DummyState(human=True))
+    recorded: list[tuple[list[str], DummyState]] = []
+
+    def fake_passthrough(*, args: list[str], state: DummyState) -> None:
+        recorded.append((args, state))
+
+    monkeypatch.setattr(
+        plugin_module, "_run_stack_plugin_passthrough", fake_passthrough
+    )
+    runner.invoke(plugin_module.plugin_app, ["show", "ore"], env=env)
+    assert recorded and recorded[0][0] == ["show", "ore"]
+
+
+def test_install_command_stack_path_renders_human_output(
+    runner: CliRunner, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: DummyState(human=True))
+    monkeypatch.setattr(plugin_module, "_is_local_plugin_ref", lambda ref: False)
+    payload = {
+        "plugin": {"name": "pkg"},
+        "impact": {
+            "change_type": "install",
+            "affected_component_kinds": ["nodes"],
+            "affected_component_ids": ["node"],
+            "activation_mode": "silent",
+            "prompt_required": False,
+            "restart_required": True,
+        },
+    }
+    monkeypatch.setattr(plugin_module, "_run_stack_plugin_json", lambda args: payload)
+    monkeypatch.setattr(
+        plugin_module, "_restart_running_stack_services", lambda state: None
+    )
+    renders: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        plugin_module, "render_json", lambda console, data, title: renders.append(data)
+    )
+    impacts: list[PluginImpactSummary] = []
+    monkeypatch.setattr(
+        plugin_module, "_render_impact", lambda state, impact: impacts.append(impact)
+    )
+    runner.invoke(plugin_module.plugin_app, ["install", "pkg"], env=env)
+    assert renders
+    assert impacts

--- a/tests/sdk/test_cli_stack.py
+++ b/tests/sdk/test_cli_stack.py
@@ -27,7 +27,7 @@ def test_stack_logs_shortcut_runs_compose_logs_follow(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     compose_file = stack_dir / "docker-compose.yml"
     compose_file.write_text("services: {}\n", encoding="utf-8")
 
@@ -67,7 +67,7 @@ def test_stack_start_shortcut_runs_compose_up_detached(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     compose_file = stack_dir / "docker-compose.yml"
     compose_file.write_text("services: {}\n", encoding="utf-8")
 
@@ -107,7 +107,7 @@ def test_stack_logs_treats_sigint_exit_as_success(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     compose_file = stack_dir / "docker-compose.yml"
     compose_file.write_text("services: {}\n", encoding="utf-8")
 
@@ -147,7 +147,7 @@ def test_stack_rejects_multiple_actions(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
     called = {"value": False}
@@ -176,7 +176,7 @@ def test_stack_requires_existing_compose_file(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
     called = {"value": False}
     monkeypatch.setattr(
@@ -204,7 +204,7 @@ def test_stack_requires_docker_binary(
     tmp_path: Path,
 ) -> None:
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: None)
     called = {"value": False}
@@ -278,7 +278,7 @@ def test_stack_no_action_raises_error(
 ) -> None:
     """Invoking stack without any action flag shows an error."""
     stack_dir = tmp_path / "stack"
-    stack_dir.mkdir()
+    stack_dir.mkdir(exist_ok=True)
     (stack_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     monkeypatch.setattr("orcheo_sdk.cli.main.shutil.which", lambda _: "/usr/bin/docker")
 

--- a/tests/test_listener_supervisor.py
+++ b/tests/test_listener_supervisor.py
@@ -75,9 +75,7 @@ async def test_listener_supervisor_claims_and_releases_subscriptions() -> None:
 
 
 @pytest.mark.asyncio()
-async def test_listener_supervisor_blocks_missing_credentials_without_retrying() -> (
-    None
-):
+async def test_listener_supervisor_retries_blocked_listeners_and_recovers() -> None:
     repository = InMemoryWorkflowRepository()
     workflow = await repository.create_workflow(
         name="Supervisor Failure Flow",
@@ -128,10 +126,11 @@ async def test_listener_supervisor_blocks_missing_credentials_without_retrying()
     assert subscription.assigned_runtime is None
 
     await supervisor.run_once()
-    claimed = await repository.get_listener_subscription(subscription.id)
-    assert claimed.status == ListenerSubscriptionStatus.BLOCKED
-    assert claimed.assigned_runtime is None
-    assert attempts == 1
+    recovered = await repository.get_listener_subscription(subscription.id)
+    assert recovered.status == ListenerSubscriptionStatus.ACTIVE
+    assert recovered.assigned_runtime == "runtime-1"
+    assert recovered.last_error is None
+    assert attempts == 2
 
     await supervisor.shutdown()
 


### PR DESCRIPTION
## Summary

This PR tightens the plugin workflow across the stack and improves the Canvas experience for plugin-backed templates.

- Add stack-aware `orcheo plugin` commands with `--runtime auto|local|stack`, so `list`, `show`, `install`, and `doctor` can run against the local stack backend instead of only the host environment.
- Restart running stack services automatically after plugin installs when the reported plugin impact requires a restart, and add `git` to the stack image so Git-based plugin installs work inside the container.
- Update plugin docs and release docs to use Git-based listener plugin install examples.

- Add backend plugin inventory support via `/api/system/plugins`, exposing both installed/enabled state and whether each plugin is actually loaded in the current backend process.
- Validate template plugin requirements on both sides:
  - Canvas now checks required plugins before creating a workflow from a template.
  - Backend ingest now rejects template imports when required plugins are not available in the active runtime.
- Extend template metadata/version metadata to carry `requiredPlugins` and `templateId`.

- Improve template rendering in Canvas by reusing template Mermaid previews for template-derived workflows, normalizing the Mermaid palette, forcing consistent left-to-right layout, and rendering thumbnails/diagrams with transparent SVG backgrounds.
- Improve workflow UX in Canvas with:
  - delete confirmation dialogs from both the gallery and the workflow view
  - a loading state for the workflow gallery while storage is being fetched
  - better credential secret copy feedback with explicit success/error states

- Harden backend/runtime behavior by:
  - recovering blocked listener subscriptions automatically once credentials become available again
  - serializing Postgres schema initialization with an advisory lock
  - avoiding unnecessary workflow backfill updates when migration columns already exist

## Coverage added

- Added backend tests for plugin inventory reporting, template ingest plugin validation, listener recovery, and Postgres initialization locking/migration behavior.
- Added SDK tests for stack-targeted plugin installs and service restarts.
- Added Canvas tests for plugin availability fetches, template creation guards, workflow delete confirmation, gallery loading state, Mermaid palette normalization, and template-based thumbnail rendering.
