### PR TITLE
Implement browser-context bridge for agent-driven workflow editing

### DIFF
--- a/apps/canvas/src/App.tsx
+++ b/apps/canvas/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Toaster } from "@/design-system/ui/toaster";
+import { BrowserContextProvider } from "@/hooks/browser-context-provider";
 import WorkflowGallery from "@features/workflow/pages/workflow-gallery";
 import WorkflowCanvas from "@features/workflow/pages/workflow-canvas";
 import WorkflowExecutionDetails from "@features/workflow/pages/workflow-execution-details";
@@ -14,34 +15,36 @@ import PublicChatPage from "@features/chatkit/pages/public-chat";
 export default function OrcheoCanvasApp() {
   return (
     <Router>
-      <Routes>
-        <Route path="/login" element={<Login />} />
+      <BrowserContextProvider>
+        <Routes>
+          <Route path="/login" element={<Login />} />
 
-        <Route path="/auth/callback" element={<OAuthCallback />} />
-        <Route path="/chat/:workflowId" element={<PublicChatPage />} />
+          <Route path="/auth/callback" element={<OAuthCallback />} />
+          <Route path="/chat/:workflowId" element={<PublicChatPage />} />
 
-        <Route element={<RequireAuth />}>
-          <Route path="/" element={<WorkflowGallery />} />
+          <Route element={<RequireAuth />}>
+            <Route path="/" element={<WorkflowGallery />} />
 
-          <Route path="/workflow-canvas" element={<WorkflowCanvas />} />
-          <Route
-            path="/workflow-canvas/:workflowId"
-            element={<WorkflowCanvas />}
-          />
+            <Route path="/workflow-canvas" element={<WorkflowCanvas />} />
+            <Route
+              path="/workflow-canvas/:workflowId"
+              element={<WorkflowCanvas />}
+            />
 
-          <Route
-            path="/workflow-execution-details/:executionId"
-            element={<WorkflowExecutionDetails />}
-          />
+            <Route
+              path="/workflow-execution-details/:executionId"
+              element={<WorkflowExecutionDetails />}
+            />
 
-          <Route path="/profile" element={<Profile />} />
+            <Route path="/profile" element={<Profile />} />
 
-          <Route path="/settings" element={<Settings />} />
+            <Route path="/settings" element={<Settings />} />
 
-          <Route path="/help-support" element={<HelpSupport />} />
-        </Route>
-      </Routes>
-      <Toaster />
+            <Route path="/help-support" element={<HelpSupport />} />
+          </Route>
+        </Routes>
+        <Toaster />
+      </BrowserContextProvider>
     </Router>
   );
 }

--- a/apps/canvas/src/features/account/components/settings/agent-settings-tab.tsx
+++ b/apps/canvas/src/features/account/components/settings/agent-settings-tab.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/design-system/ui/badge";
+import { Button } from "@/design-system/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/design-system/ui/card";
+import { Separator } from "@/design-system/ui/separator";
+
+const CONTEXT_URL = "http://localhost:3333/context/sessions";
+
+function useCopied() {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback((text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+  return { copied, copy };
+}
+
+const AgentSettingsTab = () => {
+  const [sessionCount, setSessionCount] = useState<number | null>(null);
+  const [serverRunning, setServerRunning] = useState(false);
+  const { copied: copiedLogin, copy: copyLogin } = useCopied();
+  const { copied: copiedStart, copy: copyStart } = useCopied();
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await fetch(CONTEXT_URL);
+        if (!cancelled) {
+          const sessions = await res.json();
+          setSessionCount(Array.isArray(sessions) ? sessions.length : 0);
+          setServerRunning(true);
+        }
+      } catch {
+        if (!cancelled) {
+          setSessionCount(null);
+          setServerRunning(false);
+        }
+      }
+    };
+    poll();
+    const interval = setInterval(poll, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Connect your agent</CardTitle>
+          <CardDescription>
+            Use Claude Code, Cursor, or any CLI-capable coding agent to read and
+            modify your Orcheo workflows directly from the terminal.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium">Quick start</h3>
+            <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+              <li>
+                Authenticate the CLI:
+                <div className="mt-1 flex items-center gap-2">
+                  <code className="rounded bg-muted px-2 py-1 text-xs">
+                    orcheo auth login
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => copyLogin("orcheo auth login")}
+                  >
+                    {copiedLogin ? "Copied!" : "Copy"}
+                  </Button>
+                </div>
+              </li>
+              <li>
+                Start the browser context bridge:
+                <div className="mt-1 flex items-center gap-2">
+                  <code className="rounded bg-muted px-2 py-1 text-xs">
+                    orcheo browser-aware
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => copyStart("orcheo browser-aware")}
+                  >
+                    {copiedStart ? "Copied!" : "Copy"}
+                  </Button>
+                </div>
+              </li>
+              <li>
+                Open a workflow in Canvas — your agent will automatically know
+                what you&apos;re looking at.
+              </li>
+            </ol>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Connection status</h3>
+            <div className="flex items-center gap-2">
+              <Badge variant={serverRunning ? "default" : "secondary"}>
+                {serverRunning ? "Connected" : "Not connected"}
+              </Badge>
+              {serverRunning && sessionCount !== null && (
+                <span className="text-sm text-muted-foreground">
+                  {sessionCount} active{" "}
+                  {sessionCount === 1 ? "session" : "sessions"}
+                </span>
+              )}
+            </div>
+            {!serverRunning && (
+              <p className="text-xs text-muted-foreground">
+                Run{" "}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  orcheo browser-aware
+                </code>{" "}
+                in your terminal to connect.
+              </p>
+            )}
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Agent commands</h3>
+            <div className="space-y-1 text-sm text-muted-foreground">
+              <p>
+                <code className="rounded bg-muted px-1 py-0.5">
+                  orcheo context
+                </code>{" "}
+                — See what workflow you have open
+              </p>
+              <p>
+                <code className="rounded bg-muted px-1 py-0.5">
+                  orcheo workflow show &lt;id&gt;
+                </code>{" "}
+                — View workflow details
+              </p>
+              <p>
+                <code className="rounded bg-muted px-1 py-0.5">
+                  orcheo workflow download &lt;id&gt;
+                </code>{" "}
+                — Download workflow script
+              </p>
+              <p>
+                <code className="rounded bg-muted px-1 py-0.5">
+                  orcheo workflow upload --id &lt;id&gt; &lt;file&gt;
+                </code>{" "}
+                — Upload updated script
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AgentSettingsTab;

--- a/apps/canvas/src/features/account/pages/settings.tsx
+++ b/apps/canvas/src/features/account/pages/settings.tsx
@@ -5,6 +5,7 @@ import {
   TabsTrigger,
 } from "@/design-system/ui/tabs";
 import useCredentialVault from "@/hooks/use-credential-vault";
+import AgentSettingsTab from "@features/account/components/settings/agent-settings-tab";
 import AppearanceSettingsTab from "@features/account/components/settings/appearance-settings-tab";
 import ApplicationSettingsTab from "@features/account/components/settings/application-settings-tab";
 import NotificationSettingsTab from "@features/account/components/settings/notification-settings-tab";
