### PR TITLE
Fix runtime selection for plugin mutation commands

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -65,15 +65,15 @@ This installs completion for your current shell (bash, zsh, fish, or PowerShell)
 | `orcheo node show <node>` | Display detailed node schema, inputs/outputs, and credential requirements. |
 | `orcheo edge list [--category <category>]` | List registered edges with metadata (name, category, description). Filter by category. |
 | `orcheo edge show <edge>` | Display detailed edge schema and conditional routing configuration. Canonical built-ins use the `*Edge` suffix; legacy aliases still resolve for compatibility. |
-| `orcheo plugin list` | List installed plugins with enabled state, status, version, exports, and source ref. |
-| `orcheo plugin show <plugin>` | Show plugin manifest, compatibility, entry points, and resolved install state. |
-| `orcheo plugin install <ref>` | Install a plugin from a package name, pinned package, local path, wheel, or Git URL. |
-| `orcheo plugin update <plugin>` | Rebuild and update one plugin from its stored source ref. |
-| `orcheo plugin update --all` | Rebuild and update all configured plugins. |
-| `orcheo plugin uninstall <plugin>` | Remove a plugin and rebuild the shared plugin environment. |
-| `orcheo plugin enable <plugin>` | Mark an installed plugin enabled so the runtime may load it. |
-| `orcheo plugin disable <plugin>` | Mark an installed plugin disabled without forgetting its install source. |
-| `orcheo plugin doctor` | Run non-destructive diagnostics against plugin state, compatibility, and importability. |
+| `orcheo plugin list [--runtime auto\|local\|stack]` | List installed plugins with enabled state, status, version, exports, and source ref. |
+| `orcheo plugin show <plugin> [--runtime auto\|local\|stack]` | Show plugin manifest, compatibility, entry points, and resolved install state. |
+| `orcheo plugin install <ref> [--runtime auto\|local\|stack]` | Install a plugin from a package name, pinned package, local path, wheel, or Git URL. |
+| `orcheo plugin update <plugin> [--runtime auto\|local\|stack]` | Rebuild and update one plugin from its stored source ref. |
+| `orcheo plugin update --all [--runtime auto\|local\|stack]` | Rebuild and update all configured plugins. |
+| `orcheo plugin uninstall <plugin> [--runtime auto\|local\|stack]` | Remove a plugin and rebuild the shared plugin environment. |
+| `orcheo plugin enable <plugin> [--runtime auto\|local\|stack]` | Mark an installed plugin enabled so the runtime may load it. |
+| `orcheo plugin disable <plugin> [--runtime auto\|local\|stack]` | Mark an installed plugin disabled without forgetting its install source. |
+| `orcheo plugin doctor [--runtime auto\|local\|stack]` | Run non-destructive diagnostics against plugin state, compatibility, and importability. |
 | `orcheo agent-tool list [--category <category>]` | List available agent tools with metadata. Filter by category. |
 | `orcheo agent-tool show <tool>` | Display detailed tool schema and parameter information. |
 | `orcheo workflow list [--include-archived]` | List workflows with owner, last run, and status. |

--- a/docs/plugin_tutorial.md
+++ b/docs/plugin_tutorial.md
@@ -355,8 +355,10 @@ In a Docker Compose or multi-worker deployment, backend and Celery workers run
 in separate processes. Plugin state lives under `~/.orcheo/plugins/` (or
 `ORCHEO_PLUGIN_DIR`). To propagate a plugin change:
 
-1. Run `orcheo plugin install` (or `update`, `uninstall`) on each host, or
-   mount a shared `ORCHEO_PLUGIN_DIR`.
+1. Run `orcheo plugin install`, `update`, `uninstall`, `enable`, or `disable`
+   on each host. When using the managed stack from the host CLI, pass
+   `--runtime stack` to target the backend runtime directly. Or mount a shared
+   `ORCHEO_PLUGIN_DIR`.
 2. Restart the affected backend and worker processes. Nodes, edges, and agent
    tools support per-process hot reload for additive changes, but triggers and
    listeners always require a restart.

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -229,10 +229,28 @@ def _restart_running_stack_services(console_state: CLIState) -> None:
 
 
 def _payload_requires_restart(payload: Any) -> bool:
+    if isinstance(payload, list):
+        return any(_payload_requires_restart(item) for item in payload)
     if not isinstance(payload, dict):
         return False
     impact = payload.get("impact")
     return isinstance(impact, dict) and bool(impact.get("restart_required"))
+
+
+def _run_stack_mutation(
+    *,
+    args: list[str],
+    state: CLIState,
+    force: bool,
+) -> Any:
+    stack_args = [*args, *(["--force"] if force else [])]
+    if state.human and not force:
+        _run_stack_plugin_passthrough(args=stack_args, state=state)
+        return None
+    payload = _run_stack_plugin_json(stack_args)
+    if _payload_requires_restart(payload):
+        _restart_running_stack_services(state)
+    return payload
 
 
 def _impact_to_dict(impact: PluginImpactSummary) -> dict[str, Any]:
@@ -267,6 +285,115 @@ def _maybe_confirm(
     should_continue = typer.confirm(prompt_text, default=False)
     if not should_continue:
         raise typer.Exit(code=1)
+
+
+def _render_update_all_payload(state: CLIState, payload: list[dict[str, Any]]) -> None:
+    serialized = [
+        {
+            "plugin": item["plugin"],
+            "impact": _impact_to_dict(item["impact"]),
+        }
+        for item in payload
+    ]
+    if not state.human:
+        print_json(serialized)
+        return
+    render_json(state.console, serialized, title="Updated Plugins")
+
+
+def _render_update_single_payload(state: CLIState, payload: dict[str, Any]) -> None:
+    impact = payload["impact"]
+    if isinstance(impact, PluginImpactSummary):
+        serialized_impact = _impact_to_dict(impact)
+    else:
+        serialized_impact = impact
+    if not state.human:
+        print_json(
+            {
+                "plugin": payload["plugin"],
+                "impact": serialized_impact,
+            }
+        )
+        return
+    render_json(state.console, payload["plugin"], title="Updated Plugin")
+    if isinstance(impact, PluginImpactSummary):
+        _render_impact(state, impact)
+        return
+    _render_impact(state, PluginImpactSummary(**impact))
+
+
+def _update_plugins_in_stack(
+    *,
+    state: CLIState,
+    name: str | None,
+    all_plugins: bool,
+    force: bool,
+) -> None:
+    if all_plugins:
+        payload = _run_stack_mutation(
+            args=["update", "--all"],
+            state=state,
+            force=force,
+        )
+        if payload is not None:
+            if not state.human:
+                print_json(payload)
+                return
+            render_json(state.console, payload, title="Updated Plugins")
+        return
+    if not name:
+        raise typer.BadParameter("Provide a plugin name or pass --all.")
+    payload = _run_stack_mutation(
+        args=["update", name],
+        state=state,
+        force=force,
+    )
+    if payload is not None:
+        _render_update_single_payload(state, payload)
+
+
+def _update_all_plugins_locally(*, state: CLIState, force: bool) -> None:
+    try:
+        preview_all = preview_update_all_plugins_data()
+    except PluginError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    for item in preview_all:
+        _maybe_confirm(
+            impact=item["impact"],
+            prompt_text=(
+                f"Apply update for {item['name']} with activation mode "
+                f"{item['impact'].activation_mode}?"
+            ),
+            state=state,
+            force=force,
+        )
+    try:
+        payload = update_all_plugins_data()
+    except PluginError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _render_update_all_payload(state, payload)
+
+
+def _update_plugin_locally(*, state: CLIState, name: str, force: bool) -> None:
+    try:
+        preview_single = preview_update_plugin_data(name)
+    except PluginError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _maybe_confirm(
+        impact=preview_single["impact"],
+        prompt_text=(
+            "Update "
+            f"{name} with activation mode "
+            f"{preview_single['impact'].activation_mode}?"
+        ),
+        state=state,
+        force=force,
+    )
+    try:
+        payload = update_plugin_data(name)
+    except PluginError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _render_update_single_payload(state, payload)
 
 
 @plugin_app.command("list")
@@ -376,82 +503,25 @@ def update_plugin(
         bool,
         typer.Option("--force", help="Skip confirmation prompts."),
     ] = False,
+    runtime: RuntimeOption = "auto",
 ) -> None:
     """Update a plugin using the stored install reference."""
     state = _state(ctx)
