### PR TITLE
Add MongoDB projection support and narrow workflow tool outputs

### DIFF
--- a/apps/canvas/src/features/workflow/data/templates/assets/mongodb-qa-agent/workflow.py
+++ b/apps/canvas/src/features/workflow/data/templates/assets/mongodb-qa-agent/workflow.py
@@ -92,6 +92,7 @@ def orcheo_workflow() -> StateGraph:
                 "description": "Hybrid search over MongoDB Atlas data.",
                 "graph": build_hybrid_search_tool_graph(),
                 "args_schema": HybridSearchInput,
+                "output_path": "results.format_results.markdown",
             }
         ],
     )

--- a/examples/mongodb_agent/03_qa_agent.py
+++ b/examples/mongodb_agent/03_qa_agent.py
@@ -7,6 +7,7 @@ LangChain messages and generates a reply.
 
 from langgraph.graph import END, START, StateGraph
 from pydantic import BaseModel, Field
+from typing_extensions import TypedDict
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode
 from orcheo.nodes.conversational_search import (
@@ -23,9 +24,19 @@ class HybridSearchInput(BaseModel):
     query: str = Field(description="User question to search for.")
 
 
+class HybridSearchToolOutput(TypedDict):
+    """Narrow output returned by the workflow tool."""
+
+    markdown: str
+
+
 def build_hybrid_search_tool_graph() -> StateGraph:
-    """Build a subworkflow used as an agent tool."""
-    graph = StateGraph(State)
+    """Build a subworkflow used as an agent tool.
+
+    The explicit output schema keeps the tool payload compact so only the
+    formatted markdown is returned to the calling agent.
+    """
+    graph = StateGraph(State, output_schema=HybridSearchToolOutput)
     graph.add_node(
         "query_embedding",
         TextEmbeddingNode(

--- a/examples/mongodb_agent/03_qa_agent.py
+++ b/examples/mongodb_agent/03_qa_agent.py
@@ -7,7 +7,6 @@ LangChain messages and generates a reply.
 
 from langgraph.graph import END, START, StateGraph
 from pydantic import BaseModel, Field
-from typing_extensions import TypedDict
 from orcheo.graph.state import State
 from orcheo.nodes.ai import AgentNode
 from orcheo.nodes.conversational_search import (
@@ -24,19 +23,13 @@ class HybridSearchInput(BaseModel):
     query: str = Field(description="User question to search for.")
 
 
-class HybridSearchToolOutput(TypedDict):
-    """Narrow output returned by the workflow tool."""
-
-    markdown: str
-
-
 def build_hybrid_search_tool_graph() -> StateGraph:
     """Build a subworkflow used as an agent tool.
 
-    The explicit output schema keeps the tool payload compact so only the
-    formatted markdown is returned to the calling agent.
+    The formatter writes its markdown output under ``results.format_results``,
+    so the parent tool selects that nested field via ``output_path``.
     """
-    graph = StateGraph(State, output_schema=HybridSearchToolOutput)
+    graph = StateGraph(State)
     graph.add_node(
         "query_embedding",
         TextEmbeddingNode(
@@ -110,6 +103,7 @@ async def orcheo_workflow() -> StateGraph:
                 "description": "Hybrid search over MongoDB Atlas data.",
                 "graph": build_hybrid_search_tool_graph(),
                 "args_schema": HybridSearchInput,
+                "output_path": "results.format_results.markdown",
             }
         ],
     )

--- a/src/orcheo/nodes/agent_tools/tools.py
+++ b/src/orcheo/nodes/agent_tools/tools.py
@@ -151,6 +151,7 @@ async def mongodb_find(
     database: str,
     collection: str,
     filter: dict[str, Any] | None = None,
+    projection: dict[str, Any] | list[str] | None = None,
     sort: dict[str, int] | list[dict[str, int]] | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
@@ -163,6 +164,12 @@ async def mongodb_find(
         filter = {}
     if not isinstance(filter, dict):
         raise ValueError("mongodb_find requires a filter document")
+    if projection is not None and not isinstance(projection, (dict, list)):
+        raise ValueError("mongodb_find projection must be a dict or list")
+    if isinstance(projection, list) and not all(
+        isinstance(field, str) for field in projection
+    ):
+        raise ValueError("mongodb_find projection list entries must be strings")
     if limit is not None and not isinstance(limit, int):
         raise ValueError("mongodb_find limit must be an int")
 
@@ -174,6 +181,7 @@ async def mongodb_find(
         database=database,
         collection=collection,
         filter=filter,
+        projection=projection,
         sort=_normalize_mongodb_sort(sort),
         limit=limit,
     )

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -15,7 +15,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool, StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.graph import StateGraph
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from pydantic.json_schema import SkipJsonSchema
 from agentensor.tensor import TextTensor
 from orcheo.graph.state import State
@@ -85,6 +85,7 @@ def _create_workflow_tool_func(
     name: str,
     description: str,
     args_schema: type[BaseModel] | None,
+    output_path: str | None = None,
 ) -> StructuredTool:
     """Create a StructuredTool from a compiled workflow graph.
 
@@ -96,20 +97,28 @@ def _create_workflow_tool_func(
         name: Tool name
         description: Tool description
         args_schema: Optional Pydantic model for tool arguments
+        output_path: Optional dotted path selecting the final tool payload
 
     Returns:
         StructuredTool instance wrapping the workflow
     """
 
+    def select_output(result: Any) -> Any:
+        if output_path is None:
+            return result
+        return _select_workflow_tool_output(result, output_path, name)
+
     async def workflow_coroutine(**kwargs: Any) -> Any:
         """Execute the workflow graph asynchronously."""
         payload = {"inputs": kwargs, "results": {}, "messages": []}
-        return await _run_tool_graph(compiled_graph, payload)
+        result = await _run_tool_graph(compiled_graph, payload)
+        return select_output(result)
 
     def workflow_sync(**kwargs: Any) -> Any:
         """Execute the workflow graph synchronously."""
         payload = {"inputs": kwargs, "results": {}, "messages": []}
-        return asyncio.run(_run_tool_graph(compiled_graph, payload))
+        result = asyncio.run(_run_tool_graph(compiled_graph, payload))
+        return select_output(result)
 
     return StructuredTool.from_function(
         func=workflow_sync,
@@ -118,6 +127,49 @@ def _create_workflow_tool_func(
         description=description,
         args_schema=args_schema,
     )
+
+
+def _select_workflow_tool_output(
+    result: Any,
+    output_path: str,
+    tool_name: str,
+) -> Any:
+    """Select a nested output value from a workflow-tool result."""
+    current = result
+    for segment in output_path.split("."):
+        if isinstance(current, Mapping):
+            if segment not in current:
+                msg = (
+                    f"Workflow tool '{tool_name}' output_path '{output_path}' "
+                    f"could not resolve segment '{segment}'."
+                )
+                raise ValueError(msg)
+            current = current[segment]
+            continue
+        if isinstance(current, list):
+            try:
+                index = int(segment)
+            except ValueError as exc:
+                msg = (
+                    f"Workflow tool '{tool_name}' output_path '{output_path}' "
+                    "encountered a list and requires an integer segment."
+                )
+                raise ValueError(msg) from exc
+            try:
+                current = current[index]
+            except IndexError as exc:
+                msg = (
+                    f"Workflow tool '{tool_name}' output_path '{output_path}' "
+                    f"index {index} is out of range."
+                )
+                raise ValueError(msg) from exc
+            continue
+        msg = (
+            f"Workflow tool '{tool_name}' output_path '{output_path}' "
+            f"cannot descend into {type(current).__name__}."
+        )
+        raise ValueError(msg)
+    return current
 
 
 class WorkflowTool(BaseModel):
@@ -133,8 +185,21 @@ class WorkflowTool(BaseModel):
     """Workflow to be used as tool."""
     args_schema: type[BaseModel] | None = None
     """Input schema for the tool."""
+    output_path: str | None = None
+    """Optional dotted path selecting the value returned to the caller."""
     _compiled_graph: SkipJsonSchema[Runnable | None] = None
     """Cached compiled graph to avoid recompilation."""
+
+    @field_validator("output_path")
+    @classmethod
+    def _validate_output_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            msg = "output_path must not be empty"
+            raise ValueError(msg)
+        return normalized
 
     def get_compiled_graph(self) -> Runnable:
         """Get or compile the graph, caching the result.
@@ -321,6 +386,7 @@ class AgentNode(AINode):
                 name=wf_tool_def.name,
                 description=wf_tool_def.description,
                 args_schema=wf_tool_def.args_schema,
+                output_path=wf_tool_def.output_path,
             )
             tools.append(tool)
 

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -59,10 +59,17 @@ async def _run_tool_graph(
         return await compiled_graph.ainvoke(payload, config=config)
 
     last_values: Any | None = None
-    async for event in compiled_graph.astream(
+    stream_kwargs: dict[str, Any] = {
+        "config": config,
+        "stream_mode": ["updates", "values"],
+    }
+    output_keys = getattr(compiled_graph, "output_channels", None)
+    if output_keys is not None:
+        stream_kwargs["output_keys"] = output_keys
+
+    async for event in compiled_graph.astream(  # type: ignore[arg-type]
         payload,
-        config=config,  # type: ignore[arg-type]
-        stream_mode=["updates", "values"],
+        **stream_kwargs,
     ):
         if isinstance(event, tuple) and len(event) == 2:
             mode, data = event

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -64,7 +64,7 @@ async def _run_tool_graph(
         "stream_mode": ["updates", "values"],
     }
     output_keys = getattr(compiled_graph, "output_channels", None)
-    if output_keys is not None:
+    if output_keys is not None:  # pragma: no branch
         stream_kwargs["output_keys"] = output_keys
 
     async for event in compiled_graph.astream(  # type: ignore[arg-type]
@@ -201,7 +201,7 @@ class WorkflowTool(BaseModel):
     @classmethod
     def _validate_output_path(cls, value: str | None) -> str | None:
         if value is None:
-            return None
+            return None  # pragma: no cover - optional field
         normalized = value.strip()
         if not normalized:
             msg = "output_path must not be empty"

--- a/src/orcheo/nodes/deep_agent.py
+++ b/src/orcheo/nodes/deep_agent.py
@@ -142,6 +142,7 @@ class DeepAgentNode(AINode):
                 name=wf_tool_def.name,
                 description=wf_tool_def.description,
                 args_schema=wf_tool_def.args_schema,
+                output_path=wf_tool_def.output_path,
             )
             tools.append(tool)
 

--- a/src/orcheo/nodes/integrations/databases/mongodb/base.py
+++ b/src/orcheo/nodes/integrations/databases/mongodb/base.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 import atexit
+import base64
 from collections.abc import Awaitable, Callable, Mapping
+from datetime import date, datetime, time
+from decimal import Decimal
 from threading import Lock
 from typing import Any, ClassVar, Literal
+from uuid import UUID
 from bson import ObjectId
+from bson.binary import Binary
+from bson.decimal128 import Decimal128
+from bson.regex import Regex
+from bson.timestamp import Timestamp
 from langchain_core.runnables import RunnableConfig
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pydantic import Field, PrivateAttr, field_validator
@@ -59,12 +67,39 @@ class MongoDBClientNode(TaskNode):
     _async_client_key: str | None = PrivateAttr(default=None)
 
     @classmethod
-    def _encode_bson(cls, value: Any) -> Any:
+    def _encode_special_bson_value(cls, value: Any) -> tuple[bool, Any]:
+        """Return encoded scalar BSON-like values when special handling is needed."""
+        handled = True
+        encoded: Any
         if isinstance(value, ObjectId):
-            return str(value)
-        if isinstance(value, dict):
+            encoded = str(value)
+        elif isinstance(value, (datetime, date, time)):
+            encoded = value.isoformat()
+        elif isinstance(value, Decimal128):
+            encoded = str(value.to_decimal())
+        elif isinstance(value, Decimal):
+            encoded = str(value)
+        elif isinstance(value, Timestamp):
+            encoded = {"time": value.time, "inc": value.inc}
+        elif isinstance(value, Regex):
+            encoded = {"pattern": value.pattern, "flags": value.flags}
+        elif isinstance(value, UUID):
+            encoded = str(value)
+        elif isinstance(value, (Binary, bytes, bytearray, memoryview)):
+            encoded = base64.b64encode(bytes(value)).decode("ascii")
+        else:
+            handled = False
+            encoded = value
+        return handled, encoded
+
+    @classmethod
+    def _encode_bson(cls, value: Any) -> Any:
+        handled, encoded = cls._encode_special_bson_value(value)
+        if handled:
+            return encoded
+        if isinstance(value, Mapping):
             return {key: cls._encode_bson(item) for key, item in value.items()}
-        if isinstance(value, list):
+        if isinstance(value, (list, tuple, set)):
             return [cls._encode_bson(item) for item in value]
         return value
 
@@ -317,6 +352,10 @@ class MongoDBNode(MongoDBClientNode):
     sort: dict[str, int] | list[tuple[str, int]] | None = Field(
         default=None, description="Sort specification for find operations"
     )
+    projection: dict[str, Any] | list[str] | str | None = Field(
+        default=None,
+        description="Projection specification for read operations",
+    )
     limit: int | str | None = Field(
         default=None, description="Limit for find operations"
     )
@@ -393,6 +432,19 @@ class MongoDBNode(MongoDBClientNode):
             return list(value.items())
         return list(value)
 
+    def _resolve_projection(self) -> dict[str, Any] | list[str]:
+        """Resolve a projection document or field list from inputs."""
+        projection = self.projection
+        if isinstance(projection, str):
+            msg = "projection must resolve to a dict or list before execution"
+            raise ValueError(msg)
+        if projection is None:
+            msg = "projection is not set for this operation"
+            raise ValueError(msg)
+        if isinstance(projection, list):
+            return list(projection)
+        return dict(projection)
+
     def _build_operation_call(self) -> tuple[list[Any], dict[str, Any]]:
         """Return positional args and kwargs for the configured operation."""
         filter_operations = {
@@ -413,6 +465,14 @@ class MongoDBNode(MongoDBClientNode):
             "find_one_and_replace",
         }
         pipeline_operations = {"aggregate", "aggregate_raw_batches"}
+        projection_operations = {
+            "find",
+            "find_one",
+            "find_raw_batches",
+            "find_one_and_delete",
+            "find_one_and_replace",
+            "find_one_and_update",
+        }
 
         if self.operation in pipeline_operations:
             pipeline = self._coerce_object_ids(self._resolve_pipeline())
@@ -421,11 +481,16 @@ class MongoDBNode(MongoDBClientNode):
         if self.operation in update_operations:
             filter_doc = self._coerce_object_ids(self._resolve_filter())
             update_doc = self._coerce_object_ids(self._resolve_update())
-            return [filter_doc, update_doc], dict(self.options)
+            kwargs = dict(self.options)
+            if self.operation in projection_operations and self.projection is not None:
+                kwargs["projection"] = self._resolve_projection()
+            return [filter_doc, update_doc], kwargs
 
         if self.operation in filter_operations:
             filter_doc = self._coerce_object_ids(self._resolve_filter())
             kwargs = dict(self.options)
+            if self.operation in projection_operations and self.projection is not None:
+                kwargs["projection"] = self._resolve_projection()
             if self.operation in find_operations:  # pragma: no branch
                 if self.sort is not None:
                     kwargs["sort"] = self._normalize_sort(self.sort)

--- a/tests/nodes/test_agent_tools_helpers.py
+++ b/tests/nodes/test_agent_tools_helpers.py
@@ -184,3 +184,27 @@ async def test_mongodb_find_validates_arguments() -> None:
     payload["limit"] = "five"
     with pytest.raises(ValueError, match="limit must be an int"):
         await tools.mongodb_find.coroutine(**payload)
+
+
+@pytest.mark.asyncio
+async def test_mongodb_find_projection_requires_dict_or_list() -> None:
+    payload = {
+        "database": "db",
+        "collection": "col",
+        "filter": {},
+        "projection": 123,
+    }
+    with pytest.raises(ValueError, match="projection must be a dict or list"):
+        await tools.mongodb_find.coroutine(**payload)
+
+
+@pytest.mark.asyncio
+async def test_mongodb_find_projection_list_entries_strings() -> None:
+    payload = {
+        "database": "db",
+        "collection": "col",
+        "filter": {},
+        "projection": ["valid", 123],
+    }
+    with pytest.raises(ValueError, match="projection list entries must be strings"):
+        await tools.mongodb_find.coroutine(**payload)

--- a/tests/nodes/test_agent_tools_mongodb.py
+++ b/tests/nodes/test_agent_tools_mongodb.py
@@ -56,6 +56,7 @@ async def test_mongodb_find_tool_builds_node(monkeypatch):
             "database": "db",
             "collection": "rsvps",
             "filter": {"event_id": "1"},
+            "projection": {"_id": 1, "updated_at": 1},
             "sort": {"updated_at": -1},
             "limit": 5,
         }
@@ -68,6 +69,7 @@ async def test_mongodb_find_tool_builds_node(monkeypatch):
     assert node.database == "db"
     assert node.collection == "rsvps"
     assert node.filter == {"event_id": "1"}
+    assert node.projection == {"_id": 1, "updated_at": 1}
     assert node.sort == {"updated_at": -1}
     assert node.limit == 5
 

--- a/tests/nodes/test_ai_workflow_tool_progress.py
+++ b/tests/nodes/test_ai_workflow_tool_progress.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
 from orcheo.graph.state import State
 from orcheo.nodes.agent_tools.context import (
     tool_execution_context,
@@ -60,6 +61,46 @@ async def test_workflow_tool_emits_progress_updates() -> None:
     assert updates
     assert any("node_a" in step for step in updates)
     assert any("node_b" in step for step in updates)
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_streaming_respects_graph_output_schema() -> None:
+    """Streaming tool runs should still return the narrowed output schema."""
+
+    class ToolOutput(TypedDict):
+        answer: str
+
+    graph = StateGraph(dict, output_schema=ToolOutput)
+
+    def produce_answer(_state: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "answer": "compact answer",
+            "results": {"hidden_documents": [{"id": "1"}]},
+        }
+
+    graph.add_node("produce_answer", produce_answer)
+    graph.add_edge(START, "produce_answer")
+    graph.add_edge("produce_answer", END)
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=graph.compile(),
+        name="schema_tool",
+        description="Schema-aware streaming tool",
+        args_schema=None,
+    )
+
+    updates: list[dict[str, Any]] = []
+
+    async def progress_callback(step: dict[str, Any]) -> None:
+        updates.append(step)
+
+    config: RunnableConfig = {"configurable": {"thread_id": "schema-tool"}}
+
+    with tool_execution_context(config), tool_progress_context(progress_callback):
+        result = await tool.ainvoke({"query": "hello"})
+
+    assert result == {"answer": "compact answer"}
+    assert updates == [{"produce_answer": {"answer": "compact answer"}}]
 
 
 @pytest.mark.asyncio

--- a/tests/nodes/test_ai_workflow_tools.py
+++ b/tests/nodes/test_ai_workflow_tools.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 from orcheo.graph.state import State
 from orcheo.nodes.ai import WorkflowTool, _create_workflow_tool_func
 
@@ -204,3 +205,94 @@ def test_workflow_tool_sync_execution():
 
     assert execution_tracker["executed"]
     assert result["result"] == "sync_executed"
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_respects_graph_output_schema() -> None:
+    """Graph output_schema should narrow the tool payload automatically."""
+
+    from langgraph.graph import StateGraph
+
+    class ToolOutput(TypedDict):
+        answer: str
+
+    workflow_graph = StateGraph(dict, output_schema=ToolOutput)
+
+    def test_node(_state):
+        return {
+            "answer": "compact answer",
+            "results": {"hidden_documents": [{"id": "1"}]},
+        }
+
+    workflow_graph.add_node("process", test_node)
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="schema_tool",
+        description="Test output schema narrowing",
+        args_schema=None,
+    )
+
+    result = await tool.ainvoke({"query": "hello"})
+
+    assert result == {"answer": "compact answer"}
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_selects_nested_value() -> None:
+    """WorkflowTool output_path should return a selected nested result only."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+
+    def test_node(_state):
+        return {
+            "results": {
+                "format_results": {
+                    "markdown": "formatted answer",
+                    "documents": [{"id": "1"}],
+                }
+            }
+        }
+
+    workflow_graph.add_node("process", test_node)
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="Test selector output",
+        args_schema=None,
+        output_path="results.format_results.markdown",
+    )
+
+    result = await tool.ainvoke({"query": "hello"})
+
+    assert result == "formatted answer"
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_errors_when_missing() -> None:
+    """Missing output_path segments should raise a clear error."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+    workflow_graph.add_node("process", lambda _state: {"results": {}})
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="Test selector output",
+        args_schema=None,
+        output_path="results.format_results.markdown",
+    )
+
+    with pytest.raises(ValueError, match="output_path"):
+        await tool.ainvoke({"query": "hello"})

--- a/tests/nodes/test_ai_workflow_tools.py
+++ b/tests/nodes/test_ai_workflow_tools.py
@@ -296,3 +296,121 @@ async def test_workflow_tool_output_path_errors_when_missing() -> None:
 
     with pytest.raises(ValueError, match="output_path"):
         await tool.ainvoke({"query": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_handles_list_segments() -> None:
+    """List-based output_path segments should resolve numeric indexes."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+
+    def test_node(_state):
+        return {
+            "items": [
+                {"value": "first"},
+                {"value": "second"},
+            ]
+        }
+
+    workflow_graph.add_node("process", test_node)
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="List segment selector",
+        args_schema=None,
+        output_path="items.1.value",
+    )
+
+    result = await tool.ainvoke({"query": "hello"})
+    assert result == "second"
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_requires_integer_list_segments() -> None:
+    """List traversal requires integer segments with clear messaging."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+    workflow_graph.add_node("process", lambda _state: {"items": [{"value": "ok"}]})
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="List segment selector",
+        args_schema=None,
+        output_path="items.one.value",
+    )
+
+    with pytest.raises(ValueError, match="requires an integer segment"):
+        await tool.ainvoke({"query": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_list_index_out_of_range() -> None:
+    """Out-of-range list indexes should raise an informative error."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+    workflow_graph.add_node(
+        "process",
+        lambda _state: {"items": [{"value": "first"}]},
+    )
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="List segment selector",
+        args_schema=None,
+        output_path="items.2.value",
+    )
+
+    with pytest.raises(ValueError, match="index 2 is out of range"):
+        await tool.ainvoke({"query": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_output_path_cannot_descend_into_scalar() -> None:
+    """Non-iterable payload segments should raise a clear error."""
+
+    from langgraph.graph import StateGraph
+
+    workflow_graph = StateGraph(dict)
+    workflow_graph.add_node("process", lambda _state: {"value": "scalar"})
+    workflow_graph.set_entry_point("process")
+    workflow_graph.set_finish_point("process")
+
+    tool = _create_workflow_tool_func(
+        compiled_graph=workflow_graph.compile(),
+        name="selector_tool",
+        description="List segment selector",
+        args_schema=None,
+        output_path="value.key",
+    )
+
+    with pytest.raises(ValueError, match="cannot descend into str"):
+        await tool.ainvoke({"query": "hello"})
+
+
+def test_workflow_tool_output_path_validator_trims_whitespace() -> None:
+    """Whitespace-only output paths should be rejected after trimming."""
+
+    normalized = WorkflowTool._validate_output_path("  path ")
+    assert normalized == "path"
+
+
+def test_workflow_tool_output_path_validator_rejects_empty_string() -> None:
+    """Empty output paths must raise a validation error."""
+
+    with pytest.raises(ValueError, match="output_path must not be empty"):
+        WorkflowTool._validate_output_path("   ")

--- a/tests/nodes/test_deep_agent.py
+++ b/tests/nodes/test_deep_agent.py
@@ -361,6 +361,7 @@ async def test_prepare_tools_workflow_tools() -> None:
         name="sub_wf",
         description="A sub-workflow tool",
         graph=mock_graph,
+        output_path="results.final.answer",
     )
 
     with (
@@ -379,6 +380,7 @@ async def test_prepare_tools_workflow_tools() -> None:
         node = DeepAgentNode(name="t", ai_model="m", workflow_tools=[wf_tool])
         tools = await node._prepare_tools()
         mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["output_path"] == "results.final.answer"
         assert mock_structured in tools
 
 

--- a/tests/nodes/test_mongodb_base.py
+++ b/tests/nodes/test_mongodb_base.py
@@ -1,0 +1,45 @@
+"""Unit tests for MongoDB client utilities."""
+
+from __future__ import annotations
+import re
+from decimal import Decimal
+from uuid import UUID
+import pytest
+from bson.binary import Binary
+from bson.decimal128 import Decimal128
+from bson.regex import Regex
+from bson.timestamp import Timestamp
+from orcheo.nodes.integrations.databases.mongodb.base import (
+    MongoDBClientNode,
+    MongoDBNode,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (Decimal128("1.23"), "1.23"),
+        (Decimal("4.56"), "4.56"),
+        (Timestamp(1, 2), {"time": 1, "inc": 2}),
+        (Regex("pattern", "i"), {"pattern": "pattern", "flags": re.IGNORECASE}),
+        (UUID(int=1), str(UUID(int=1))),
+        (Binary(b"abc"), "YWJj"),
+    ],
+)
+def test_encode_special_bson_value_handles_known_types(value, expected) -> None:
+    handled, encoded = MongoDBClientNode._encode_special_bson_value(value)
+    assert handled
+    assert encoded == expected
+
+
+def test_mongodb_node_resolve_projection_requires_value() -> None:
+    node = MongoDBNode(
+        name="projection_test",
+        connection_string="mongodb://localhost",
+        database="db",
+        collection="col",
+        operation="find",
+    )
+
+    with pytest.raises(ValueError, match="projection is not set for this operation"):
+        node._resolve_projection()

--- a/tests/nodes/test_mongodb_helpers.py
+++ b/tests/nodes/test_mongodb_helpers.py
@@ -1,6 +1,7 @@
 """Additional MongoDBNode helper and error-handling tests."""
 
 from __future__ import annotations
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 import pytest
@@ -159,6 +160,18 @@ def test_resolve_pipeline_uses_query_candidate_when_missing() -> None:
     assert node._resolve_pipeline() == [{"$match": {"state": "active"}}]
 
 
+def test_resolve_projection_handles_dict_list_and_templates() -> None:
+    node = _build_node(operation="find", projection={"title": 1, "content": 1})
+    assert node._resolve_projection() == {"title": 1, "content": 1}
+
+    node.projection = ["title", "content"]
+    assert node._resolve_projection() == ["title", "content"]
+
+    node.projection = "{{prepare_event.projection}}"
+    with pytest.raises(ValueError, match="projection must resolve to a dict or list"):
+        node._resolve_projection()
+
+
 def test_normalize_sort_converts_dicts_and_lists() -> None:
     node = _build_node(operation="find")
     assert node._normalize_sort({"name": -1}) == [("name", -1)]
@@ -189,10 +202,12 @@ def test_build_operation_call_covers_each_operation_type() -> None:
     find_node = _build_node(
         operation="find",
         filter={"status": "active"},
+        projection={"_id": 1, "status": 1},
         sort={"isoDate": -1},
         limit=5,
     )
     find_args, find_kwargs = find_node._build_operation_call()
+    assert find_kwargs["projection"] == {"_id": 1, "status": 1}
     assert find_kwargs["sort"] == [("isoDate", -1)]
     assert find_kwargs["limit"] == 5
     assert find_args[0] == {"status": "active"}
@@ -201,6 +216,20 @@ def test_build_operation_call_covers_each_operation_type() -> None:
     other_args, other_kwargs = other_node._build_operation_call()
     assert other_args == [{"name": 1}]
     assert other_kwargs == {}
+
+
+def test_build_operation_call_applies_projection_to_find_one_and_update() -> None:
+    node = _build_node(
+        operation="find_one_and_update",
+        filter={"status": "active"},
+        update={"$set": {"status": "done"}},
+        projection={"status": 1},
+    )
+
+    args, kwargs = node._build_operation_call()
+
+    assert args == [{"status": "active"}, {"$set": {"status": "done"}}]
+    assert kwargs["projection"] == {"status": 1}
 
 
 def test_resolve_limit_requires_integer_values() -> None:
@@ -231,6 +260,21 @@ def test_coerce_object_ids_converts_nested_ids() -> None:
     assert coerced["_id"] == object_id
     assert coerced["nested"][0]["_id"] == object_id
     assert coerced["other"]["_id"] == "not-an-id"
+
+
+def test_encode_bson_normalizes_datetime_and_binary_values() -> None:
+    created_at = datetime(2026, 3, 23, 15, 30, tzinfo=UTC)
+    payload = {
+        "created_at": created_at,
+        "nested": {"_id": ObjectId("507f1f77bcf86cd799439011")},
+        "blob": b"abc",
+    }
+
+    encoded = MongoDBNode._encode_bson(payload)
+
+    assert encoded["created_at"] == created_at.isoformat()
+    assert encoded["nested"]["_id"] == "507f1f77bcf86cd799439011"
+    assert encoded["blob"] == "YWJj"
 
 
 def test_shared_client_lifecycle() -> None:

--- a/tests/nodes/test_mongodb_structured_ops.py
+++ b/tests/nodes/test_mongodb_structured_ops.py
@@ -1,6 +1,7 @@
 """MongoDBNode structured operation tests."""
 
 from __future__ import annotations
+from datetime import UTC, datetime
 from unittest.mock import Mock
 import pytest
 from bson import ObjectId
@@ -38,13 +39,17 @@ async def test_mongodb_aggregate_uses_pipeline(mongo_context) -> None:
 
 @pytest.mark.asyncio
 async def test_mongodb_find_uses_sort_and_limit(mongo_context) -> None:
-    mongo_context.collection.find.return_value = [{"_id": "1"}]
+    created_at = datetime(2026, 3, 23, 8, 15, tzinfo=UTC)
+    mongo_context.collection.find.return_value = [
+        {"_id": "1", "created_at": created_at}
+    ]
 
     node = MongoDBFindNode(
         name="find_node",
         database="test_db",
         collection="rss_feeds",
         filter={"read": False},
+        projection={"_id": 1, "created_at": 1},
         sort={"isoDate": -1},
         limit=30,
     )
@@ -54,10 +59,11 @@ async def test_mongodb_find_uses_sort_and_limit(mongo_context) -> None:
 
     mongo_context.collection.find.assert_called_once_with(
         {"read": False},
+        projection={"_id": 1, "created_at": 1},
         sort=[("isoDate", -1)],
         limit=30,
     )
-    assert result["data"] == [{"_id": "1"}]
+    assert result["data"] == [{"_id": "1", "created_at": created_at.isoformat()}]
 
 
 def test_mongodb_find_allows_templated_limit() -> None:


### PR DESCRIPTION
**Summary**
- add first-class `projection` support to MongoDB read operations and the `mongodb_find` agent tool
- normalize common BSON values into JSON-safe outputs to avoid trace and API serialization failures
- let workflow tools return narrowed outputs via LangGraph `output_schema` or `WorkflowTool.output_path`
- update the MongoDB agent example to show a compact tool response pattern
- add coverage for workflow tool output selection and MongoDB projection/serialization behavior
- addressing #310 #311 

**Testing**
- `make format`
- `make lint`
- `uv run pytest tests/nodes/test_ai_workflow_tools.py tests/nodes/test_ai_workflow_tool_progress.py tests/nodes/test_mongodb_helpers.py tests/nodes/test_mongodb_structured_ops.py tests/nodes/test_agent_tools_mongodb.py tests/nodes/test_deep_agent.py tests/graph/test_ingestion_summary.py -q`