@@ -42,6 +43,7 @@ export default function Settings() {
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
             <TabsTrigger value="application">Application</TabsTrigger>
             <TabsTrigger value="teams">Teams & Billing</TabsTrigger>
+            <TabsTrigger value="agent">Connect Agent</TabsTrigger>
           </TabsList>
           <TabsContent value="appearance" className="space-y-4">
             <AppearanceSettingsTab />
@@ -54,6 +56,9 @@ export default function Settings() {
           </TabsContent>
           <TabsContent value="teams" className="space-y-4">
             <TeamBillingSettingsTab />
+          </TabsContent>
+          <TabsContent value="agent" className="space-y-4">
+            <AgentSettingsTab />
           </TabsContent>
         </Tabs>
       </div>

--- a/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-canvas.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { WorkflowCanvasLayout } from "@features/workflow/pages/workflow-canvas/components/workflow-canvas-layout";
 import { useWorkflowCanvasController } from "@features/workflow/pages/workflow-canvas/hooks/controller/use-workflow-canvas-controller";
+import { usePageContext } from "@/hooks/use-page-context";
 
 import type {
   CanvasEdge,
@@ -19,5 +21,19 @@ export default function WorkflowCanvas({
     initialNodes,
     initialEdges,
   );
+
+  const { setPageContext } = usePageContext();
+  const workflowId = layoutProps.workflowProps.workflowId ?? null;
+  const workflowName =
+    layoutProps.topNavigationProps.currentWorkflow.name ?? null;
+
+  useEffect(() => {
+    setPageContext({
+      page: "canvas",
+      workflowId,
+      workflowName,
+    });
+  }, [setPageContext, workflowId, workflowName]);
+
   return <WorkflowCanvasLayout {...layoutProps} />;
 }

--- a/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
+++ b/apps/canvas/src/features/workflow/pages/workflow-gallery.tsx
@@ -1,10 +1,16 @@
+import { useEffect } from "react";
 import TopNavigation from "@features/shared/components/top-navigation";
 import useCredentialVault from "@/hooks/use-credential-vault";
+import { usePageContext } from "@/hooks/use-page-context";
 import { WorkflowGalleryHeader } from "@/features/workflow/pages/workflow-gallery/workflow-gallery-header";
 import { WorkflowGalleryTabs } from "@/features/workflow/pages/workflow-gallery/workflow-gallery-tabs";
 import { useWorkflowGallery } from "@/features/workflow/pages/workflow-gallery/use-workflow-gallery";
 
 export default function WorkflowGallery() {
+  const { setPageContext } = usePageContext();
+  useEffect(() => {
+    setPageContext({ page: "gallery" });
+  }, [setPageContext]);
   const {
     credentials,
     isLoading: isCredentialsLoading,

--- a/apps/canvas/src/hooks/browser-context-provider.tsx
+++ b/apps/canvas/src/hooks/browser-context-provider.tsx
@@ -1,0 +1,17 @@
+/**
+ * BrowserContextProvider — wraps the app to relay Canvas page context
+ * to the local `orcheo browser-aware` HTTP server.
+ */
+
+import type { ReactNode } from "react";
+import { useBrowserContext } from "@/hooks/use-browser-context";
+import { BrowserContext } from "@/hooks/use-page-context";
+
+export function BrowserContextProvider({ children }: { children: ReactNode }) {
+  const { setPageContext } = useBrowserContext();
+  return (
+    <BrowserContext.Provider value={{ setPageContext }}>
+      {children}
+    </BrowserContext.Provider>
+  );
+}

--- a/apps/canvas/src/hooks/use-browser-context.test.tsx
+++ b/apps/canvas/src/hooks/use-browser-context.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+
+import { useBrowserContext } from "./use-browser-context";
+
+let fetchSpy: MockInstance;
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function HookHarness() {
+  const { setPageContext } = useBrowserContext();
+  return (
+    <div>
+      <button
+        data-testid="set-gallery"
+        onClick={() => setPageContext({ page: "gallery" })}
+      />
+      <button
+        data-testid="set-canvas"
+        onClick={() =>
+          setPageContext({
+            page: "canvas",
+            workflowId: "wf-1",
+            workflowName: "Test",
+          })
+        }
+      />
+    </div>
+  );
+}
+
+describe("useBrowserContext", () => {
+  it("fires POST on setPageContext", async () => {
+    render(<HookHarness />);
+
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3333/context",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.page).toBe("gallery");
+    expect(body.session_id).toBeTruthy();
+  });
+
+  it("generates stable session_id from sessionStorage", async () => {
+    render(<HookHarness />);
+
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+
+    const firstBody = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    const sessionId = firstBody.session_id;
+
+    expect(sessionStorage.getItem("orcheo_browser_session_id")).toBe(sessionId);
+  });
+
+  it("posts workflow_id and workflow_name for canvas context", async () => {
+    render(<HookHarness />);
+
+    await act(async () => {
+      screen.getByTestId("set-canvas").click();
+    });
+
+    const call = fetchSpy.mock.calls.find((c) => {
+      const body = JSON.parse((c as [string, RequestInit])[1].body as string);
+      return body.page === "canvas";
+    }) as [string, RequestInit] | undefined;
+
+    expect(call).toBeDefined();
+    const body = JSON.parse(call![1].body as string);
+    expect(body.workflow_id).toBe("wf-1");
+    expect(body.workflow_name).toBe("Test");
+  });
+
+  it("starts heartbeat on mount when tab is visible", async () => {
+    vi.useFakeTimers();
+
+    render(<HookHarness />);
+    fetchSpy.mockClear();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("silently handles fetch failure", async () => {
+    fetchSpy.mockRejectedValue(new Error("Connection refused"));
+
+    render(<HookHarness />);
+
+    // Should not throw
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+  });
+
+  it("includes focused flag based on document.hasFocus", async () => {
+    render(<HookHarness />);
+
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(typeof body.focused).toBe("boolean");
+  });
+
+  it("fires POST on focus event", async () => {
+    render(<HookHarness />);
+
+    // Set a context first so there's something to send
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+    fetchSpy.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.focused).toBe(true);
+  });
+
+  it("fires POST on blur event", async () => {
+    render(<HookHarness />);
+
+    await act(async () => {
+      screen.getByTestId("set-gallery").click();
+    });
+    fetchSpy.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.focused).toBe(false);
+  });
+});

--- a/apps/canvas/src/hooks/use-browser-context.ts
+++ b/apps/canvas/src/hooks/use-browser-context.ts
@@ -1,0 +1,125 @@
+/**
+ * BrowserContextProvider — relays Canvas page context to the local
+ * `orcheo browser-aware` HTTP server so coding agents stay in sync.
+ *
+ * Usage:
+ *   const { setPageContext } = useBrowserContext();
+ *   setPageContext({ page: "canvas", workflowId: "abc", workflowName: "My Flow" });
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+const CONTEXT_URL = "http://localhost:3333/context";
+const HEARTBEAT_INTERVAL_MS = 5_000;
+
+interface PageContext {
+  page: "gallery" | "canvas" | "other";
+  workflowId?: string | null;
+  workflowName?: string | null;
+}
+
+function getOrCreateSessionId(): string {
+  const key = "orcheo_browser_session_id";
+  let id = sessionStorage.getItem(key);
+  if (!id) {
+    id = crypto.randomUUID();
+    sessionStorage.setItem(key, id);
+  }
+  return id;
+}
+
+async function postContext(
+  sessionId: string,
+  ctx: PageContext,
+  focused: boolean,
+): Promise<void> {
+  try {
+    await fetch(CONTEXT_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: sessionId,
+        page: ctx.page,
+        workflow_id: ctx.workflowId ?? null,
+        workflow_name: ctx.workflowName ?? null,
+        focused,
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Server not running — silently ignore.
+  }
+}
+
+export function useBrowserContext() {
+  const sessionIdRef = useRef<string>(getOrCreateSessionId());
+  const contextRef = useRef<PageContext>({ page: "other" });
+  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startHeartbeat = useCallback(() => {
+    if (heartbeatRef.current) return;
+    heartbeatRef.current = setInterval(() => {
+      postContext(
+        sessionIdRef.current,
+        contextRef.current,
+        document.hasFocus(),
+      );
+    }, HEARTBEAT_INTERVAL_MS);
+  }, []);
+
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatRef.current) {
+      clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+  }, []);
+
+  // Visibility / focus listeners — start/stop heartbeat.
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        // Fire immediately on becoming visible, then start heartbeat.
+        postContext(
+          sessionIdRef.current,
+          contextRef.current,
+          document.hasFocus(),
+        );
+        startHeartbeat();
+      } else {
+        stopHeartbeat();
+      }
+    };
+
+    const handleFocus = () => {
+      postContext(sessionIdRef.current, contextRef.current, true);
+    };
+
+    const handleBlur = () => {
+      postContext(sessionIdRef.current, contextRef.current, false);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
+    // Start heartbeat if tab is already visible.
+    if (document.visibilityState === "visible") {
+      startHeartbeat();
+    }
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+      stopHeartbeat();
+    };
+  }, [startHeartbeat, stopHeartbeat]);
+
+  const setPageContext = useCallback((ctx: PageContext) => {
+    contextRef.current = ctx;
+    // Fire immediately on context change.
+    postContext(sessionIdRef.current, ctx, document.hasFocus());
+  }, []);
+
+  return { setPageContext };
+}

--- a/apps/canvas/src/hooks/use-browser-context.ts
+++ b/apps/canvas/src/hooks/use-browser-context.ts
@@ -10,7 +10,10 @@
 import { useCallback, useEffect, useRef } from "react";
 
 const CONTEXT_URL = "http://localhost:3333/context";
-const HEARTBEAT_INTERVAL_MS = 5_000;
+const HEARTBEAT_ACTIVE_MS = 5_000;
+const HEARTBEAT_IDLE_MS = 30_000;
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 500;
 
 interface PageContext {
   page: "gallery" | "canvas" | "other";
@@ -33,43 +36,60 @@ async function postContext(
   ctx: PageContext,
   focused: boolean,
 ): Promise<void> {
-  try {
-    await fetch(CONTEXT_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        session_id: sessionId,
-        page: ctx.page,
-        workflow_id: ctx.workflowId ?? null,
-        workflow_name: ctx.workflowName ?? null,
-        focused,
-        timestamp: new Date().toISOString(),
-      }),
-    });
-  } catch {
-    // Server not running — silently ignore.
+  const body = JSON.stringify({
+    session_id: sessionId,
+    page: ctx.page,
+    workflow_id: ctx.workflowId ?? null,
+    workflow_name: ctx.workflowName ?? null,
+    focused,
+    timestamp: new Date().toISOString(),
+  });
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(CONTEXT_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      if (res.ok || res.status < 500) return;
+    } catch {
+      // Network error — retry with backoff if attempts remain.
+    }
+    if (attempt < MAX_RETRIES) {
+      await new Promise((r) =>
+        setTimeout(r, INITIAL_BACKOFF_MS * 2 ** attempt),
+      );
+    }
   }
 }
 
 export function useBrowserContext() {
   const sessionIdRef = useRef<string>(getOrCreateSessionId());
   const contextRef = useRef<PageContext>({ page: "other" });
-  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const heartbeatRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const startHeartbeat = useCallback(() => {
     if (heartbeatRef.current) return;
-    heartbeatRef.current = setInterval(() => {
+
+    const tick = () => {
       postContext(
         sessionIdRef.current,
         contextRef.current,
         document.hasFocus(),
       );
-    }, HEARTBEAT_INTERVAL_MS);
+      // Reduce frequency when the tab is not focused.
+      const interval = document.hasFocus()
+        ? HEARTBEAT_ACTIVE_MS
+        : HEARTBEAT_IDLE_MS;
+      heartbeatRef.current = setTimeout(tick, interval);
+    };
+    heartbeatRef.current = setTimeout(tick, HEARTBEAT_ACTIVE_MS);
   }, []);
 
   const stopHeartbeat = useCallback(() => {
     if (heartbeatRef.current) {
-      clearInterval(heartbeatRef.current);
+      clearTimeout(heartbeatRef.current);
       heartbeatRef.current = null;
     }
   }, []);

--- a/apps/canvas/src/hooks/use-page-context.ts
+++ b/apps/canvas/src/hooks/use-page-context.ts
@@ -1,0 +1,23 @@
+/**
+ * Hook for accessing the browser context from page components.
+ */
+
+import { createContext, useContext } from "react";
+
+interface PageContext {
+  page: "gallery" | "canvas" | "other";
+  workflowId?: string | null;
+  workflowName?: string | null;
+}
+
+interface BrowserContextValue {
+  setPageContext: (ctx: PageContext) => void;
+}
+
+export const BrowserContext = createContext<BrowserContextValue>({
+  setPageContext: () => {},
+});
+
+export function usePageContext(): BrowserContextValue {
+  return useContext(BrowserContext);
+}

--- a/docs/connect_coding_agent.md
+++ b/docs/connect_coding_agent.md
@@ -1,0 +1,101 @@
+# Connect a Coding Agent to Orcheo Canvas
+
+Use Claude Code, Cursor, or any CLI-capable coding agent to read and modify
+your Orcheo workflows directly from the terminal. The agent stays in sync with
+the workflow you have open in Canvas — no copy-pasting required.
+
+## Prerequisites
+
+- **Orcheo CLI** (`orcheo`) installed and updated to the latest version.
+- An Orcheo account with API access.
+
+## Quick Start
+
+### 1. Authenticate
+
+```bash
+orcheo auth login
+```
+
+This opens your browser for OAuth login and stores credentials locally.
+Alternatively set the `ORCHEO_SERVICE_TOKEN` environment variable.
+
+### 2. Start the browser context bridge
+
+```bash
+orcheo browser-aware
+```
+
+This starts a lightweight HTTP server on `localhost:3333` that receives context
+from your Canvas browser tabs. Keep it running while you work.
+
+Use `--port` to change the port:
+
+```bash
+orcheo browser-aware --port 4444
+```
+
+### 3. Open Canvas
+
+Navigate to any workflow in Orcheo Canvas. The browser tab automatically relays
+which page and workflow you're viewing to the local server.
+
+### 4. Use your agent
+
+Your coding agent can now run CLI commands to interact with the active workflow:
+
+```bash
+# See what you have open in Canvas
+orcheo context
+
+# View workflow details
+orcheo workflow show <workflow-id>
+
+# Download the workflow script
+orcheo workflow download <workflow-id>
+
+# Upload an updated script
+orcheo workflow upload --id <workflow-id> updated_script.py
+
+# List all workflows
+orcheo workflow list
+```
+
+## Connect Claude Code to Orcheo Canvas
+
+1. Start the browser context bridge: `orcheo browser-aware`
+2. Open a workflow in Canvas.
+3. In your terminal, ask Claude Code: *"What workflow am I looking at?"*
+4. Claude Code runs `orcheo context` to read the active workflow, then
+   `orcheo workflow show <id>` or `orcheo workflow download <id>` to fetch the
+   script.
+5. Ask Claude Code to make changes — it will edit the script and run
+   `orcheo workflow upload --id <id> <file>` to push the update.
+6. Refresh Canvas to see the updated workflow graph.
+
+## Connect Cursor to Orcheo Canvas
+
+1. Start the browser context bridge: `orcheo browser-aware`
+2. Open a workflow in Canvas.
+3. In Cursor's terminal, run `orcheo context` to see the active workflow.
+4. Use `orcheo workflow download <id>` to get the script, edit it in Cursor,
+   then `orcheo workflow upload --id <id> <file>` to push changes.
+
+## Multi-tab Support
+
+If you have multiple Canvas tabs open, `orcheo context` returns the most
+recently focused tab's context. Use `orcheo context sessions` to see all
+active tabs:
+
+```bash
+orcheo context sessions
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `orcheo context` says "Could not connect" | Make sure `orcheo browser-aware` is running in another terminal. |
+| `orcheo context` says "No active Canvas session" | Open Orcheo Canvas in your browser. The context relay only works when a Canvas tab is open. |
+| Context is stale | Check that the Canvas tab is not minimized or suspended. The heartbeat pauses when the tab is hidden. |
+| Authentication errors on workflow commands | Run `orcheo auth login` to refresh your credentials. |

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/__init__.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/__init__.py
@@ -1,0 +1,25 @@
+"""Browser context bridge for exposing Canvas context to coding agents.
+
+Agents interact with workflows via existing CLI commands — no additional tool
+definitions are needed:
+
+- ``orcheo context`` — active Canvas page and workflow.
+- ``orcheo context sessions`` — all active Canvas sessions.
+- ``orcheo workflow show <id>`` — fetch workflow details and script.
+- ``orcheo workflow download <id>`` — download workflow script to a file.
+- ``orcheo workflow upload --id <id> <file>`` — upload an updated script.
+- ``orcheo workflow upload <file>`` — create a new workflow from a script.
+- ``orcheo workflow list`` — list all workflows.
+"""
+
+from __future__ import annotations
+from orcheo_sdk.cli.browser_context.store import (
+    BrowserContextEntry,
+    BrowserContextStore,
+)
+
+
+__all__ = [
+    "BrowserContextEntry",
+    "BrowserContextStore",
+]

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/commands.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/commands.py
@@ -1,0 +1,145 @@
+"""CLI commands for browser context bridge."""
+
+from __future__ import annotations
+import logging
+from typing import Annotated
+import httpx
+import typer
+from orcheo_sdk.cli.output import print_json, render_json, render_table
+from orcheo_sdk.cli.state import CLIState
+
+
+browser_aware_app = typer.Typer(help="Start the browser context bridge server.")
+context_app = typer.Typer(help="Inspect browser context from Canvas tabs.")
+
+DEFAULT_PORT = 3333
+
+
+def _state(ctx: typer.Context) -> CLIState:
+    """Retrieve CLI state from Typer context."""
+    return ctx.ensure_object(CLIState)
+
+
+def _context_base_url(port: int = DEFAULT_PORT) -> str:
+    return f"http://localhost:{port}"
+
+
+@browser_aware_app.callback(invoke_without_command=True)
+def browser_aware(
+    ctx: typer.Context,
+    port: Annotated[
+        int,
+        typer.Option("--port", help="Port for the context bridge HTTP server."),
+    ] = DEFAULT_PORT,
+) -> None:
+    """Start a local HTTP server that receives context from Canvas browser tabs."""
+    if ctx.invoked_subcommand is not None:
+        return  # pragma: no cover
+
+    from orcheo_sdk.cli.browser_context.server import run_server
+
+    state = _state(ctx)
+    state.console.print(
+        f"[cyan]Browser context server starting on localhost:{port}[/cyan]"
+    )
+    state.console.print("Press Ctrl+C to stop.\n")
+    logging.basicConfig(level=logging.INFO)
+    run_server(host="localhost", port=port)
+
+
+@context_app.callback(invoke_without_command=True)
+def context(
+    ctx: typer.Context,
+    port: Annotated[
+        int,
+        typer.Option("--port", help="Port of the browser-aware HTTP server."),
+    ] = DEFAULT_PORT,
+) -> None:
+    """Show the active browser context (current Canvas page and workflow)."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    state = _state(ctx)
+    url = f"{_context_base_url(port)}/context"
+    try:
+        response = httpx.get(url, timeout=5)
+        data = response.json()
+    except httpx.ConnectError:
+        msg = (
+            "Could not connect to browser-aware server. "
+            f"Run 'orcheo browser-aware' to start it (port {port})."
+        )
+        if state.human:
+            state.console.print(f"[yellow]{msg}[/yellow]")
+        else:
+            print_json({"error": msg})
+        raise typer.Exit(code=1) from None
+
+    if data.get("total_sessions", 0) == 0:
+        msg = (
+            "No active Canvas session found. "
+            "Open Orcheo Canvas in your browser to provide context."
+        )
+        if state.human:
+            state.console.print(f"[yellow]{msg}[/yellow]")
+        else:
+            print_json({"warning": msg, **data})
+        return
+
+    if state.human:
+        render_json(state.console, data, title="Active Context")
+    else:
+        print_json(data)
+
+
+@context_app.command("sessions")
+def context_sessions(
+    ctx: typer.Context,
+    port: Annotated[
+        int,
+        typer.Option("--port", help="Port of the browser-aware HTTP server."),
+    ] = DEFAULT_PORT,
+) -> None:
+    """List all active Canvas sessions."""
+    state = _state(ctx)
+    url = f"{_context_base_url(port)}/context/sessions"
+    try:
+        response = httpx.get(url, timeout=5)
+        data = response.json()
+    except httpx.ConnectError:
+        msg = (
+            "Could not connect to browser-aware server. "
+            f"Run 'orcheo browser-aware' to start it (port {port})."
+        )
+        if state.human:
+            state.console.print(f"[yellow]{msg}[/yellow]")
+        else:
+            print_json({"error": msg})
+        raise typer.Exit(code=1) from None
+
+    if not data:
+        msg = "No active sessions."
+        if state.human:
+            state.console.print(f"[yellow]{msg}[/yellow]")
+        else:
+            print_json([])
+        return
+
+    if state.human:
+        columns = [
+            "session_id",
+            "page",
+            "workflow_id",
+            "workflow_name",
+            "focused",
+            "staleness_seconds",
+        ]
+        rows = [[session.get(col, "") for col in columns] for session in data]
+        render_table(
+            state.console,
+            title="Active Sessions",
+            columns=columns,
+            rows=rows,
+        )
+    else:
+        print_json(data)

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
@@ -17,10 +17,24 @@ logger = logging.getLogger(__name__)
 _REQUIRED_POST_FIELDS = {"session_id", "page", "focused"}
 
 
-def _cors_headers() -> dict[str, str]:
-    """Return CORS headers allowing any origin (localhost-bound server)."""
+def _cors_headers(origin: str | None = None) -> dict[str, str]:
+    """Return CORS headers restricted to localhost origins."""
+    allowed_origin = ""
+    if origin:
+        # Allow any localhost origin (any port, http only).
+        try:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(origin)
+            if (
+                parsed.hostname in ("localhost", "127.0.0.1")
+                and parsed.scheme == "http"
+            ):
+                allowed_origin = origin
+        except Exception:  # noqa: BLE001
+            pass
     return {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": allowed_origin,
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type",
     }
@@ -61,11 +75,15 @@ class ContextRequestHandler(BaseHTTPRequestHandler):
 
     store: ClassVar[BrowserContextStore]
 
+    def _origin(self) -> str | None:
+        """Return the Origin header from the request."""
+        return self.headers.get("Origin")
+
     def _send_json(self, status: int, data: Any) -> None:
         """Send a JSON response with CORS headers."""
         body = json.dumps(data, default=str).encode()
         self.send_response(status)
-        for key, value in _cors_headers().items():
+        for key, value in _cors_headers(self._origin()).items():
             self.send_header(key, value)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -75,7 +93,7 @@ class ContextRequestHandler(BaseHTTPRequestHandler):
     def _send_no_content(self) -> None:
         """Send a 204 No Content response with CORS headers."""
         self.send_response(204)
-        for key, value in _cors_headers().items():
+        for key, value in _cors_headers(self._origin()).items():
             self.send_header(key, value)
         self.end_headers()
 
@@ -134,12 +152,37 @@ def create_request_handler(
     )
 
 
-def run_server(*, host: str = "localhost", port: int = 3333) -> None:
-    """Start the browser context HTTP server (blocking)."""
+def run_server(
+    *, host: str = "localhost", port: int = 3333, max_port_attempts: int = 10
+) -> None:
+    """Start the browser context HTTP server (blocking).
+
+    If the requested port is in use, tries up to ``max_port_attempts``
+    consecutive ports before giving up.
+    """
     store = BrowserContextStore()
     handler_class = create_request_handler(store)
-    server = HTTPServer((host, port), handler_class)
-    logger.info("Browser context server listening on %s:%d", host, port)
+
+    server: HTTPServer | None = None
+    last_error: OSError | None = None
+    for port_attempt in range(port, port + max_port_attempts):
+        try:
+            server = HTTPServer((host, port_attempt), handler_class)
+            break
+        except OSError as exc:
+            last_error = exc
+            logger.debug("Port %d unavailable, trying next", port_attempt)
+            continue
+
+    if server is None:
+        msg = (
+            f"Could not bind to any port in range {port}–{port + max_port_attempts - 1}"
+        )
+        raise OSError(msg) from last_error
+
+    logger.info(
+        "Browser context server listening on %s:%d", host, server.server_address[1]
+    )
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
@@ -1,0 +1,148 @@
+"""HTTP server for the browser context bridge.
+
+Serves context relay endpoints on localhost for Canvas → CLI communication.
+"""
+
+from __future__ import annotations
+import json
+import logging
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, ClassVar
+from orcheo_sdk.cli.browser_context.store import BrowserContextStore
+
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_POST_FIELDS = {"session_id", "page", "focused"}
+
+
+def _cors_headers() -> dict[str, str]:
+    """Return CORS headers allowing any origin (localhost-bound server)."""
+    return {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+    }
+
+
+def _parse_context_body(raw: bytes) -> dict[str, Any] | str:
+    """Parse and validate a POST /context body.
+
+    Returns the parsed dict on success, or an error string on failure.
+    """
+    try:
+        body: dict[str, Any] = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "invalid JSON"
+
+    missing = _REQUIRED_POST_FIELDS - set(body.keys())
+    if missing:
+        return f"missing fields: {', '.join(sorted(missing))}"
+
+    return body
+
+
+def _resolve_timestamp(body: dict[str, Any]) -> datetime:
+    """Extract and parse the timestamp field, falling back to now."""
+    if "timestamp" in body:
+        try:
+            return datetime.fromisoformat(body["timestamp"])
+        except (ValueError, TypeError):
+            pass
+    return datetime.now(UTC)
+
+
+class ContextRequestHandler(BaseHTTPRequestHandler):
+    """Handles context relay HTTP requests.
+
+    Set the ``store`` class variable before use.
+    """
+
+    store: ClassVar[BrowserContextStore]
+
+    def _send_json(self, status: int, data: Any) -> None:
+        """Send a JSON response with CORS headers."""
+        body = json.dumps(data, default=str).encode()
+        self.send_response(status)
+        for key, value in _cors_headers().items():
+            self.send_header(key, value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_no_content(self) -> None:
+        """Send a 204 No Content response with CORS headers."""
+        self.send_response(204)
+        for key, value in _cors_headers().items():
+            self.send_header(key, value)
+        self.end_headers()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        """Handle CORS preflight requests."""
+        self._send_no_content()
+
+    def do_GET(self) -> None:  # noqa: N802
+        """Handle GET requests for context endpoints."""
+        if self.path == "/context":
+            self._send_json(200, self.store.get_active())
+        elif self.path == "/context/sessions":
+            self._send_json(200, self.store.get_all_sessions())
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        """Handle POST /context to upsert a session entry."""
+        if self.path != "/context":
+            self._send_json(404, {"error": "not found"})
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            self._send_json(400, {"error": "empty body"})
+            return
+
+        result = _parse_context_body(self.rfile.read(content_length))
+        if isinstance(result, str):
+            self._send_json(400, {"error": result})
+            return
+
+        self.store.upsert(
+            session_id=result["session_id"],
+            page=result["page"],
+            workflow_id=result.get("workflow_id"),
+            workflow_name=result.get("workflow_name"),
+            focused=bool(result["focused"]),
+            timestamp=_resolve_timestamp(result),
+        )
+        self._send_no_content()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Route HTTP server log messages to the logger."""
+        logger.debug(format, *args)
+
+
+def create_request_handler(
+    store: BrowserContextStore,
+) -> type[ContextRequestHandler]:
+    """Create a request handler subclass bound to the given store."""
+    return type(
+        "BoundContextHandler",
+        (ContextRequestHandler,),
+        {"store": store},
+    )
+
+
+def run_server(*, host: str = "localhost", port: int = 3333) -> None:
+    """Start the browser context HTTP server (blocking)."""
+    store = BrowserContextStore()
+    handler_class = create_request_handler(store)
+    server = HTTPServer((host, port), handler_class)
+    logger.info("Browser context server listening on %s:%d", host, port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
@@ -1,0 +1,148 @@
+"""In-memory browser context store with TTL eviction and focus-priority."""
+
+from __future__ import annotations
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+
+@dataclass(slots=True)
+class BrowserContextEntry:
+    """A single browser tab's context."""
+
+    session_id: str
+    page: str
+    workflow_id: str | None
+    workflow_name: str | None
+    focused: bool
+    last_seen: datetime
+    last_focused_at: datetime | None = None
+
+
+class BrowserContextStore:
+    """In-memory context store keyed by session_id with TTL eviction.
+
+    Thread-safe. Entries are evicted after ``ttl_seconds`` without an update.
+    Focus-priority resolution returns the session with the most recent
+    ``last_focused_at``, falling back to the most recently seen session.
+    """
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        """Create a store with the given TTL in seconds."""
+        self._ttl = timedelta(seconds=ttl_seconds)
+        self._sessions: dict[str, BrowserContextEntry] = {}
+        self._lock = threading.Lock()
+
+    def upsert(
+        self,
+        *,
+        session_id: str,
+        page: str,
+        workflow_id: str | None,
+        workflow_name: str | None,
+        focused: bool,
+        timestamp: datetime | None = None,
+    ) -> None:
+        """Insert or update a session entry. Resets the TTL."""
+        now = timestamp or datetime.now(UTC)
+        with self._lock:
+            existing = self._sessions.get(session_id)
+            last_focused_at = existing.last_focused_at if existing else None
+            if focused:
+                last_focused_at = now
+            self._sessions[session_id] = BrowserContextEntry(
+                session_id=session_id,
+                page=page,
+                workflow_id=workflow_id,
+                workflow_name=workflow_name,
+                focused=focused,
+                last_seen=now,
+                last_focused_at=last_focused_at,
+            )
+
+    def _evict(self, now: datetime) -> None:
+        """Remove entries older than TTL. Must be called under lock."""
+        cutoff = now - self._ttl
+        expired = [
+            sid for sid, entry in self._sessions.items() if entry.last_seen < cutoff
+        ]
+        for sid in expired:
+            del self._sessions[sid]
+
+    def get_active(self) -> dict[str, object]:
+        """Return the active context using focus-priority resolution.
+
+        Returns the session with the most recent ``last_focused_at``.
+        If no session has focus history, returns the most recently seen.
+        If no sessions exist, returns a null context.
+        """
+        now = datetime.now(UTC)
+        with self._lock:
+            self._evict(now)
+            if not self._sessions:
+                return {
+                    "session_id": None,
+                    "page": None,
+                    "workflow_id": None,
+                    "workflow_name": None,
+                    "focused": False,
+                    "last_focused_at": None,
+                    "staleness_seconds": 0,
+                    "total_sessions": 0,
+                }
+
+            total = len(self._sessions)
+
+            # Focus-priority: pick session with most recent last_focused_at
+            focused_entries = [
+                e for e in self._sessions.values() if e.last_focused_at is not None
+            ]
+            if focused_entries:
+                best = max(
+                    focused_entries,
+                    key=lambda e: e.last_focused_at or datetime.min.replace(tzinfo=UTC),
+                )
+            else:
+                best = max(self._sessions.values(), key=lambda e: e.last_seen)
+
+            staleness = (now - best.last_seen).total_seconds()
+            return {
+                "session_id": best.session_id,
+                "page": best.page,
+                "workflow_id": best.workflow_id,
+                "workflow_name": best.workflow_name,
+                "focused": best.focused,
+                "last_focused_at": (
+                    best.last_focused_at.isoformat() if best.last_focused_at else None
+                ),
+                "staleness_seconds": int(staleness),
+                "total_sessions": total,
+            }
+
+    def get_all_sessions(self) -> list[dict[str, object]]:
+        """Return all active (non-expired) sessions."""
+        now = datetime.now(UTC)
+        with self._lock:
+            self._evict(now)
+            results: list[dict[str, object]] = []
+            for entry in sorted(
+                self._sessions.values(), key=lambda e: e.last_seen, reverse=True
+            ):
+                staleness = (now - entry.last_seen).total_seconds()
+                results.append(
+                    {
+                        "session_id": entry.session_id,
+                        "page": entry.page,
+                        "workflow_id": entry.workflow_id,
+                        "workflow_name": entry.workflow_name,
+                        "focused": entry.focused,
+                        "last_seen": entry.last_seen.isoformat(),
+                        "last_focused_at": (
+                            entry.last_focused_at.isoformat()
+                            if entry.last_focused_at
+                            else None
+                        ),
+                        "staleness_seconds": int(staleness),
+                    }
+                )
+            return results

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
@@ -32,6 +32,8 @@ class BrowserContextStore:
         self._ttl = timedelta(seconds=ttl_seconds)
         self._sessions: dict[str, BrowserContextEntry] = {}
         self._lock = threading.Lock()
+        self._cleanup_timer: threading.Timer | None = None
+        self._start_periodic_cleanup()
 
     def upsert(
         self,
@@ -59,6 +61,20 @@ class BrowserContextStore:
                 last_seen=now,
                 last_focused_at=last_focused_at,
             )
+
+    def _start_periodic_cleanup(self) -> None:
+        """Schedule a background cleanup every TTL interval."""
+        interval = self._ttl.total_seconds()
+        self._cleanup_timer = threading.Timer(interval, self._periodic_cleanup)
+        self._cleanup_timer.daemon = True
+        self._cleanup_timer.start()
+
+    def _periodic_cleanup(self) -> None:
+        """Run eviction and reschedule the next cleanup."""
+        now = datetime.now(UTC)
+        with self._lock:
+            self._evict(now)
+        self._start_periodic_cleanup()
 
     def _evict(self, now: datetime) -> None:
         """Remove entries older than TTL. Must be called under lock."""

--- a/packages/sdk/src/orcheo_sdk/cli/main.py
+++ b/packages/sdk/src/orcheo_sdk/cli/main.py
@@ -16,6 +16,7 @@ import typer
 from rich.console import Console
 from orcheo_sdk.cli.agent_tool import agent_tool_app
 from orcheo_sdk.cli.auth import auth_app
+from orcheo_sdk.cli.browser_context.commands import browser_aware_app, context_app
 from orcheo_sdk.cli.cache import CacheManager
 from orcheo_sdk.cli.codegen import code_app
 from orcheo_sdk.cli.config import get_cache_dir, resolve_settings
@@ -105,6 +106,8 @@ app.add_typer(code_app, name="code")
 app.add_typer(config_app, name="config")
 app.add_typer(agent_tool_app, name="agent-tool")
 app.add_typer(service_token_app, name="token")
+app.add_typer(browser_aware_app, name="browser-aware")
+app.add_typer(context_app, name="context")
 install_app = typer.Typer(
     help="Install or upgrade the Orcheo stack components.",
     invoke_without_command=True,

--- a/project/initiatives/browser_context/3_plan.md
+++ b/project/initiatives/browser_context/3_plan.md
@@ -27,17 +27,17 @@ Deliver the Browser Context Bridge feature in three phases: local HTTP server wi
 
 #### Task Checklist
 
-- [ ] Task 1.1: Implement `BrowserContextStore` — in-memory store keyed by `session_id` with 300-second TTL eviction and focus-priority resolution using `last_focused_at` timestamp. Single-user (runs locally in HTTP server process)
+- [x] Task 1.1: Implement `BrowserContextStore` — in-memory store keyed by `session_id` with 300-second TTL eviction and focus-priority resolution using `last_focused_at` timestamp. Single-user (runs locally in HTTP server process)
   - Dependencies: None
-- [ ] Task 1.2: Implement context relay HTTP endpoints on the HTTP server — `POST /context` (upsert), `GET /context` (active context with focus-priority, `staleness_seconds`, `total_sessions`), `GET /context/sessions` (all sessions). CORS enabled for Canvas origin. Bound to `localhost` only
+- [x] Task 1.2: Implement context relay HTTP endpoints on the HTTP server — `POST /context` (upsert), `GET /context` (active context with focus-priority, `staleness_seconds`, `total_sessions`), `GET /context/sessions` (all sessions). CORS enabled for Canvas origin. Bound to `localhost` only
   - Dependencies: Task 1.1
-- [ ] Task 1.3: Document that agents use existing CLI commands for workflow operations — `orcheo workflow show`, `orcheo workflow download`, `orcheo workflow upload`, `orcheo workflow create`, etc. No additional tool definitions needed
+- [x] Task 1.3: Document that agents use existing CLI commands for workflow operations — `orcheo workflow show`, `orcheo workflow download`, `orcheo workflow upload`, `orcheo workflow create`, etc. No additional tool definitions needed
   - Dependencies: None
-- [ ] Task 1.4: Implement `orcheo browser-aware` command — starts a plain HTTP server (default `localhost:3333`) serving context relay endpoints; `--port` flag
+- [x] Task 1.4: Implement `orcheo browser-aware` command — starts a plain HTTP server (default `localhost:3333`) serving context relay endpoints; `--port` flag
   - Dependencies: Task 1.2
-- [ ] Task 1.5: Write unit tests for `BrowserContextStore` (TTL, focus-priority), context relay endpoints (CORS, upsert, GET response), and CLI commands (`orcheo context`, `orcheo context sessions`). Smoke test for `orcheo browser-aware`
+- [x] Task 1.5: Write unit tests for `BrowserContextStore` (TTL, focus-priority), context relay endpoints (CORS, upsert, GET response), and CLI commands (`orcheo context`, `orcheo context sessions`). Smoke test for `orcheo browser-aware`
   - Dependencies: Task 1.4
-- [ ] Task 1.6: Implement `orcheo context` and `orcheo context sessions` CLI commands — thin wrappers that hit `GET /context` and `GET /context/sessions` on the localhost HTTP server started by `orcheo browser-aware`
+- [x] Task 1.6: Implement `orcheo context` and `orcheo context sessions` CLI commands — thin wrappers that hit `GET /context` and `GET /context/sessions` on the localhost HTTP server started by `orcheo browser-aware`
   - Dependencies: Task 1.2
 
 ---
@@ -48,11 +48,11 @@ Deliver the Browser Context Bridge feature in three phases: local HTTP server wi
 
 #### Task Checklist
 
-- [ ] Task 2.1: Implement `BrowserContextProvider` React component — generates stable `sessionId` from `sessionStorage`; posts page identity (`page`, `workflow_id`, `workflow_name`, `focused`) to `http://localhost:3333/context` on `setPageContext()` call; attaches `visibilitychange`/`focus`/`blur` listeners; starts/stops 5-second heartbeat based on visibility. Silently handles connection failures (HTTP server not running)
+- [x] Task 2.1: Implement `BrowserContextProvider` React component — generates stable `sessionId` from `sessionStorage`; posts page identity (`page`, `workflow_id`, `workflow_name`, `focused`) to `http://localhost:3333/context` on `setPageContext()` call; attaches `visibilitychange`/`focus`/`blur` listeners; starts/stops 5-second heartbeat based on visibility. Silently handles connection failures (HTTP server not running)
   - Dependencies: Milestone 1
-- [ ] Task 2.2: Mount `BrowserContextProvider` in `App.tsx`; call `setPageContext()` in `WorkflowGallery` (on load) and `WorkflowCanvas` (on workflow load)
+- [x] Task 2.2: Mount `BrowserContextProvider` in `App.tsx`; call `setPageContext()` in `WorkflowGallery` (on load) and `WorkflowCanvas` (on workflow load)
   - Dependencies: Task 2.1
-- [ ] Task 2.3: Write unit tests for `BrowserContextProvider` — fires POST to localhost on route change, heartbeat start/stop on visibility change, focus flag accuracy, graceful failure when HTTP server is down
+- [x] Task 2.3: Write unit tests for `BrowserContextProvider` — fires POST to localhost on route change, heartbeat start/stop on visibility change, focus flag accuracy, graceful failure when HTTP server is down
   - Dependencies: Task 2.1
 - [ ] Task 2.4: End-to-end manual QA: open Canvas gallery → `orcheo context` returns gallery page; navigate to workflow → context updates within 2 seconds; open two tabs → `orcheo context sessions` shows both
   - Dependencies: Tasks 2.2, 2.3
@@ -65,11 +65,11 @@ Deliver the Browser Context Bridge feature in three phases: local HTTP server wi
 
 #### Task Checklist
 
-- [ ] Task 3.1: Add "Connect your agent" section to Canvas Settings — CLI quickstart instructions with copy button (links to `orcheo auth login` for token setup), active session count indicator
+- [x] Task 3.1: Add "Connect your agent" section to Canvas Settings — CLI quickstart instructions with copy button (links to `orcheo auth login` for token setup), active session count indicator
   - Dependencies: Milestone 2
-- [ ] Task 3.2: Write and publish onboarding documentation — "Connect Claude Code to Orcheo Canvas" and "Connect Cursor to Orcheo Canvas" guides
+- [x] Task 3.2: Write and publish onboarding documentation — "Connect Claude Code to Orcheo Canvas" and "Connect Cursor to Orcheo Canvas" guides
   - Dependencies: Milestones 1, 2
-- [ ] Task 3.3: Run `make lint`, `make test`, `make canvas-lint`, `make canvas-test` — all green with zero errors
+- [x] Task 3.3: Run `make lint`, `make test`, `make canvas-lint`, `make canvas-test` — all green with zero errors
   - Dependencies: All previous tasks
 
 ---

--- a/tests/sdk/test_browser_context_commands.py
+++ b/tests/sdk/test_browser_context_commands.py
@@ -5,6 +5,7 @@ import json
 import threading
 from datetime import UTC, datetime
 from http.server import HTTPServer
+from unittest.mock import patch
 import httpx
 import pytest
 from typer.testing import CliRunner
@@ -132,3 +133,90 @@ def test_context_sessions_empty(
     result = runner.invoke(app, ["context", "sessions", "--port", str(port)], env=env)
     assert result.exit_code == 0
     assert "no active" in result.stdout.lower()
+
+
+def test_browser_aware_starts_server(runner: CliRunner, env: dict[str, str]) -> None:
+    """orcheo browser-aware invokes run_server with correct arguments."""
+    with patch("orcheo_sdk.cli.browser_context.server.run_server") as mock_run_server:
+        result = runner.invoke(app, ["browser-aware", "--port", "4444"], env=env)
+    assert result.exit_code == 0
+    mock_run_server.assert_called_once_with(host="localhost", port=4444)
+    assert "4444" in result.stdout
+
+
+def test_context_no_server_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """orcheo context outputs JSON error in machine mode when server not running."""
+    result = runner.invoke(app, ["context", "--port", "19999"], env=machine_env)
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert "error" in data
+
+
+def test_context_no_sessions_machine_mode(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    _context_server: tuple[int, HTTPServer],
+) -> None:
+    """orcheo context outputs JSON warning in machine mode when no sessions exist."""
+    port, _ = _context_server
+    result = runner.invoke(app, ["context", "--port", str(port)], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert "warning" in data
+    assert data["total_sessions"] == 0
+
+
+def test_context_sessions_no_server_machine_mode(
+    runner: CliRunner, machine_env: dict[str, str]
+) -> None:
+    """orcheo context sessions outputs JSON error in machine mode when no server."""
+    result = runner.invoke(
+        app, ["context", "sessions", "--port", "19999"], env=machine_env
+    )
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert "error" in data
+
+
+def test_context_sessions_empty_machine_mode(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    _context_server: tuple[int, HTTPServer],
+) -> None:
+    """orcheo context sessions outputs empty JSON list in machine mode."""
+    port, _ = _context_server
+    result = runner.invoke(
+        app, ["context", "sessions", "--port", str(port)], env=machine_env
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == []
+
+
+def test_context_sessions_machine_output(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    _context_server: tuple[int, HTTPServer],
+) -> None:
+    """orcheo context sessions outputs JSON list of sessions in machine mode."""
+    port, _ = _context_server
+    httpx.post(
+        f"http://localhost:{port}/context",
+        json={
+            "session_id": "tab-machine",
+            "page": "canvas",
+            "workflow_id": "wf-1",
+            "workflow_name": "Machine Flow",
+            "focused": True,
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+    )
+    result = runner.invoke(
+        app, ["context", "sessions", "--port", str(port)], env=machine_env
+    )
+    assert result.exit_code == 0
+    sessions = json.loads(result.stdout)
+    assert isinstance(sessions, list)
+    assert any(s["session_id"] == "tab-machine" for s in sessions)

--- a/tests/sdk/test_browser_context_commands.py
+++ b/tests/sdk/test_browser_context_commands.py
@@ -1,0 +1,134 @@
+"""Tests for browser context CLI commands."""
+
+from __future__ import annotations
+import json
+import threading
+from datetime import UTC, datetime
+from http.server import HTTPServer
+import httpx
+import pytest
+from typer.testing import CliRunner
+from orcheo_sdk.cli.browser_context.server import create_request_handler
+from orcheo_sdk.cli.browser_context.store import BrowserContextStore
+from orcheo_sdk.cli.main import app
+
+
+def _ts() -> str:
+    """Return a fresh ISO 8601 timestamp string."""
+    return datetime.now(UTC).isoformat()
+
+
+@pytest.fixture()
+def _context_server() -> tuple[int, HTTPServer]:
+    """Start a context server on a random port."""
+    store = BrowserContextStore()
+    handler = create_request_handler(store)
+    server = HTTPServer(("localhost", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield port, server
+    server.shutdown()
+
+
+def test_context_no_server(runner: CliRunner, env: dict[str, str]) -> None:
+    """orcheo context fails gracefully when server is not running."""
+    result = runner.invoke(app, ["context", "--port", "19999"], env=env)
+    assert result.exit_code == 1
+    assert (
+        "browser-aware" in result.stdout.lower() or "connect" in result.stdout.lower()
+    )
+
+
+def test_context_no_sessions(
+    runner: CliRunner, env: dict[str, str], _context_server: tuple[int, HTTPServer]
+) -> None:
+    """orcheo context shows warning when no sessions exist."""
+    port, _ = _context_server
+    result = runner.invoke(app, ["context", "--port", str(port)], env=env)
+    assert result.exit_code == 0
+    assert "no active" in result.stdout.lower()
+
+
+def test_context_with_session(
+    runner: CliRunner, env: dict[str, str], _context_server: tuple[int, HTTPServer]
+) -> None:
+    """orcheo context shows active context after posting a session."""
+    port, _ = _context_server
+    httpx.post(
+        f"http://localhost:{port}/context",
+        json={
+            "session_id": "tab-1",
+            "page": "canvas",
+            "workflow_id": "wf-abc",
+            "workflow_name": "My Flow",
+            "focused": True,
+            "timestamp": _ts(),
+        },
+    )
+    result = runner.invoke(app, ["context", "--port", str(port)], env=env)
+    assert result.exit_code == 0
+    assert "wf-abc" in result.stdout
+
+
+def test_context_sessions_command(
+    runner: CliRunner, env: dict[str, str], _context_server: tuple[int, HTTPServer]
+) -> None:
+    """orcheo context sessions lists all sessions."""
+    port, _ = _context_server
+    for i in range(2):
+        httpx.post(
+            f"http://localhost:{port}/context",
+            json={
+                "session_id": f"tab-{i}",
+                "page": "canvas",
+                "workflow_id": f"wf-{i}",
+                "workflow_name": f"Flow {i}",
+                "focused": i == 0,
+                "timestamp": _ts(),
+            },
+        )
+    result = runner.invoke(app, ["context", "sessions", "--port", str(port)], env=env)
+    assert result.exit_code == 0
+    assert "tab-0" in result.stdout
+    assert "tab-1" in result.stdout
+
+
+def test_context_machine_output(
+    runner: CliRunner,
+    machine_env: dict[str, str],
+    _context_server: tuple[int, HTTPServer],
+) -> None:
+    """orcheo context outputs JSON in machine mode."""
+    port, _ = _context_server
+    httpx.post(
+        f"http://localhost:{port}/context",
+        json={
+            "session_id": "tab-1",
+            "page": "canvas",
+            "workflow_id": "wf-abc",
+            "workflow_name": "My Flow",
+            "focused": True,
+            "timestamp": _ts(),
+        },
+    )
+    result = runner.invoke(app, ["context", "--port", str(port)], env=machine_env)
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["session_id"] == "tab-1"
+
+
+def test_context_sessions_no_server(runner: CliRunner, env: dict[str, str]) -> None:
+    """orcheo context sessions fails gracefully when server is not running."""
+    result = runner.invoke(app, ["context", "sessions", "--port", "19999"], env=env)
+    assert result.exit_code == 1
+
+
+def test_context_sessions_empty(
+    runner: CliRunner, env: dict[str, str], _context_server: tuple[int, HTTPServer]
+) -> None:
+    """orcheo context sessions shows message when no sessions exist."""
+    port, _ = _context_server
+    result = runner.invoke(app, ["context", "sessions", "--port", str(port)], env=env)
+    assert result.exit_code == 0
+    assert "no active" in result.stdout.lower()

--- a/tests/sdk/test_browser_context_server.py
+++ b/tests/sdk/test_browser_context_server.py
@@ -83,11 +83,30 @@ def test_get_sessions(context_server: tuple[str, HTTPServer]) -> None:
     assert len(sessions) == 3
 
 
-def test_cors_headers(context_server: tuple[str, HTTPServer]) -> None:
-    """All responses include CORS headers."""
+def test_cors_headers_without_origin(context_server: tuple[str, HTTPServer]) -> None:
+    """Requests without an Origin header get an empty CORS origin."""
     base_url, _ = context_server
     resp = httpx.get(f"{base_url}/context")
-    assert resp.headers["access-control-allow-origin"] == "*"
+    assert resp.headers["access-control-allow-origin"] == ""
+
+
+def test_cors_headers_with_localhost_origin(
+    context_server: tuple[str, HTTPServer],
+) -> None:
+    """Requests from a localhost origin are reflected back."""
+    base_url, _ = context_server
+    origin = "http://localhost:5173"
+    resp = httpx.get(f"{base_url}/context", headers={"Origin": origin})
+    assert resp.headers["access-control-allow-origin"] == origin
+
+
+def test_cors_headers_rejects_non_localhost(
+    context_server: tuple[str, HTTPServer],
+) -> None:
+    """Requests from non-localhost origins get an empty CORS origin."""
+    base_url, _ = context_server
+    resp = httpx.get(f"{base_url}/context", headers={"Origin": "http://evil.com"})
+    assert resp.headers["access-control-allow-origin"] == ""
 
 
 def test_options_preflight(context_server: tuple[str, HTTPServer]) -> None:

--- a/tests/sdk/test_browser_context_server.py
+++ b/tests/sdk/test_browser_context_server.py
@@ -1,0 +1,143 @@
+"""Tests for browser context HTTP server endpoints."""
+
+from __future__ import annotations
+import threading
+from datetime import UTC, datetime
+from http.server import HTTPServer
+import httpx
+import pytest
+from orcheo_sdk.cli.browser_context.server import create_request_handler
+from orcheo_sdk.cli.browser_context.store import BrowserContextStore
+
+
+def _ts() -> str:
+    """Return a fresh ISO 8601 timestamp string."""
+    return datetime.now(UTC).isoformat()
+
+
+@pytest.fixture()
+def context_server() -> tuple[str, HTTPServer]:
+    """Start a context server on a random port and return (base_url, server)."""
+    store = BrowserContextStore()
+    handler = create_request_handler(store)
+    server = HTTPServer(("localhost", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://localhost:{port}", server
+    server.shutdown()
+
+
+def test_get_context_empty(context_server: tuple[str, HTTPServer]) -> None:
+    """GET /context on empty store returns null context."""
+    base_url, _ = context_server
+    resp = httpx.get(f"{base_url}/context")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] is None
+    assert data["total_sessions"] == 0
+
+
+def test_post_then_get_context(context_server: tuple[str, HTTPServer]) -> None:
+    """POST /context then GET /context returns the posted context."""
+    base_url, _ = context_server
+    payload = {
+        "session_id": "tab-1",
+        "page": "canvas",
+        "workflow_id": "wf-abc",
+        "workflow_name": "Test Flow",
+        "focused": True,
+        "timestamp": _ts(),
+    }
+    resp = httpx.post(f"{base_url}/context", json=payload)
+    assert resp.status_code == 204
+
+    resp = httpx.get(f"{base_url}/context")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] == "tab-1"
+    assert data["page"] == "canvas"
+    assert data["workflow_id"] == "wf-abc"
+    assert data["total_sessions"] == 1
+
+
+def test_get_sessions(context_server: tuple[str, HTTPServer]) -> None:
+    """GET /context/sessions returns all sessions."""
+    base_url, _ = context_server
+    for i in range(3):
+        httpx.post(
+            f"{base_url}/context",
+            json={
+                "session_id": f"tab-{i}",
+                "page": "gallery",
+                "workflow_id": None,
+                "workflow_name": None,
+                "focused": i == 0,
+                "timestamp": _ts(),
+            },
+        )
+
+    resp = httpx.get(f"{base_url}/context/sessions")
+    assert resp.status_code == 200
+    sessions = resp.json()
+    assert len(sessions) == 3
+
+
+def test_cors_headers(context_server: tuple[str, HTTPServer]) -> None:
+    """All responses include CORS headers."""
+    base_url, _ = context_server
+    resp = httpx.get(f"{base_url}/context")
+    assert resp.headers["access-control-allow-origin"] == "*"
+
+
+def test_options_preflight(context_server: tuple[str, HTTPServer]) -> None:
+    """OPTIONS request returns 204 with CORS headers."""
+    base_url, _ = context_server
+    resp = httpx.options(f"{base_url}/context")
+    assert resp.status_code == 204
+    assert "access-control-allow-origin" in resp.headers
+
+
+def test_post_missing_fields(context_server: tuple[str, HTTPServer]) -> None:
+    """POST /context with missing required fields returns 400."""
+    base_url, _ = context_server
+    resp = httpx.post(f"{base_url}/context", json={"session_id": "x"})
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "missing fields" in data["error"]
+
+
+def test_post_invalid_json(context_server: tuple[str, HTTPServer]) -> None:
+    """POST /context with invalid JSON returns 400."""
+    base_url, _ = context_server
+    resp = httpx.post(
+        f"{base_url}/context",
+        content=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+def test_post_empty_body(context_server: tuple[str, HTTPServer]) -> None:
+    """POST /context with empty body returns 400."""
+    base_url, _ = context_server
+    resp = httpx.post(
+        f"{base_url}/context",
+        content=b"",
+        headers={"Content-Type": "application/json", "Content-Length": "0"},
+    )
+    assert resp.status_code == 400
+
+
+def test_unknown_path(context_server: tuple[str, HTTPServer]) -> None:
+    """GET on unknown path returns 404."""
+    base_url, _ = context_server
+    resp = httpx.get(f"{base_url}/unknown")
+    assert resp.status_code == 404
+
+
+def test_post_unknown_path(context_server: tuple[str, HTTPServer]) -> None:
+    """POST on unknown path returns 404."""
+    base_url, _ = context_server
+    resp = httpx.post(f"{base_url}/unknown", json={})
+    assert resp.status_code == 404

--- a/tests/sdk/test_browser_context_server.py
+++ b/tests/sdk/test_browser_context_server.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 import threading
 from datetime import UTC, datetime
 from http.server import HTTPServer
+from unittest.mock import patch
 import httpx
 import pytest
-from orcheo_sdk.cli.browser_context.server import create_request_handler
+from orcheo_sdk.cli.browser_context.server import (
+    _cors_headers,
+    _resolve_timestamp,
+    create_request_handler,
+    run_server,
+)
 from orcheo_sdk.cli.browser_context.store import BrowserContextStore
 
 
@@ -160,3 +166,85 @@ def test_post_unknown_path(context_server: tuple[str, HTTPServer]) -> None:
     base_url, _ = context_server
     resp = httpx.post(f"{base_url}/unknown", json={})
     assert resp.status_code == 404
+
+
+def test_cors_headers_urlparse_exception() -> None:
+    """_cors_headers returns empty origin when urlparse raises."""
+    with patch("urllib.parse.urlparse", side_effect=Exception("bad parse")):
+        headers = _cors_headers("http://localhost:5173")
+    assert headers["Access-Control-Allow-Origin"] == ""
+
+
+def test_resolve_timestamp_invalid() -> None:
+    """_resolve_timestamp falls back to now() when timestamp is unparseable."""
+    before = datetime.now(UTC)
+    result = _resolve_timestamp({"timestamp": "not-a-date"})
+    after = datetime.now(UTC)
+    assert before <= result <= after
+
+
+def test_resolve_timestamp_no_key() -> None:
+    """_resolve_timestamp falls back to now() when timestamp key is absent."""
+    before = datetime.now(UTC)
+    result = _resolve_timestamp({})
+    after = datetime.now(UTC)
+    assert before <= result <= after
+
+
+def test_run_server_keyboard_interrupt() -> None:
+    """run_server shuts down cleanly on KeyboardInterrupt."""
+
+    class _FakeServer:
+        server_address = ("localhost", 9876)
+
+        def serve_forever(self) -> None:
+            raise KeyboardInterrupt
+
+        def server_close(self) -> None:
+            pass
+
+    with patch(
+        "orcheo_sdk.cli.browser_context.server.HTTPServer",
+        return_value=_FakeServer(),
+    ):
+        # Should not raise
+        run_server(host="localhost", port=9876)
+
+
+def test_run_server_port_retry() -> None:
+    """run_server retries the next port when the first is unavailable."""
+    call_count = 0
+
+    class _FakeServer:
+        server_address = ("localhost", 9878)
+
+        def serve_forever(self) -> None:
+            raise KeyboardInterrupt
+
+        def server_close(self) -> None:
+            pass
+
+    def _fake_http_server(addr: tuple[str, int], handler: type) -> _FakeServer:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("port in use")
+        return _FakeServer()
+
+    with patch(
+        "orcheo_sdk.cli.browser_context.server.HTTPServer",
+        side_effect=_fake_http_server,
+    ):
+        run_server(host="localhost", port=9877, max_port_attempts=3)
+
+    assert call_count == 2
+
+
+def test_run_server_all_ports_busy() -> None:
+    """run_server raises OSError when all port attempts fail."""
+    with patch(
+        "orcheo_sdk.cli.browser_context.server.HTTPServer",
+        side_effect=OSError("port in use"),
+    ):
+        with pytest.raises(OSError, match="Could not bind"):
+            run_server(host="localhost", port=9900, max_port_attempts=3)

--- a/tests/sdk/test_browser_context_store.py
+++ b/tests/sdk/test_browser_context_store.py
@@ -1,0 +1,239 @@
+"""Tests for BrowserContextStore — TTL eviction and focus-priority resolution."""
+
+from __future__ import annotations
+from datetime import UTC, datetime, timedelta
+from orcheo_sdk.cli.browser_context.store import BrowserContextStore
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def test_empty_store_returns_null_context() -> None:
+    """An empty store returns a null active context."""
+    store = BrowserContextStore()
+    result = store.get_active()
+    assert result["session_id"] is None
+    assert result["page"] is None
+    assert result["total_sessions"] == 0
+
+
+def test_upsert_and_get_active() -> None:
+    """A single upsert makes that session the active one."""
+    store = BrowserContextStore()
+    now = _now()
+    store.upsert(
+        session_id="s1",
+        page="canvas",
+        workflow_id="wf-1",
+        workflow_name="My Flow",
+        focused=True,
+        timestamp=now,
+    )
+    result = store.get_active()
+    assert result["session_id"] == "s1"
+    assert result["page"] == "canvas"
+    assert result["workflow_id"] == "wf-1"
+    assert result["workflow_name"] == "My Flow"
+    assert result["focused"] is True
+    assert result["total_sessions"] == 1
+
+
+def test_focus_priority_resolution() -> None:
+    """The session with the most recent last_focused_at wins."""
+    store = BrowserContextStore()
+    now = _now()
+    t1 = now - timedelta(seconds=20)
+    t2 = now - timedelta(seconds=10)
+
+    store.upsert(
+        session_id="s1",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=True,
+        timestamp=t1,
+    )
+    store.upsert(
+        session_id="s2",
+        page="canvas",
+        workflow_id="wf-2",
+        workflow_name="Flow 2",
+        focused=True,
+        timestamp=t2,
+    )
+    # Update s1 more recently but without focus
+    t3 = now
+    store.upsert(
+        session_id="s1",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=t3,
+    )
+
+    result = store.get_active()
+    # s2 was focused at t2; s1 was focused at t1 (earlier), so s2 wins
+    assert result["session_id"] == "s2"
+    assert result["total_sessions"] == 2
+
+
+def test_fallback_to_most_recently_seen() -> None:
+    """When no sessions have focus history, the most recently seen wins."""
+    store = BrowserContextStore()
+    now = _now()
+    t1 = now - timedelta(seconds=10)
+    t2 = now
+
+    store.upsert(
+        session_id="s1",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=t1,
+    )
+    store.upsert(
+        session_id="s2",
+        page="canvas",
+        workflow_id="wf-2",
+        workflow_name="Flow 2",
+        focused=False,
+        timestamp=t2,
+    )
+
+    result = store.get_active()
+    assert result["session_id"] == "s2"
+
+
+def test_ttl_eviction() -> None:
+    """Sessions older than TTL are evicted."""
+    store = BrowserContextStore(ttl_seconds=10)
+    old_time = _now() - timedelta(seconds=20)
+    store.upsert(
+        session_id="expired",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=old_time,
+    )
+    result = store.get_active()
+    assert result["total_sessions"] == 0
+    assert result["session_id"] is None
+
+
+def test_ttl_eviction_preserves_fresh() -> None:
+    """Only expired sessions are evicted; fresh ones remain."""
+    store = BrowserContextStore(ttl_seconds=10)
+    old_time = _now() - timedelta(seconds=20)
+    store.upsert(
+        session_id="expired",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=old_time,
+    )
+    store.upsert(
+        session_id="fresh",
+        page="canvas",
+        workflow_id="wf-1",
+        workflow_name="Fresh",
+        focused=True,
+    )
+    result = store.get_active()
+    assert result["total_sessions"] == 1
+    assert result["session_id"] == "fresh"
+
+
+def test_get_all_sessions() -> None:
+    """get_all_sessions returns all non-expired sessions ordered by last_seen."""
+    store = BrowserContextStore()
+    now = _now()
+    t1 = now - timedelta(seconds=10)
+    t2 = now
+
+    store.upsert(
+        session_id="s1",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=t1,
+    )
+    store.upsert(
+        session_id="s2",
+        page="canvas",
+        workflow_id="wf-2",
+        workflow_name="Flow 2",
+        focused=True,
+        timestamp=t2,
+    )
+
+    sessions = store.get_all_sessions()
+    assert len(sessions) == 2
+    # Most recently seen first
+    assert sessions[0]["session_id"] == "s2"
+    assert sessions[1]["session_id"] == "s1"
+
+
+def test_upsert_updates_existing() -> None:
+    """Upserting the same session_id updates the entry."""
+    store = BrowserContextStore()
+    now = _now()
+    t1 = now - timedelta(seconds=10)
+    t2 = now
+
+    store.upsert(
+        session_id="s1",
+        page="gallery",
+        workflow_id=None,
+        workflow_name=None,
+        focused=False,
+        timestamp=t1,
+    )
+    store.upsert(
+        session_id="s1",
+        page="canvas",
+        workflow_id="wf-1",
+        workflow_name="My Flow",
+        focused=True,
+        timestamp=t2,
+    )
+
+    result = store.get_active()
+    assert result["session_id"] == "s1"
+    assert result["page"] == "canvas"
+    assert result["workflow_id"] == "wf-1"
+    assert result["total_sessions"] == 1
+
+
+def test_focus_preserved_across_unfocused_update() -> None:
+    """last_focused_at is preserved when a later update has focused=False."""
+    store = BrowserContextStore()
+    now = _now()
+    t1 = now - timedelta(seconds=10)
+    t2 = now
+
+    store.upsert(
+        session_id="s1",
+        page="canvas",
+        workflow_id="wf-1",
+        workflow_name="Flow",
+        focused=True,
+        timestamp=t1,
+    )
+    store.upsert(
+        session_id="s1",
+        page="canvas",
+        workflow_id="wf-1",
+        workflow_name="Flow",
+        focused=False,
+        timestamp=t2,
+    )
+
+    result = store.get_active()
+    # last_focused_at should still be t1
+    assert result["last_focused_at"] == t1.isoformat()


### PR DESCRIPTION
## Summary

This PR adds a browser-context bridge between Orcheo Canvas and the CLI so coding agents can discover the active Canvas page and workflow directly from the user's browser session.

It introduces a local browser-aware server and CLI commands for reading active context, wires Canvas to publish page/workflow context automatically, and adds onboarding UX/docs for connecting agents such as Claude Code or Cursor.

## Main Changes

### CLI and SDK
- Added a new browser context module in the SDK.
- Introduced `orcheo browser-aware` to start a local HTTP bridge on `localhost:3333`.
- Introduced `orcheo context` to show the active Canvas context.
- Introduced `orcheo context sessions` to list all active Canvas tabs/sessions.
- Added an in-memory browser context store with:
  - TTL-based session eviction
  - focus-priority selection of the active session
  - session metadata including page, workflow, and staleness

### Browser Context Server
- Added localhost HTTP endpoints for Canvas-to-CLI context relay:
  - `POST /context`
  - `GET /context`
  - `GET /context/sessions`
- Added request validation, CORS handling, and active-session resolution.

### Canvas Integration
- Added a browser context provider and hooks to publish Canvas context to the local bridge.
- Wrapped the app in the new provider.
- Wired page context updates from:
  - workflow gallery
  - workflow canvas
- Context updates include page type, workflow ID, workflow name, focus state, and heartbeat updates for active tabs.

### Settings and Onboarding
- Added a new **Connect Agent** tab in Canvas settings.
- Included quickstart instructions for authenticating the CLI and starting the browser-aware bridge.
- Added copy buttons for key CLI commands.
- Added live connection/session status in settings.

### Documentation and Tests
- Added a new `connect_coding_agent` guide covering:
  - quick start
  - Claude Code flow
  - Cursor flow
  - multi-tab behavior
  - troubleshooting
- Added tests for:
  - browser context store behavior
  - browser context server endpoints
  - CLI commands
  - frontend browser-context hook
- Updated the browser-context initiative plan to mark implemented tasks complete.

## Outcome

With this change, a coding agent can infer what workflow the user is currently viewing in Canvas and use existing workflow CLI commands to inspect, download, modify, and upload workflow scripts without manual copy-paste between the browser and terminal.