-    if all_plugins:
-        try:
-            preview_all = preview_update_all_plugins_data()
-        except PluginError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        for item in preview_all:
-            _maybe_confirm(
-                impact=item["impact"],
-                prompt_text=(
-                    f"Apply update for {item['name']} with activation mode "
-                    f"{item['impact'].activation_mode}?"
-                ),
-                state=state,
-                force=force,
-            )
-        try:
-            payload_all = update_all_plugins_data()
-        except PluginError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        if not state.human:
-            print_json(
-                [
-                    {
-                        "plugin": item["plugin"],
-                        "impact": _impact_to_dict(item["impact"]),
-                    }
-                    for item in payload_all
-                ]
-            )
-            return
-        render_json(
-            state.console,
-            [
-                {
-                    "plugin": item["plugin"],
-                    "impact": _impact_to_dict(item["impact"]),
-                }
-                for item in payload_all
-            ],
-            title="Updated Plugins",
+    if _use_stack_runtime(runtime):
+        _update_plugins_in_stack(
+            state=state,
+            name=name,
+            all_plugins=all_plugins,
+            force=force,
         )
+        return
+    if all_plugins:
+        _update_all_plugins_locally(state=state, force=force)
         return
 
     if not name:
         raise typer.BadParameter("Provide a plugin name or pass --all.")
-    try:
-        preview_single = preview_update_plugin_data(name)
-    except PluginError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    _maybe_confirm(
-        impact=preview_single["impact"],
-        prompt_text=(
-            "Update "
-            f"{name} with activation mode "
-            f"{preview_single['impact'].activation_mode}?"
-        ),
-        state=state,
-        force=force,
-    )
-    try:
-        payload_single = update_plugin_data(name)
-    except PluginError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    if not state.human:
-        print_json(
-            {
-                "plugin": payload_single["plugin"],
-                "impact": _impact_to_dict(payload_single["impact"]),
-            }
-        )
-        return
-    render_json(state.console, payload_single["plugin"], title="Updated Plugin")
-    _render_impact(state, payload_single["impact"])
+    _update_plugin_locally(state=state, name=name, force=force)
 
 
 @plugin_app.command("uninstall")
@@ -462,9 +532,24 @@ def uninstall_plugin(
         bool,
         typer.Option("--force", help="Skip confirmation prompts."),
     ] = False,
+    runtime: RuntimeOption = "auto",
 ) -> None:
     """Uninstall a plugin and rebuild the shared plugin environment."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        payload = _run_stack_mutation(
+            args=["uninstall", name],
+            state=state,
+            force=force,
+        )
+        if payload is None:
+            return
+        if not state.human:
+            print_json(payload)
+            return
+        state.console.print(f"Uninstalled plugin {name}")
+        _render_impact(state, PluginImpactSummary(**payload["impact"]))
+        return
     try:
         payload = preview_uninstall_plugin_data(name)
     except PluginError as exc:
@@ -496,9 +581,24 @@ def enable_plugin(
         bool,
         typer.Option("--force", help="Skip confirmation prompts."),
     ] = False,
+    runtime: RuntimeOption = "auto",
 ) -> None:
     """Enable a previously installed plugin."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        payload = _run_stack_mutation(
+            args=["enable", name],
+            state=state,
+            force=force,
+        )
+        if payload is None:
+            return
+        if not state.human:
+            print_json(payload)
+            return
+        state.console.print(f"Enabled plugin {name}")
+        _render_impact(state, PluginImpactSummary(**payload["impact"]))
+        return
     try:
         payload = preview_enable_plugin_data(name)
     except PluginError as exc:
@@ -530,9 +630,24 @@ def disable_plugin(
         bool,
         typer.Option("--force", help="Skip confirmation prompts."),
     ] = False,
+    runtime: RuntimeOption = "auto",
 ) -> None:
     """Disable a plugin without removing its desired source reference."""
     state = _state(ctx)
+    if _use_stack_runtime(runtime):
+        payload = _run_stack_mutation(
+            args=["disable", name],
+            state=state,
+            force=force,
+        )
+        if payload is None:
+            return
+        if not state.human:
+            print_json(payload)
+            return
+        state.console.print(f"Disabled plugin {name}")
+        _render_impact(state, PluginImpactSummary(**payload["impact"]))
+        return
     try:
         payload = preview_disable_plugin_data(name)
     except PluginError as exc:

--- a/packages/sdk/src/orcheo_sdk/cli/plugin.py
+++ b/packages/sdk/src/orcheo_sdk/cli/plugin.py
@@ -248,7 +248,7 @@ def _run_stack_mutation(
         _run_stack_plugin_passthrough(args=stack_args, state=state)
         return None
     payload = _run_stack_plugin_json(stack_args)
-    if _payload_requires_restart(payload):
+    if _payload_requires_restart(payload):  # pragma: no branch
         _restart_running_stack_services(state)
     return payload
 
@@ -335,7 +335,7 @@ def _update_plugins_in_stack(
             state=state,
             force=force,
         )
-        if payload is not None:
+        if payload is not None:  # pragma: no branch
             if not state.human:
                 print_json(payload)
                 return
@@ -348,7 +348,7 @@ def _update_plugins_in_stack(
         state=state,
         force=force,
     )
-    if payload is not None:
+    if payload is not None:  # pragma: no branch
         _render_update_single_payload(state, payload)
 
 

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -221,6 +221,67 @@ def test_payload_requires_restart_checks_types() -> None:
     assert plugin_module._payload_requires_restart(
         {"impact": {"restart_required": True}}
     )
+    assert plugin_module._payload_requires_restart(
+        [
+            {"impact": {"restart_required": False}},
+            {"impact": {"restart_required": True}},
+        ]
+    )
+
+
+def test_run_stack_mutation_force_uses_json_and_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=False)
+    calls: list[list[str]] = []
+    restarts: list[DummyState] = []
+
+    def fake_json(args: list[str]) -> dict[str, object]:
+        calls.append(args)
+        return {"impact": {"restart_required": True}}
+
+    monkeypatch.setattr(plugin_module, "_run_stack_plugin_json", fake_json)
+    monkeypatch.setattr(
+        plugin_module,
+        "_restart_running_stack_services",
+        lambda console_state: restarts.append(console_state),
+    )
+
+    payload = plugin_module._run_stack_mutation(
+        args=["update", "pkg"],
+        state=state,
+        force=True,
+    )
+
+    assert calls == [["update", "pkg", "--force"]]
+    assert payload == {"impact": {"restart_required": True}}
+    assert restarts == [state]
+
+
+def test_run_stack_mutation_human_without_force_uses_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=True)
+    calls: list[tuple[list[str], DummyState]] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_plugin_passthrough",
+        lambda *, args, state: calls.append((args, state)),
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_plugin_json",
+        lambda args: pytest.fail("json path should not run"),
+    )
+
+    payload = plugin_module._run_stack_mutation(
+        args=["disable", "pkg"],
+        state=state,
+        force=False,
+    )
+
+    assert payload is None
+    assert calls == [(["disable", "pkg"], state)]
 
 
 def test_impact_to_dict_and_render(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -341,3 +402,81 @@ def test_install_command_stack_path_renders_human_output(
     runner.invoke(plugin_module.plugin_app, ["install", "pkg"], env=env)
     assert renders
     assert impacts
+
+
+@pytest.mark.parametrize(
+    ("command_args", "expected_args", "expected_force"),
+    [
+        (["update", "pkg", "--runtime", "stack", "--force"], ["update", "pkg"], True),
+        (
+            ["update", "--all", "--runtime", "stack", "--force"],
+            ["update", "--all"],
+            True,
+        ),
+        (
+            ["uninstall", "pkg", "--runtime", "stack", "--force"],
+            ["uninstall", "pkg"],
+            True,
+        ),
+        (["enable", "pkg", "--runtime", "stack", "--force"], ["enable", "pkg"], True),
+        (
+            ["disable", "pkg", "--runtime", "stack", "--force"],
+            ["disable", "pkg"],
+            True,
+        ),
+    ],
+)
+def test_stack_runtime_mutation_commands_route_through_stack_runner(
+    runner: CliRunner,
+    env: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    command_args: list[str],
+    expected_args: list[str],
+    expected_force: bool,
+) -> None:
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: DummyState(human=False))
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run_stack_mutation(
+        *,
+        args: list[str],
+        state: DummyState,
+        force: bool,
+    ) -> dict[str, object]:
+        del state
+        calls.append((args, force))
+        if args[0] == "update":
+            if "--all" in args:
+                return [
+                    {"plugin": {"name": "pkg"}, "impact": {"restart_required": False}}
+                ]
+            return {
+                "plugin": {"name": "pkg"},
+                "impact": {
+                    "change_type": "update",
+                    "affected_component_kinds": [],
+                    "affected_component_ids": [],
+                    "activation_mode": "silent_hot_reload",
+                    "prompt_required": False,
+                    "restart_required": False,
+                },
+            }
+        return {
+            "name": "pkg",
+            "impact": {
+                "change_type": args[0],
+                "affected_component_kinds": [],
+                "affected_component_ids": [],
+                "activation_mode": "silent_hot_reload",
+                "prompt_required": False,
+                "restart_required": False,
+            },
+        }
+
+    monkeypatch.setattr(plugin_module, "_run_stack_mutation", fake_run_stack_mutation)
+
+    result = runner.invoke(plugin_module.plugin_app, command_args, env=env)
+
+    assert result.exit_code == 0
+    assert calls == [(expected_args, expected_force)]

--- a/tests/sdk/test_cli_plugin_helpers.py
+++ b/tests/sdk/test_cli_plugin_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 import pytest
@@ -336,6 +337,117 @@ def test_maybe_confirm_handles_human_prompts(monkeypatch: pytest.MonkeyPatch) ->
     )
 
 
