### PR TITLE
Add provider-aware chat model credential resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ orcheo credential create openai_api_key --secret sk-your-key
 python examples/conversational_search/demo_2_basic_rag/demo_2.py
 ```
 
+Provider-aware chat models use provider-specific credential names in the active
+vault by default. For example, `openai:gpt-4.1` looks for `openai_api_key`,
+while `deepseek:deepseek-chat` looks for `deepseek_api_key`.
+
 ## Reference
 
 - **[SDK Reference](https://orcheo.readthedocs.io/en/latest/sdk_reference/)** — Python SDK for programmatic workflow execution

--- a/packages/agentensor/pyproject.toml
+++ b/packages/agentensor/pyproject.toml
@@ -6,6 +6,7 @@ requires = ["hatchling"]
 dependencies = [
   "datasets>=3.5.0",
   "langchain>=1.1.3",
+  "langchain-deepseek>=1.0.1",
   "langchain-ollama>=0.3.3",
   "langchain-openai>=0.3.18",
   "langgraph>=1.0.5",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -205,6 +205,10 @@ orcheo credential create my-api-key \
   --secret sk-xxx \
   --access private
 
+# Provider-specific credentials used for model switching
+orcheo credential create openai_api_key --provider openai --secret sk-openai
+orcheo credential create deepseek_api_key --provider deepseek --secret sk-deepseek
+
 # Delete a credential
 orcheo credential delete cred-id --force
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "uvicorn>=0.24.0",
   "pydantic>=2.4.2",
   "langchain-community>=0.0.10",
+  "langchain-deepseek>=1.0.1",
   "langchain-openai>=0.0.5",
   "python-dotenv>=1.0.0",
   "websockets>=12.0",

--- a/src/orcheo/nodes/ai.py
+++ b/src/orcheo/nodes/ai.py
@@ -28,6 +28,7 @@ from orcheo.nodes.agent_tools.registry import tool_registry
 from orcheo.nodes.base import AINode, TaskNode
 from orcheo.nodes.registry import NodeMetadata, registry
 from orcheo.nodes.storage import get_graph_store as _get_graph_store_fn
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
 from orcheo.tracing.model_metadata import (
     build_ai_trace_metadata,
     infer_chat_result_model_name,
@@ -931,7 +932,10 @@ class AgentNode(AINode):
             response_format_strategy = ProviderStrategy(self.response_format)  # type: ignore[arg-type]
 
         # Initialize chat model with model_kwargs
-        model = init_chat_model(self.ai_model, **self.model_kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, self.model_kwargs),
+        )
         agent = create_agent(
             model,
             tools=tools,
@@ -1089,7 +1093,10 @@ class LLMNode(AgentNode):
         if self.response_format is not None:
             response_format_strategy = ProviderStrategy(self.response_format)  # type: ignore[arg-type]
 
-        model = init_chat_model(self.ai_model, **self.model_kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, self.model_kwargs),
+        )
         agent = create_agent(
             model,
             tools=tools,

--- a/src/orcheo/nodes/conversational_search/generation.py
+++ b/src/orcheo/nodes/conversational_search/generation.py
@@ -11,6 +11,7 @@ from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.conversational_search.models import SearchResult
 from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
 from orcheo.tracing.model_metadata import (
     build_ai_trace_metadata,
     infer_chat_result_model_name,
@@ -227,7 +228,10 @@ class GroundedGeneratorNode(TaskNode):
 
         # Initialize chat model
         kwargs = self.model_kwargs if isinstance(self.model_kwargs, dict) else {}
-        model = init_chat_model(self.ai_model, **kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, kwargs),
+        )
 
         # Build messages list
         messages: list[Any] = []
@@ -419,7 +423,10 @@ class StreamingGeneratorNode(TaskNode):
 
         # Initialize chat model
         kwargs = self.model_kwargs if isinstance(self.model_kwargs, dict) else {}
-        model = init_chat_model(self.ai_model, **kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, kwargs),
+        )
 
         # Build messages list
         messages = self._build_streaming_messages(query, history)

--- a/src/orcheo/nodes/conversational_search/query_processing.py
+++ b/src/orcheo/nodes/conversational_search/query_processing.py
@@ -12,6 +12,7 @@ from orcheo.nodes.ai import AgentNode
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.conversational_search.models import SearchResult
 from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
 from orcheo.tracing.model_metadata import (
     build_ai_trace_metadata,
     infer_model_name_from_instance,
@@ -94,7 +95,10 @@ class QueryRewriteNode(AgentNode):
                 "context": "",
             }
 
-        model = init_chat_model(self.ai_model, **self.model_kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, self.model_kwargs),
+        )
         prompt = self._system_prompt_text
         llm_messages = [
             SystemMessage(content=prompt),
@@ -387,7 +391,10 @@ class ContextCompressorNode(TaskNode):
             msg = "AI model identifier is required for model-based summarization"
             raise ValueError(msg)
         kwargs = self.model_kwargs if isinstance(self.model_kwargs, dict) else {}
-        model = init_chat_model(self.ai_model, **kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, kwargs),
+        )
 
         prompt = (
             "User Query: {query}\n\nRetrieved Context:\n{context}\n\n"

--- a/src/orcheo/nodes/deep_agent.py
+++ b/src/orcheo/nodes/deep_agent.py
@@ -17,6 +17,7 @@ from orcheo.nodes.agent_tools.registry import tool_registry
 from orcheo.nodes.ai import WorkflowTool, _create_workflow_tool_func
 from orcheo.nodes.base import AINode
 from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
 from orcheo.skills.manager import SkillManager
 from orcheo.skills.paths import get_skills_dir
 from orcheo.tracing.model_metadata import (
@@ -222,9 +223,12 @@ class DeepAgentNode(AINode):
         if self.response_format is not None:
             response_format_strategy = ProviderStrategy(self.response_format)  # type: ignore[arg-type]
 
-        model_kwargs = self.model_kwargs
+        model_kwargs = normalize_chat_model_kwargs(self.ai_model, self.model_kwargs)
         if model_kwargs:
-            model = init_chat_model(self.ai_model, **model_kwargs)
+            model = init_chat_model(
+                self.ai_model,
+                **model_kwargs,
+            )
         else:
             model = self.ai_model  # type: ignore[assignment]
 

--- a/src/orcheo/nodes/evaluation/judges.py
+++ b/src/orcheo/nodes/evaluation/judges.py
@@ -11,6 +11,7 @@ from orcheo.graph.state import State
 from orcheo.nodes.base import TaskNode
 from orcheo.nodes.evaluation.metrics import _tokenize
 from orcheo.nodes.registry import NodeMetadata, registry
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
 from orcheo.tracing.model_metadata import (
     build_ai_trace_metadata,
     infer_model_name_from_instance,
@@ -69,7 +70,10 @@ class LLMJudgeNode(TaskNode):
             msg = "LLMJudgeNode requires ai_model for model-based judging"
             raise ValueError(msg)
         kwargs = self.model_kwargs if isinstance(self.model_kwargs, dict) else {}
-        model = init_chat_model(self.ai_model, **kwargs)
+        model = init_chat_model(
+            self.ai_model,
+            **normalize_chat_model_kwargs(self.ai_model, kwargs),
+        )
         self._set_trace_metadata_for_run(
             {
                 "ai": build_ai_trace_metadata(

--- a/src/orcheo/runtime/chat_models.py
+++ b/src/orcheo/runtime/chat_models.py
@@ -47,16 +47,17 @@ def normalize_chat_model_kwargs(
 ) -> dict[str, Any]:
     """Return chat-model kwargs with provider-specific auth normalized."""
     normalized = dict(model_kwargs or {})
-    provider_key_values = _pop_provider_key_aliases(normalized)
 
     api_key = normalized.get("api_key")
     if isinstance(api_key, str) and api_key.strip():
+        _pop_provider_key_aliases(normalized)
         return normalized
 
     provider = _resolve_provider(ai_model, normalized)
     if provider is None:
         return normalized
 
+    provider_key_values = _pop_provider_key_aliases(normalized)
     explicit_provider_key = provider_key_values.get(provider)
     if isinstance(explicit_provider_key, str):
         explicit_provider_key = explicit_provider_key.strip()

--- a/src/orcheo/runtime/chat_models.py
+++ b/src/orcheo/runtime/chat_models.py
@@ -1,0 +1,129 @@
+"""Helpers for provider-aware chat model initialization."""
+
+from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+from orcheo.runtime.credentials import (
+    CredentialReferenceNotFoundError,
+    DuplicateCredentialReferenceError,
+    UnknownCredentialPayloadError,
+    credential_ref,
+    get_active_credential_resolver,
+)
+
+
+_MODEL_PREFIX_TO_PROVIDER: dict[str, str] = {
+    "gpt-": "openai",
+    "o1": "openai",
+    "o3": "openai",
+    "o4": "openai",
+    "claude": "anthropic",
+    "command": "cohere",
+    "deepseek": "deepseek",
+    "grok": "xai",
+    "mistral": "mistralai",
+    "sonar": "perplexity",
+}
+
+_PROVIDER_SECRET_NAMES: dict[str, str] = {
+    "anthropic": "anthropic_api_key",
+    "azure_openai": "azure_openai_api_key",
+    "cohere": "cohere_api_key",
+    "deepseek": "deepseek_api_key",
+    "fireworks": "fireworks_api_key",
+    "google_genai": "google_api_key",
+    "groq": "groq_api_key",
+    "mistralai": "mistralai_api_key",
+    "openai": "openai_api_key",
+    "perplexity": "perplexity_api_key",
+    "together": "together_api_key",
+    "xai": "xai_api_key",
+}
+
+
+def normalize_chat_model_kwargs(
+    ai_model: str | None,
+    model_kwargs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return chat-model kwargs with provider-specific auth normalized."""
+    normalized = dict(model_kwargs or {})
+    provider_key_values = _pop_provider_key_aliases(normalized)
+
+    api_key = normalized.get("api_key")
+    if isinstance(api_key, str) and api_key.strip():
+        return normalized
+
+    provider = _resolve_provider(ai_model, normalized)
+    if provider is None:
+        return normalized
+
+    explicit_provider_key = provider_key_values.get(provider)
+    if isinstance(explicit_provider_key, str):
+        explicit_provider_key = explicit_provider_key.strip()
+        if explicit_provider_key:
+            normalized["api_key"] = explicit_provider_key
+            return normalized
+
+    resolved_api_key = _resolve_provider_api_key(provider)
+    if resolved_api_key:
+        normalized["api_key"] = resolved_api_key
+    return normalized
+
+
+def _resolve_provider(
+    ai_model: str | None,
+    model_kwargs: Mapping[str, Any],
+) -> str | None:
+    provider = model_kwargs.get("model_provider")
+    if isinstance(provider, str):
+        normalized_provider = provider.strip()
+        if normalized_provider:
+            return normalized_provider
+
+    if not isinstance(ai_model, str):
+        return None
+    normalized_model = ai_model.strip()
+    if not normalized_model:
+        return None
+    if ":" in normalized_model:
+        provider_name, _model = normalized_model.split(":", 1)
+        provider_name = provider_name.strip()
+        return provider_name or None
+
+    folded = normalized_model.casefold()
+    for prefix, provider_name in _MODEL_PREFIX_TO_PROVIDER.items():
+        if folded.startswith(prefix):
+            return provider_name
+    return None
+
+
+def _resolve_provider_api_key(provider: str) -> str | None:
+    resolver = get_active_credential_resolver()
+    credential_name = _PROVIDER_SECRET_NAMES.get(provider)
+    if resolver is not None and credential_name is not None:
+        try:
+            resolved = resolver.resolve(credential_ref(credential_name))
+        except (
+            CredentialReferenceNotFoundError,
+            DuplicateCredentialReferenceError,
+            UnknownCredentialPayloadError,
+        ):
+            resolved = None
+        if isinstance(resolved, str):
+            secret = resolved.strip()
+            if secret:
+                return secret
+
+    return None
+
+
+def _pop_provider_key_aliases(model_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Remove provider-specific API key aliases and return their values."""
+    aliases: dict[str, Any] = {}
+    for provider, secret_name in _PROVIDER_SECRET_NAMES.items():
+        if secret_name in model_kwargs:
+            aliases[provider] = model_kwargs.pop(secret_name)
+    return aliases
+
+
+__all__ = ["normalize_chat_model_kwargs"]

--- a/src/orcheo/runtime/chat_models.py
+++ b/src/orcheo/runtime/chat_models.py
@@ -61,7 +61,7 @@ def normalize_chat_model_kwargs(
     explicit_provider_key = provider_key_values.get(provider)
     if isinstance(explicit_provider_key, str):
         explicit_provider_key = explicit_provider_key.strip()
-        if explicit_provider_key:
+        if explicit_provider_key:  # pragma: no branch
             normalized["api_key"] = explicit_provider_key
             return normalized
 
@@ -78,7 +78,7 @@ def _resolve_provider(
     provider = model_kwargs.get("model_provider")
     if isinstance(provider, str):
         normalized_provider = provider.strip()
-        if normalized_provider:
+        if normalized_provider:  # pragma: no branch
             return normalized_provider
 
     if not isinstance(ai_model, str):

--- a/tests/backend/test_app_credential_readiness.py
+++ b/tests/backend/test_app_credential_readiness.py
@@ -76,6 +76,40 @@ def orcheo_workflow() -> StateGraph:
     assert placeholders["telegram_token"] == {"[[telegram_token]]"}
 
 
+def test_collect_workflow_credential_placeholders_scans_provider_specific_aliases() -> (
+    None
+):
+    source = """
+from langgraph.graph import END, START, StateGraph
+from orcheo.graph.state import State
+from orcheo.nodes.ai import AgentNode
+
+def orcheo_workflow() -> StateGraph:
+    graph = StateGraph(State)
+    agent = AgentNode(
+        name="agent",
+        ai_model="{{config.configurable.ai_model}}",
+        model_kwargs={
+            "openai_api_key": "[[openai_primary_key]]",
+            "deepseek_api_key": "[[deepseek_team_key]]",
+        },
+    )
+    graph.add_node("agent", agent)
+    graph.add_edge(START, "agent")
+    graph.add_edge("agent", END)
+    return graph
+"""
+
+    placeholders = collect_workflow_credential_placeholders(
+        {"source": source, "entrypoint": None},
+        {"configurable": {"ai_model": "deepseek:deepseek-chat"}},
+    )
+
+    assert sorted(placeholders) == ["deepseek_team_key", "openai_primary_key"]
+    assert placeholders["openai_primary_key"] == {"[[openai_primary_key]]"}
+    assert placeholders["deepseek_team_key"] == {"[[deepseek_team_key]]"}
+
+
 def test_collect_workflow_credential_placeholders_falls_back_when_source_fails() -> (
     None
 ):

--- a/tests/nodes/test_deep_agent.py
+++ b/tests/nodes/test_deep_agent.py
@@ -652,6 +652,45 @@ async def test_run_model_kwargs_uses_init_chat_model(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_uses_inferred_provider_api_key_when_available(
+    tmp_path: Path,
+) -> None:
+    """run() initializes the model when provider key inference supplies kwargs."""
+    mock_agent = AsyncMock()
+    mock_agent.ainvoke.return_value = {"messages": []}
+
+    with (
+        patch(
+            "orcheo.nodes.deep_agent.normalize_chat_model_kwargs",
+            return_value={"api_key": "resolved-key"},
+        ),
+        patch("orcheo.nodes.deep_agent.init_chat_model") as mock_init,
+        patch(
+            "orcheo.nodes.deep_agent.create_deep_agent", return_value=mock_agent
+        ) as mock_create,
+        patch("orcheo.nodes.deep_agent.MultiServerMCPClient") as mock_mcp,
+        patch("orcheo.nodes.deep_agent.get_skills_dir", return_value=tmp_path),
+    ):
+        mock_model = MagicMock()
+        mock_init.return_value = mock_model
+        mock_mcp_instance = AsyncMock()
+        mock_mcp_instance.get_tools.return_value = []
+        mock_mcp.return_value = mock_mcp_instance
+
+        node = DeepAgentNode(
+            name="t",
+            ai_model="deepseek:deepseek-chat",
+            input_query="Test.",
+        )
+        await node.run(State({}), RunnableConfig())
+
+        mock_init.assert_called_once_with(
+            "deepseek:deepseek-chat", api_key="resolved-key"
+        )
+        assert mock_create.call_args[0][0] is mock_model
+
+
+@pytest.mark.asyncio
 async def test_run_passes_skills_and_memory() -> None:
     """run() passes skills and memory to create_deep_agent."""
     mock_agent = AsyncMock()

--- a/tests/runtime/test_chat_models.py
+++ b/tests/runtime/test_chat_models.py
@@ -1,0 +1,80 @@
+"""Tests for provider-aware chat model kwargs normalization."""
+
+from __future__ import annotations
+import pytest
+from orcheo.runtime.chat_models import normalize_chat_model_kwargs
+
+
+def test_normalize_chat_model_kwargs_prefers_explicit_api_key() -> None:
+    result = normalize_chat_model_kwargs(
+        "deepseek:deepseek-chat",
+        {"api_key": "explicit-key", "deepseek_api_key": "provider-key"},
+    )
+
+    assert result["api_key"] == "explicit-key"
+    assert "deepseek_api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_promotes_provider_specific_alias() -> None:
+    result = normalize_chat_model_kwargs(
+        "deepseek:deepseek-chat",
+        {
+            "deepseek_api_key": "deepseek-secret",
+            "openai_api_key": "openai-secret",
+            "temperature": 0.1,
+        },
+    )
+
+    assert result["api_key"] == "deepseek-secret"
+    assert result["temperature"] == 0.1
+    assert "deepseek_api_key" not in result
+    assert "openai_api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_uses_active_credential_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResolver:
+        def resolve(self, reference: object) -> str:
+            assert getattr(reference, "identifier", None) == "deepseek_api_key"
+            return "resolved-from-vault"
+
+    monkeypatch.setattr(
+        "orcheo.runtime.chat_models.get_active_credential_resolver",
+        lambda: StubResolver(),
+    )
+
+    result = normalize_chat_model_kwargs("deepseek:deepseek-chat")
+
+    assert result["api_key"] == "resolved-from-vault"
+
+
+def test_normalize_chat_model_kwargs_leaves_api_key_unset_without_alias_or_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "orcheo.runtime.chat_models.get_active_credential_resolver",
+        lambda: None,
+    )
+
+    result = normalize_chat_model_kwargs("deepseek:deepseek-chat")
+
+    assert "api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_infers_openai_provider_from_model_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResolver:
+        def resolve(self, reference: object) -> str:
+            assert getattr(reference, "identifier", None) == "openai_api_key"
+            return "resolved-openai-key"
+
+    monkeypatch.setattr(
+        "orcheo.runtime.chat_models.get_active_credential_resolver",
+        lambda: StubResolver(),
+    )
+
+    result = normalize_chat_model_kwargs("gpt-4.1")
+
+    assert result["api_key"] == "resolved-openai-key"

--- a/tests/runtime/test_chat_models.py
+++ b/tests/runtime/test_chat_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import pytest
 from orcheo.runtime.chat_models import normalize_chat_model_kwargs
+from orcheo.runtime.credentials import CredentialReferenceNotFoundError
 
 
 def test_normalize_chat_model_kwargs_prefers_explicit_api_key() -> None:
@@ -87,4 +88,72 @@ def test_normalize_chat_model_kwargs_preserves_aliases_when_provider_unknown() -
     )
 
     assert result["fireworks_api_key"] == "fireworks-secret"
+    assert "api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_trims_provider_alias_before_api_key_set() -> None:
+    result = normalize_chat_model_kwargs(
+        "deepseek:deepseek-chat",
+        {"deepseek_api_key": "  trimmed-secret  "},
+    )
+
+    assert result["api_key"] == "trimmed-secret"
+    assert "deepseek_api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_respects_model_provider_keyword() -> None:
+    result = normalize_chat_model_kwargs(
+        "unused-model",
+        {"model_provider": "  openai ", "openai_api_key": "provider-key"},
+    )
+
+    assert result["api_key"] == "provider-key"
+    assert "openai_api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_leaves_alias_when_model_unspecified() -> None:
+    result = normalize_chat_model_kwargs(None, {"openai_api_key": "openai-secret"})
+
+    assert result["openai_api_key"] == "openai-secret"
+    assert "api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_leaves_alias_when_model_blank() -> None:
+    result = normalize_chat_model_kwargs("   ", {"openai_api_key": "openai-secret"})
+
+    assert result["openai_api_key"] == "openai-secret"
+    assert "api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_handles_resolver_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResolver:
+        def resolve(self, reference: object) -> None:
+            raise CredentialReferenceNotFoundError("missing secret")
+
+    monkeypatch.setattr(
+        "orcheo.runtime.chat_models.get_active_credential_resolver",
+        lambda: StubResolver(),
+    )
+
+    result = normalize_chat_model_kwargs("gpt-4")
+
+    assert "api_key" not in result
+
+
+def test_normalize_chat_model_kwargs_ignores_blank_resolver_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubResolver:
+        def resolve(self, reference: object) -> str:
+            return "   "
+
+    monkeypatch.setattr(
+        "orcheo.runtime.chat_models.get_active_credential_resolver",
+        lambda: StubResolver(),
+    )
+
+    result = normalize_chat_model_kwargs("gpt-4")
+
     assert "api_key" not in result

--- a/tests/runtime/test_chat_models.py
+++ b/tests/runtime/test_chat_models.py
@@ -78,3 +78,13 @@ def test_normalize_chat_model_kwargs_infers_openai_provider_from_model_name(
     result = normalize_chat_model_kwargs("gpt-4.1")
 
     assert result["api_key"] == "resolved-openai-key"
+
+
+def test_normalize_chat_model_kwargs_preserves_aliases_when_provider_unknown() -> None:
+    result = normalize_chat_model_kwargs(
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
+        {"fireworks_api_key": "fireworks-secret"},
+    )
+
+    assert result["fireworks_api_key"] == "fireworks-secret"
+    assert "api_key" not in result

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,7 @@ source = { editable = "packages/agentensor" }
 dependencies = [
     { name = "datasets" },
     { name = "langchain" },
+    { name = "langchain-deepseek" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
     { name = "langgraph" },
@@ -76,6 +77,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=3.5.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.2.4" },
     { name = "langchain", specifier = ">=1.1.3" },
+    { name = "langchain-deepseek", specifier = ">=1.0.1" },
     { name = "langchain-ollama", specifier = ">=0.3.3" },
     { name = "langchain-openai", specifier = ">=0.3.18" },
     { name = "langgraph", specifier = ">=1.0.5" },
@@ -2148,6 +2150,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-deepseek"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/c4/de579ea21e22777959f214af165761c6cd101248222bcc0886d020d67185/langchain_deepseek-1.0.1.tar.gz", hash = "sha256:e7a0238f2c14e928e1562641b2df639c19cdf867287a7f2293ffb1372daf83ae", size = 147216 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/dd/a803dfbf64273232f3fc82f859487331abb717671bbcdf266fd80de6ef78/langchain_deepseek-1.0.1-py3-none-any.whl", hash = "sha256:0a9862f335f1873370bb0fe1928ac19b8b9292b014ef5412da462ded8bb82c5a", size = 8325 },
+]
+
+[[package]]
 name = "langchain-google-genai"
 version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3507,6 +3522,7 @@ dependencies = [
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-community" },
+    { name = "langchain-deepseek" },
     { name = "langchain-google-genai" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
@@ -3582,6 +3598,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain", specifier = ">=1.1.3" },
     { name = "langchain-community", specifier = ">=0.0.10" },
+    { name = "langchain-deepseek", specifier = ">=1.0.1" },
     { name = "langchain-google-genai", specifier = ">=3.0.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.2.1" },
     { name = "langchain-openai", specifier = ">=0.0.5" },


### PR DESCRIPTION
## Summary
- normalize chat model kwargs to infer the provider, promote provider-specific API key aliases, and resolve provider defaults from the active credential vault
- apply the normalization across AI, deep agent, conversational search, and evaluation nodes so provider-prefixed models initialize consistently
- add `langchain-deepseek` and document provider-specific credential setup for model switching

## Testing
- Not run (not requested)