### PR TITLE
Add standard Lark tenant access token node

### DIFF
--- a/apps/canvas/src/features/workflow/data/templates/assets/wecom-lark-shared-listener/workflow.py
+++ b/apps/canvas/src/features/workflow/data/templates/assets/wecom-lark-shared-listener/workflow.py
@@ -4,8 +4,7 @@ from orcheo_plugin_wecom_listener import WeComListenerPluginNode, WeComWsReplyNo
 from orcheo.edges import Switch, SwitchCase
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode, AgentReplyExtractorNode
-from orcheo.nodes.data import HttpRequestNode
-from orcheo.nodes.lark import LarkSendMessageNode
+from orcheo.nodes.lark import LarkSendMessageNode, LarkTenantAccessTokenNode
 
 
 def orcheo_workflow() -> StateGraph:
@@ -57,16 +56,10 @@ def orcheo_workflow() -> StateGraph:
     )
     graph.add_node(
         "get_lark_tenant_token",
-        HttpRequestNode(  # TODO: make this a standard node in orcheo.nodes.lark
+        LarkTenantAccessTokenNode(
             name="get_lark_tenant_token",
-            method="POST",
-            url="https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal",
-            headers={"Content-Type": "application/json; charset=utf-8"},
-            json_body={
-                "app_id": "[[lark_app_id]]",
-                "app_secret": "[[lark_app_secret]]",
-            },
-            raise_for_status=True,
+            app_id="[[lark_app_id]]",
+            app_secret="[[lark_app_secret]]",
         ),
     )
     graph.add_node(

--- a/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
+++ b/apps/canvas/src/features/workflow/data/templates/wecom-lark-shared-listener.ts
@@ -40,7 +40,7 @@ export const WECOM_LARK_SHARED_LISTENER_WORKFLOW: Workflow = {
   description:
     "Uses plugin-provided WeCom and Lark listener nodes in one workflow, generates one shared AgentNode reply, and sends it through the matching channel branch.",
   createdAt: "2026-03-16T12:00:00Z",
-  updatedAt: "2026-03-16T12:00:00Z",
+  updatedAt: "2026-03-20T12:00:00Z",
   owner: TEMPLATE_OWNER,
   tags: ["template", "wecom", "lark", "listener", "plugin", "agent"],
   nodes: [
@@ -136,10 +136,11 @@ export const WECOM_LARK_SHARED_LISTENER_WORKFLOW: Workflow = {
       type: "utility",
       position: { x: 1300, y: 220 },
       data: {
-        label: "HttpRequestNode",
+        label: "LarkTenantAccessTokenNode",
         type: "utility",
-        backendType: "HttpRequestNode",
-        description: "Fetches a Lark tenant access token for the send branch.",
+        backendType: "LarkTenantAccessTokenNode",
+        description:
+          "Fetches a Lark tenant access token with the standard Lark auth node.",
       },
     },
     {
@@ -223,10 +224,10 @@ export const WECOM_LARK_SHARED_LISTENER_TEMPLATE: WorkflowTemplateDefinition = {
   notes:
     "Seeded from the shared WeCom and Lark listener plugin reply template.",
   metadata: {
-    templateVersion: "1.0.0",
+    templateVersion: "1.0.1",
     minOrcheoVersion: "0.1.0",
     validatedProviderApi: "wecom-lark-listener-plugin-suite-2026-03-16",
-    validationDate: "2026-03-16",
+    validationDate: "2026-03-20",
     owner: "Shaojie Jiang",
     requiredPlugins: [
       "orcheo-plugin-wecom-listener",
@@ -240,7 +241,7 @@ export const WECOM_LARK_SHARED_LISTENER_TEMPLATE: WorkflowTemplateDefinition = {
     ],
     revalidationTriggers: [
       "WeCom or Lark listener plugin contract change",
-      "WeComWsReplyNode or Lark OpenAPI send contract change",
+      "WeComWsReplyNode, LarkTenantAccessTokenNode, or Lark OpenAPI send contract change",
       "Shared listener payload contract change",
       "Canvas template import contract change",
     ],

--- a/apps/canvas/src/features/workflow/lib/workflow-storage.template.integration.test.ts
+++ b/apps/canvas/src/features/workflow/lib/workflow-storage.template.integration.test.ts
@@ -911,9 +911,9 @@ describe("workflow-storage API integration - template creation", () => {
     expect(ingestBody.script).toContain("AgentNode");
     expect(ingestBody.script).toContain("AgentReplyExtractorNode");
     expect(ingestBody.script).toContain("WeComWsReplyNode");
-    expect(ingestBody.script).toContain("HttpRequestNode");
-    expect(ingestBody.script).toContain("tenant_access_token/internal");
-    expect(ingestBody.metadata?.template?.templateVersion).toBe("1.0.0");
+    expect(ingestBody.script).toContain("LarkSendMessageNode");
+    expect(ingestBody.script).toContain("LarkTenantAccessTokenNode");
+    expect(ingestBody.metadata?.template?.templateVersion).toBe("1.0.1");
     expect(ingestBody.metadata?.template?.validatedProviderApi).toBe(
       "wecom-lark-listener-plugin-suite-2026-03-16",
     );

--- a/apps/canvas/src/testing/mocks/backend.ts
+++ b/apps/canvas/src/testing/mocks/backend.ts
@@ -23,8 +23,12 @@ export const setupMockBackendFetch = () => {
       input: Parameters<typeof fetch>[0],
       init?: Parameters<typeof fetch>[1],
     ) => {
+      const clonedInit = init ? { ...init } : undefined;
+      if (clonedInit) {
+        delete clonedInit.signal;
+      }
       const request =
-        input instanceof Request ? input : new Request(input, init);
+        input instanceof Request ? input : new Request(input, clonedInit);
 
       const url = new URL(request.url, "http://localhost:8000");
 

--- a/src/orcheo/nodes/__init__.py
+++ b/src/orcheo/nodes/__init__.py
@@ -28,7 +28,7 @@ from orcheo.nodes.data import (
 )
 from orcheo.nodes.debug import DebugNode
 from orcheo.nodes.javascript_sandbox import JavaScriptSandboxNode
-from orcheo.nodes.lark import LarkSendMessageNode
+from orcheo.nodes.lark import LarkSendMessageNode, LarkTenantAccessTokenNode
 from orcheo.nodes.listeners import (
     DiscordBotListenerNode,
     QQBotListenerNode,
@@ -118,6 +118,7 @@ __all__ = [
     "TelegramEventsParserNode",
     "JavaScriptSandboxNode",
     "LarkSendMessageNode",
+    "LarkTenantAccessTokenNode",
     "DebugNode",
     "SubWorkflowNode",
     "TelegramBotListenerNode",

--- a/src/orcheo/nodes/lark.py
+++ b/src/orcheo/nodes/lark.py
@@ -14,6 +14,9 @@ from orcheo.nodes.registry import NodeMetadata, registry
 
 logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 10.0
+LARK_TENANT_ACCESS_TOKEN_URL = (
+    "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal"
+)
 
 
 def _normalize_optional_value(value: str | None) -> str | None:
@@ -24,6 +27,92 @@ def _normalize_optional_value(value: str | None) -> str | None:
     if not stripped or ("{{" in stripped and "}}" in stripped):
         return None
     return stripped
+
+
+def _parse_tenant_access_token_response(data: dict[str, Any]) -> str:
+    """Extract and validate the tenant access token from a Lark auth response."""
+    if data.get("code", 0) != 0:
+        msg = data.get("msg", "Unknown error")
+        raise ValueError(f"Lark tenant token error: {msg}")
+
+    token = data.get("tenant_access_token")
+    if not isinstance(token, str) or not token.strip():
+        raise ValueError("Lark tenant token response missing tenant_access_token")
+    return token
+
+
+def _extract_tenant_access_token(result: Any) -> str | None:
+    """Extract a tenant access token from a prior node result when present."""
+    if not isinstance(result, dict):
+        return None
+
+    token = result.get("tenant_access_token")
+    if isinstance(token, str) and token.strip():
+        return token
+
+    json_payload = result.get("json")
+    if not isinstance(json_payload, dict):
+        return None
+
+    token = json_payload.get("tenant_access_token")
+    if isinstance(token, str) and token.strip():
+        return token
+
+    return None
+
+
+async def _request_tenant_access_token(
+    app_id: str,
+    app_secret: str,
+    timeout: float | None,
+) -> dict[str, Any]:
+    """Request a tenant access token from the Lark auth API."""
+    payload = {
+        "app_id": app_id,
+        "app_secret": app_secret,
+    }
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(LARK_TENANT_ACCESS_TOKEN_URL, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+@registry.register(
+    NodeMetadata(
+        name="LarkTenantAccessTokenNode",
+        description="Fetch a tenant access token from the Lark auth API",
+        category="lark",
+    )
+)
+class LarkTenantAccessTokenNode(TaskNode):
+    """Fetch a Lark tenant access token."""
+
+    app_id: str = Field(description="Lark app ID")
+    app_secret: str = Field(description="Lark app secret")
+    timeout: float | None = Field(
+        default=DEFAULT_TIMEOUT,
+        description="Timeout in seconds for the tenant access token request",
+    )
+
+    async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
+        """Fetch a tenant access token from the Lark auth API."""
+        del state
+        del config
+
+        data = await _request_tenant_access_token(
+            app_id=self.app_id,
+            app_secret=self.app_secret,
+            timeout=self.timeout,
+        )
+        token = _parse_tenant_access_token_response(data)
+
+        return {
+            "tenant_access_token": token,
+            "expire": data.get("expire"),
+            "code": data.get("code", 0),
+            "msg": data.get("msg", "success"),
+            "json": data,
+        }
 
 
 @registry.register(
@@ -62,36 +151,20 @@ class LarkSendMessageNode(TaskNode):
 
     async def _fetch_tenant_access_token(self) -> str:
         """Fetch a tenant access token directly from the Lark auth API."""
-        url = (
-            "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal"
+        data = await _request_tenant_access_token(
+            app_id=self.app_id,
+            app_secret=self.app_secret,
+            timeout=self.timeout,
         )
-        payload = {
-            "app_id": self.app_id,
-            "app_secret": self.app_secret,
-        }
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
-            data = response.json()
-        if data.get("code", 0) != 0:
-            msg = data.get("msg", "Unknown error")
-            raise ValueError(f"Lark tenant token error: {msg}")
-        token = data.get("tenant_access_token")
-        if not isinstance(token, str) or not token.strip():
-            raise ValueError("Lark tenant token response missing tenant_access_token")
-        return token
+        return _parse_tenant_access_token_response(data)
 
     async def _resolve_access_token(self, state: State) -> str:
         """Resolve the tenant access token from prior results or fetch it."""
         results = state.get("results", {})
         if isinstance(results, dict):
-            token_result = results.get("get_lark_tenant_token")
-            if isinstance(token_result, dict):
-                json_payload = token_result.get("json")
-                if isinstance(json_payload, dict):
-                    token = json_payload.get("tenant_access_token")
-                    if isinstance(token, str) and token.strip():
-                        return token
+            token = _extract_tenant_access_token(results.get("get_lark_tenant_token"))
+            if token is not None:
+                return token
         return await self._fetch_tenant_access_token()
 
     async def run(self, state: State, config: RunnableConfig) -> dict[str, Any]:
@@ -185,4 +258,4 @@ class LarkSendMessageNode(TaskNode):
         }
 
 
-__all__ = ["LarkSendMessageNode"]
+__all__ = ["LarkSendMessageNode", "LarkTenantAccessTokenNode"]

--- a/tests/nodes/test_lark.py
+++ b/tests/nodes/test_lark.py
@@ -5,7 +5,49 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.runnables import RunnableConfig
 from orcheo.graph.state import State
-from orcheo.nodes.lark import LarkSendMessageNode
+from orcheo.nodes.lark import LarkSendMessageNode, LarkTenantAccessTokenNode
+
+
+@pytest.mark.asyncio
+async def test_lark_tenant_access_token_node_returns_normalized_payload() -> None:
+    """The standard Lark token node should normalize the auth response shape."""
+    node = LarkTenantAccessTokenNode(
+        name="get_lark_tenant_token",
+        app_id="cli_app_id",
+        app_secret="app_secret",
+    )
+
+    token_response = MagicMock()
+    token_response.json.return_value = {
+        "code": 0,
+        "msg": "success",
+        "tenant_access_token": "tenant_token",
+        "expire": 7200,
+    }
+    token_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+    mock_client.post = AsyncMock(return_value=token_response)
+
+    with patch("orcheo.nodes.lark.httpx.AsyncClient", return_value=mock_client):
+        result = await node.run(
+            State(messages=[], inputs={}, results={}), RunnableConfig()
+        )
+
+    assert result == {
+        "tenant_access_token": "tenant_token",
+        "expire": 7200,
+        "code": 0,
+        "msg": "success",
+        "json": {
+            "code": 0,
+            "msg": "success",
+            "tenant_access_token": "tenant_token",
+            "expire": 7200,
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -210,6 +252,27 @@ async def test_lark_resolve_access_token_results_not_dict() -> None:
     with patch("orcheo.nodes.lark.httpx.AsyncClient", return_value=mock_client):
         token = await node._resolve_access_token(state)
     assert token == "fetched_token"
+
+
+@pytest.mark.asyncio
+async def test_lark_resolve_access_token_standard_node_result() -> None:
+    """_resolve_access_token should accept the standard node's top-level token."""
+    node = LarkSendMessageNode(
+        name="send_lark",
+        app_id="app",
+        app_secret="secret",
+        receive_id="oc_chat",
+        message="Hello",
+    )
+    state = State(
+        messages=[],
+        inputs={},
+        results={"get_lark_tenant_token": {"tenant_access_token": "node_token"}},
+    )
+
+    token = await node._resolve_access_token(state)
+
+    assert token == "node_token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `LarkTenantAccessTokenNode` to standardize Lark tenant token retrieval and response parsing
- update `LarkSendMessageNode` to reuse shared token request/parsing logic and accept token output from the standard node
- switch the WeCom/Lark shared listener template to use the new Lark auth node and refresh template metadata
- add node tests covering normalized token payloads and token resolution from standard node results

## Testing
- Not run (not requested)