### PR TITLE
Fix orcheo-skill validation and simplify browser-context CORS handling

### DIFF
--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/commands.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/commands.py
@@ -133,6 +133,7 @@ def context_sessions(
             "workflow_name",
             "focused",
             "staleness_seconds",
+            "origin",
         ]
         rows = [[session.get(col, "") for col in columns] for session in data]
         render_table(

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/server.py
@@ -17,24 +17,13 @@ logger = logging.getLogger(__name__)
 _REQUIRED_POST_FIELDS = {"session_id", "page", "focused"}
 
 
-def _cors_headers(origin: str | None = None) -> dict[str, str]:
-    """Return CORS headers restricted to localhost origins."""
-    allowed_origin = ""
-    if origin:
-        # Allow any localhost origin (any port, http only).
-        try:
-            from urllib.parse import urlparse
+def _cors_headers() -> dict[str, str]:
+    """Return permissive CORS headers.
 
-            parsed = urlparse(origin)
-            if (
-                parsed.hostname in ("localhost", "127.0.0.1")
-                and parsed.scheme == "http"
-            ):
-                allowed_origin = origin
-        except Exception:  # noqa: BLE001
-            pass
+    The browser-context server only binds to localhost so all origins are allowed.
+    """
     return {
-        "Access-Control-Allow-Origin": allowed_origin,
+        "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type",
     }
@@ -75,15 +64,11 @@ class ContextRequestHandler(BaseHTTPRequestHandler):
 
     store: ClassVar[BrowserContextStore]
 
-    def _origin(self) -> str | None:
-        """Return the Origin header from the request."""
-        return self.headers.get("Origin")
-
     def _send_json(self, status: int, data: Any) -> None:
         """Send a JSON response with CORS headers."""
         body = json.dumps(data, default=str).encode()
         self.send_response(status)
-        for key, value in _cors_headers(self._origin()).items():
+        for key, value in _cors_headers().items():
             self.send_header(key, value)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -93,7 +78,7 @@ class ContextRequestHandler(BaseHTTPRequestHandler):
     def _send_no_content(self) -> None:
         """Send a 204 No Content response with CORS headers."""
         self.send_response(204)
-        for key, value in _cors_headers(self._origin()).items():
+        for key, value in _cors_headers().items():
             self.send_header(key, value)
         self.end_headers()
 
@@ -133,6 +118,7 @@ class ContextRequestHandler(BaseHTTPRequestHandler):
             workflow_name=result.get("workflow_name"),
             focused=bool(result["focused"]),
             timestamp=_resolve_timestamp(result),
+            origin=self.headers.get("Origin"),
         )
         self._send_no_content()
 

--- a/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
+++ b/packages/sdk/src/orcheo_sdk/cli/browser_context/store.py
@@ -17,6 +17,7 @@ class BrowserContextEntry:
     focused: bool
     last_seen: datetime
     last_focused_at: datetime | None = None
+    origin: str | None = None
 
 
 class BrowserContextStore:
@@ -44,6 +45,7 @@ class BrowserContextStore:
         workflow_name: str | None,
         focused: bool,
         timestamp: datetime | None = None,
+        origin: str | None = None,
     ) -> None:
         """Insert or update a session entry. Resets the TTL."""
         now = timestamp or datetime.now(UTC)
@@ -60,6 +62,7 @@ class BrowserContextStore:
                 focused=focused,
                 last_seen=now,
                 last_focused_at=last_focused_at,
+                origin=origin,
             )
 
     def _start_periodic_cleanup(self) -> None:
@@ -105,6 +108,7 @@ class BrowserContextStore:
                     "last_focused_at": None,
                     "staleness_seconds": 0,
                     "total_sessions": 0,
+                    "origin": None,
                 }
 
             total = len(self._sessions)
@@ -133,6 +137,7 @@ class BrowserContextStore:
                 ),
                 "staleness_seconds": int(staleness),
                 "total_sessions": total,
+                "origin": best.origin,
             }
 
     def get_all_sessions(self) -> list[dict[str, object]]:
@@ -159,6 +164,7 @@ class BrowserContextStore:
                             else None
                         ),
                         "staleness_seconds": int(staleness),
+                        "origin": entry.origin,
                     }
                 )
             return results

--- a/packages/sdk/src/orcheo_sdk/services/orcheo_skill.py
+++ b/packages/sdk/src/orcheo_sdk/services/orcheo_skill.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 import httpx
-from orcheo.skills.manager import SkillError, SkillManager
+from orcheo.skills.manager import SkillError
+from orcheo.skills.parser import parse_skill_md
 
 
 OFFICIAL_ORCHEO_SKILL_NAME = "orcheo"
