### PR TITLE
Fix stack plugin installs for remote Git refs

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -54,6 +55,8 @@ RuntimeOption = Annotated[
 ]
 
 _STACK_RUNTIME_SERVICES = ("backend", "worker", "celery-beat")
+_REMOTE_PLUGIN_REF_PATTERN = re.compile(r"^(?:git\+)?[A-Za-z][A-Za-z0-9+.-]*://")
+_GIT_SCP_PLUGIN_REF_PATTERN = re.compile(r"^[^/\\\\]+@[^:]+:.+")
 
 
 def _state(ctx: typer.Context) -> CLIState:
@@ -186,14 +189,21 @@ def _run_stack_plugin_passthrough(*, args: list[str], state: CLIState) -> None:
 
 
 def _is_local_plugin_ref(ref: str) -> bool:
-    candidate = Path(ref).expanduser()
+    stripped = ref.strip()
+    if _REMOTE_PLUGIN_REF_PATTERN.match(stripped) and not stripped.startswith(
+        "file://"
+    ):
+        return False
+    if _GIT_SCP_PLUGIN_REF_PATTERN.match(stripped):
+        return False
+    candidate = Path(stripped).expanduser()
     if candidate.exists():
         return True
-    if ref.startswith(("./", "../", "~/")):
+    if stripped.startswith(("./", "../", "~/")) or candidate.is_absolute():
         return True
     if candidate.suffix == ".whl":
         return True
-    return "/" in ref or "\\" in ref
+    return "/" in stripped or "\\" in stripped
 
 
 def _run_stack_plugin_json(args: list[str]) -> Any:

--- a/tests/sdk/test_cli_plugin.py
+++ b/tests/sdk/test_cli_plugin.py
@@ -342,6 +342,88 @@ def test_plugin_install_targets_stack_and_restarts_running_services(
     ]
 
 
+def test_plugin_install_git_ref_targets_stack_runtime(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Git refs should install into the stack when stack runtime is requested."""
+    stack_dir = tmp_path / "stack"
+    compose_file = stack_dir / "docker-compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    git_ref = "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"
+    executed: list[list[str]] = []
+    responses = iter(
+        [
+            subprocess.CompletedProcess(["docker"], 0, stdout="backend\n"),
+            subprocess.CompletedProcess(
+                ["docker"],
+                0,
+                stdout=json.dumps(
+                    {
+                        "plugin": {"name": "orcheo-plugin-wecom-listener"},
+                        "impact": {
+                            "change_type": "install",
+                            "affected_component_kinds": ["listeners"],
+                            "affected_component_ids": ["wecom"],
+                            "activation_mode": "restart_required",
+                            "prompt_required": False,
+                            "restart_required": True,
+                        },
+                    }
+                ),
+            ),
+            subprocess.CompletedProcess(["docker"], 0, stdout="backend\n"),
+            subprocess.CompletedProcess(["docker"], 0, stdout=""),
+        ]
+    )
+
+    def _run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture_output, text
+        executed.append(command)
+        return next(responses)
+
+    monkeypatch.setattr("orcheo_sdk.cli.plugin.subprocess.run", _run)
+    monkeypatch.setattr(
+        "orcheo_sdk.cli.plugin.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    result = runner.invoke(
+        app,
+        ["plugin", "install", "--runtime", "stack", git_ref],
+        env=_stack_env(machine_env, stack_dir),
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["plugin"]["name"] == "orcheo-plugin-wecom-listener"
+    assert executed[1] == [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "--project-directory",
+        str(stack_dir),
+        "exec",
+        "-T",
+        "backend",
+        "orcheo",
+        "plugin",
+        "install",
+        git_ref,
+        "--runtime",
+        "local",
+    ]
+
+
 def test_plugin_install_local_path_ignores_stack_runtime(
     runner: CliRunner,
     machine_env: dict[str, str],

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -163,6 +163,9 @@ def test_is_local_plugin_ref_detects_variants(tmp_path: Path) -> None:
     assert not plugin_module._is_local_plugin_ref(
         "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"
     )
+    assert not plugin_module._is_local_plugin_ref(
+        "git@github.com:ShaojieJiang/orcheo-plugin-wecom-listener.git"
+    )
 
 
 def test_run_stack_plugin_json_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -160,6 +160,9 @@ def test_is_local_plugin_ref_detects_variants(tmp_path: Path) -> None:
     assert plugin_module._is_local_plugin_ref("./cli")
     assert plugin_module._is_local_plugin_ref("plugin.whl")
     assert plugin_module._is_local_plugin_ref("group/plugin")
+    assert not plugin_module._is_local_plugin_ref(
+        "git+https://github.com/ShaojieJiang/orcheo-plugin-wecom-listener.git"
+    )
 
 
 def test_run_stack_plugin_json_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- treat remote plugin refs such as `git+https://...` and SCP-style Git URLs as non-local so `--runtime stack` installs into the stack backend
- keep local filesystem paths and wheel refs on the host runtime
- add SDK CLI regression coverage for remote ref classification and stack-targeted Git installs

## Testing
- `make format`
- `uv run pytest tests/sdk/test_cli_plugin.py tests/sdk/test_cli_plugin_helpers.py -q`
- `make lint`