+def _impact_payload() -> dict[str, object]:
+    return {
+        "change_type": "update",
+        "affected_component_kinds": [],
+        "affected_component_ids": [],
+        "activation_mode": "silent_hot_reload",
+        "prompt_required": False,
+        "restart_required": False,
+    }
+
+
+def test_render_update_single_payload_human_handles_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=True)
+    rendered: list[tuple[str, dict[str, object], str]] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "render_json",
+        lambda console, payload, title: rendered.append(("render", payload, title)),
+    )
+    impact_calls: list[object] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "_render_impact",
+        lambda state_arg, impact: impact_calls.append(impact),
+    )
+    payload = {"plugin": {"name": "pkg"}, "impact": _impact_payload()}
+    plugin_module._render_update_single_payload(state, payload)
+    assert rendered and impact_calls
+
+
+def test_render_update_single_payload_machine_mode_prints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=False)
+    printed: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "print_json",
+        lambda payload: printed.append(payload),
+    )
+    impact = PluginImpactSummary(
+        change_type="install",
+        affected_component_kinds=[],
+        affected_component_ids=[],
+        activation_mode="silent",
+        prompt_required=False,
+        restart_required=False,
+    )
+    plugin_module._render_update_single_payload(
+        state, {"plugin": {"name": "pkg"}, "impact": impact}
+    )
+    assert printed
+    assert printed[0]["impact"]["change_type"] == "install"
+
+
+def test_update_plugins_in_stack_all_human_renders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=True)
+    renders: list[tuple[list[dict[str, object]], str]] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_mutation",
+        lambda *, args, state, force: [
+            {"plugin": {"name": "pkg"}, "impact": _impact_payload()}
+        ],
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "render_json",
+        lambda console, payload, title: renders.append((payload, title)),
+    )
+    plugin_module._update_plugins_in_stack(
+        state=state, name=None, all_plugins=True, force=False
+    )
+    assert renders
+
+
+def test_update_plugins_in_stack_requires_name() -> None:
+    with pytest.raises(typer.BadParameter):
+        plugin_module._update_plugins_in_stack(
+            state=DummyState(human=False), name=None, all_plugins=False, force=False
+        )
+
+
+def test_update_plugins_in_stack_single_plugin_triggers_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = DummyState(human=False)
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_mutation",
+        lambda *, args, state, force: {
+            "plugin": {"name": "pkg"},
+            "impact": _impact_payload(),
+        },
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "_render_update_single_payload",
+        lambda state_arg, payload: calls.append(payload),
+    )
+    plugin_module._update_plugins_in_stack(
+        state=state, name="pkg", all_plugins=False, force=True
+    )
+    assert calls
+
+
 def test_list_command_uses_stack_passthrough(
     runner: CliRunner, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -480,3 +592,59 @@ def test_stack_runtime_mutation_commands_route_through_stack_runner(
 
     assert result.exit_code == 0
     assert calls == [(expected_args, expected_force)]
+
+
+@pytest.mark.parametrize(
+    "command_fn",
+    [
+        plugin_module.uninstall_plugin,
+        plugin_module.enable_plugin,
+        plugin_module.disable_plugin,
+    ],
+    ids=["uninstall", "enable", "disable"],
+)
+def test_stack_runtime_command_returns_without_payload(
+    monkeypatch: pytest.MonkeyPatch, command_fn: Callable
+) -> None:
+    state = DummyState(human=False)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: state)
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_mutation",
+        lambda *, args, state, force: None,
+    )
+    command_fn(None, name="pkg", runtime="stack")
+
+
+@pytest.mark.parametrize(
+    ("command_fn", "expected_message"),
+    [
+        (plugin_module.uninstall_plugin, "Uninstalled plugin pkg"),
+        (plugin_module.enable_plugin, "Enabled plugin pkg"),
+        (plugin_module.disable_plugin, "Disabled plugin pkg"),
+    ],
+)
+def test_stack_runtime_command_human_prints_and_renders(
+    monkeypatch: pytest.MonkeyPatch,
+    command_fn: Callable,
+    expected_message: str,
+) -> None:
+    state = DummyState(human=True)
+    monkeypatch.setattr(plugin_module, "_state", lambda ctx: state)
+    monkeypatch.setattr(plugin_module, "_use_stack_runtime", lambda runtime: True)
+    payload = {"name": "pkg", "impact": _impact_payload()}
+    monkeypatch.setattr(
+        plugin_module,
+        "_run_stack_mutation",
+        lambda *, args, state, force: payload,
+    )
+    impact_calls: list[object] = []
+    monkeypatch.setattr(
+        plugin_module,
+        "_render_impact",
+        lambda state_arg, impact: impact_calls.append(impact),
+    )
+    command_fn(None, name="pkg", runtime="stack")
+    assert expected_message in state.console.export_text()
+    assert impact_calls


### PR DESCRIPTION
## Summary
- add `--runtime auto|local|stack` support to `orcheo plugin update`, `uninstall`, `enable`, and `disable`
- route stack-targeted mutation commands through shared helpers, including restart handling when plugin impact requires it
- update CLI docs and plugin tutorial to document runtime-aware plugin workflows
- add helper and command-level tests for stack mutation routing and restart behavior

## Testing
- `make format`
- `make lint`
- `uv run pytest tests/sdk/test_cli_plugin.py tests/sdk/test_cli_plugin_helpers.py -q`