@@ -66,7 +67,8 @@ def resolve_orcheo_skill_targets(
 
 
 def _validate_orcheo_skill(source_dir: Path) -> None:
-    validation = SkillManager().validate(str(source_dir))
+    skill_md = source_dir / "SKILL.md"
+    validation = parse_skill_md(skill_md)
     if not validation.valid or validation.skill_metadata is None:
         messages = "; ".join(
             f"{error.field}: {error.message}" for error in validation.errors

--- a/tests/sdk/test_browser_context_server.py
+++ b/tests/sdk/test_browser_context_server.py
@@ -89,30 +89,11 @@ def test_get_sessions(context_server: tuple[str, HTTPServer]) -> None:
     assert len(sessions) == 3
 
 
-def test_cors_headers_without_origin(context_server: tuple[str, HTTPServer]) -> None:
-    """Requests without an Origin header get an empty CORS origin."""
+def test_cors_headers_allow_all(context_server: tuple[str, HTTPServer]) -> None:
+    """All responses include Access-Control-Allow-Origin: *."""
     base_url, _ = context_server
     resp = httpx.get(f"{base_url}/context")
-    assert resp.headers["access-control-allow-origin"] == ""
-
-
-def test_cors_headers_with_localhost_origin(
-    context_server: tuple[str, HTTPServer],
-) -> None:
-    """Requests from a localhost origin are reflected back."""
-    base_url, _ = context_server
-    origin = "http://localhost:5173"
-    resp = httpx.get(f"{base_url}/context", headers={"Origin": origin})
-    assert resp.headers["access-control-allow-origin"] == origin
-
-
-def test_cors_headers_rejects_non_localhost(
-    context_server: tuple[str, HTTPServer],
-) -> None:
-    """Requests from non-localhost origins get an empty CORS origin."""
-    base_url, _ = context_server
-    resp = httpx.get(f"{base_url}/context", headers={"Origin": "http://evil.com"})
-    assert resp.headers["access-control-allow-origin"] == ""
+    assert resp.headers["access-control-allow-origin"] == "*"
 
 
 def test_options_preflight(context_server: tuple[str, HTTPServer]) -> None:
@@ -120,7 +101,8 @@ def test_options_preflight(context_server: tuple[str, HTTPServer]) -> None:
     base_url, _ = context_server
     resp = httpx.options(f"{base_url}/context")
     assert resp.status_code == 204
-    assert "access-control-allow-origin" in resp.headers
+    assert resp.headers["access-control-allow-origin"] == "*"
+    assert "access-control-allow-methods" in resp.headers
 
 
 def test_post_missing_fields(context_server: tuple[str, HTTPServer]) -> None:
@@ -168,11 +150,12 @@ def test_post_unknown_path(context_server: tuple[str, HTTPServer]) -> None:
     assert resp.status_code == 404
 
 
-def test_cors_headers_urlparse_exception() -> None:
-    """_cors_headers returns empty origin when urlparse raises."""
-    with patch("urllib.parse.urlparse", side_effect=Exception("bad parse")):
-        headers = _cors_headers("http://localhost:5173")
-    assert headers["Access-Control-Allow-Origin"] == ""
+def test_cors_headers_returns_wildcard() -> None:
+    """_cors_headers always returns Access-Control-Allow-Origin: *."""
+    headers = _cors_headers()
+    assert headers["Access-Control-Allow-Origin"] == "*"
+    assert "Access-Control-Allow-Methods" in headers
+    assert "Access-Control-Allow-Headers" in headers
 
 
 def test_resolve_timestamp_invalid() -> None:

--- a/tests/sdk/test_services_orcheo_skill.py
+++ b/tests/sdk/test_services_orcheo_skill.py
@@ -95,12 +95,12 @@ def test_resolve_orcheo_skill_targets_rejects_unknown(
 def test_validate_orcheo_skill_reports_invalid(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    class FakeManager:
-        def validate(self, ref: str) -> SkillValidationResult:
-            return _fake_validation(valid=False)
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("name: orcheo", encoding="utf-8")
 
     monkeypatch.setattr(
-        "orcheo_sdk.services.orcheo_skill.SkillManager", lambda: FakeManager()
+        "orcheo_sdk.services.orcheo_skill.parse_skill_md",
+        lambda path: _fake_validation(valid=False),
     )
 
     with pytest.raises(SkillError, match="Official Orcheo skill is invalid"):
@@ -110,12 +110,12 @@ def test_validate_orcheo_skill_reports_invalid(
 def test_validate_orcheo_skill_rejects_non_official_name(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    class FakeManager:
-        def validate(self, ref: str) -> SkillValidationResult:
-            return _fake_validation(valid=True, name="other-skill")
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("name: other-skill", encoding="utf-8")
 
     monkeypatch.setattr(
-        "orcheo_sdk.services.orcheo_skill.SkillManager", lambda: FakeManager()
+        "orcheo_sdk.services.orcheo_skill.parse_skill_md",
+        lambda path: _fake_validation(valid=True, name="other-skill"),
     )
 
     with pytest.raises(SkillError, match="unexpected name"):
@@ -231,13 +231,12 @@ def test_validate_orcheo_skill_succeeds_with_correct_name(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """_validate_orcheo_skill returns normally when name matches (line 75 false branch)."""  # noqa: E501
-
-    class FakeManager:
-        def validate(self, ref: str) -> SkillValidationResult:
-            return _fake_validation(valid=True, name="orcheo")
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("name: orcheo", encoding="utf-8")
 
     monkeypatch.setattr(
-        "orcheo_sdk.services.orcheo_skill.SkillManager", lambda: FakeManager()
+        "orcheo_sdk.services.orcheo_skill.parse_skill_md",
+        lambda path: _fake_validation(valid=True, name="orcheo"),
     )
 
     _validate_orcheo_skill(tmp_path)  # must not raise


### PR DESCRIPTION
## Summary

- **Browser-context CORS**: Replace restrictive localhost-only CORS origin checking with a permissive `Access-Control-Allow-Origin: *` policy, since the server only binds to localhost anyway. Removes the `_origin()` helper and `origin` parameter from `_cors_headers()`.
- **Browser-context origin tracking**: Add an `origin` field to `BrowserContextEntry` so the HTTP `Origin` header from each POST is stored, surfaced in session listings (`get_context`, `get_all_sessions`), and displayed in the CLI `context sessions` table.
- **Orcheo skill validation**: Switch `_validate_orcheo_skill` from using `SkillManager().validate()` to the lighter `parse_skill_md()` parser, removing the dependency on `SkillManager`.
- Update tests to match all of the above changes.