### PR TITLE
Auto-init external agent worktrees and switch templates to /workspace/agents

### DIFF
--- a/apps/canvas/src/features/workflow/data/templates/assets/claude-code-agent/config.json
+++ b/apps/canvas/src/features/workflow/data/templates/assets/claude-code-agent/config.json
@@ -1,5 +1,5 @@
 {
   "configurable": {
-    "working_directory": "/app"
+    "working_directory": "/workspace/agents"
   }
 }

--- a/apps/canvas/src/features/workflow/data/templates/assets/codex-agent/config.json
+++ b/apps/canvas/src/features/workflow/data/templates/assets/codex-agent/config.json
@@ -1,5 +1,5 @@
 {
   "configurable": {
-    "working_directory": "/app"
+    "working_directory": "/workspace/agents"
   }
 }

--- a/apps/canvas/src/features/workflow/data/templates/template-definition.test.ts
+++ b/apps/canvas/src/features/workflow/data/templates/template-definition.test.ts
@@ -68,10 +68,10 @@ describe("template compatibility", () => {
     expect(claudeTemplate!.workflow.name).toBe("Claude Code Agent");
     expect(codexTemplate!.workflow.name).toBe("Codex Agent");
     expect(claudeTemplate!.runnableConfig?.configurable).toEqual({
-      working_directory: "/app",
+      working_directory: "/workspace/agents",
     });
     expect(codexTemplate!.runnableConfig?.configurable).toEqual({
-      working_directory: "/app",
+      working_directory: "/workspace/agents",
     });
   });
 

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -76,6 +76,7 @@ services:
     env_file: .env
     volumes:
       - orcheo_data:/data
+      - ./workspace/agents:/workspace/agents
       - ./chatkit_widgets:/app/examples/chatkit_widgets/widgets:ro
     environment:
       HOME: /data/home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
     env_file: .env
     volumes:
       - .:/app
+      - .:/workspace/agents
       - orcheo_data:/data
       - worker_venv:/app/.venv
       - uv_cache:/root/.cache/uv

--- a/docs/external_agent_nodes.md
+++ b/docs/external_agent_nodes.md
@@ -69,10 +69,12 @@ Both `ClaudeCodeNode` and `CodexNode` share the same workflow-facing fields:
 - `prompt`
 - `system_prompt`
 - `working_directory`
+- `auto_init_git_worktree`
 - `timeout_seconds`
 
-The `working_directory` must resolve to an existing path inside a Git worktree.
-Orcheo rejects `/`, the worker home directory, and the managed runtime root.
+By default, Orcheo initializes a Git worktree in `working_directory` when the
+path is safe but not yet inside one. Orcheo still rejects `/`, the worker home
+directory, and the managed runtime root.
 
 Normalized node output includes:
 

--- a/src/orcheo/external_agents/paths.py
+++ b/src/orcheo/external_agents/paths.py
@@ -64,24 +64,30 @@ def provider_staging_dir(runtime_root: Path, provider: str) -> Path:
     return provider_root(runtime_root, provider) / STAGING_DIR_NAME
 
 
-def validate_working_directory(
-    candidate: str | Path,
-    *,
-    runtime_root: Path,
-    home_directory: Path | None = None,
-) -> Path:
-    """Validate a requested working directory for external agent execution."""
-    resolved = Path(candidate).expanduser().resolve(strict=True)
-    runtime_root_resolved = runtime_root.expanduser().resolve()
-    home_resolved = (
-        home_directory.expanduser().resolve()
-        if home_directory is not None
-        else Path.home().resolve()
-    )
+def _run_git_command(directory: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command for working-directory validation."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(directory), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        msg = (
+            "Git is required to validate external-agent working directories, but "
+            "the 'git' executable is not available in this environment."
+        )
+        raise WorkingDirectoryValidationError(msg) from exc
 
-    if not resolved.is_dir():
-        msg = f"Working directory '{resolved}' is not a directory."
-        raise WorkingDirectoryValidationError(msg)
+
+def _assert_safe_working_directory(
+    resolved: Path,
+    *,
+    runtime_root_resolved: Path,
+    home_resolved: Path,
+) -> None:
+    """Reject unsafe working-directory targets before any git operations."""
     if resolved == Path(resolved.root):
         msg = "Refusing to run an external agent against '/'."
         raise WorkingDirectoryValidationError(msg)
@@ -94,24 +100,74 @@ def validate_working_directory(
         msg = "Refusing to run an external agent inside the managed runtime root."
         raise WorkingDirectoryValidationError(msg)
 
-    try:
-        git_check = subprocess.run(
-            ["git", "-C", str(resolved), "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        msg = (
-            "Git is required to validate external-agent working directories, but "
-            "the 'git' executable is not available in this environment."
-        )
-        raise WorkingDirectoryValidationError(msg) from exc
-    if git_check.returncode != 0:
-        msg = (
-            f"Working directory '{resolved}' must be a Git worktree root or a "
-            "descendant inside a Git worktree."
-        )
+
+def _ensure_directory_exists(resolved: Path, *, auto_init_git_worktree: bool) -> None:
+    """Create or validate the requested working directory before git checks."""
+    if resolved.exists():
+        if not resolved.is_dir():
+            msg = f"Working directory '{resolved}' is not a directory."
+            raise WorkingDirectoryValidationError(msg)
+        return
+    if not auto_init_git_worktree:
+        msg = f"Working directory '{resolved}' does not exist."
         raise WorkingDirectoryValidationError(msg)
+    resolved.mkdir(parents=True, exist_ok=True)
+
+
+def _ensure_git_worktree(resolved: Path, *, auto_init_git_worktree: bool) -> None:
+    """Require a git worktree, optionally initializing one in place."""
+    git_check = _run_git_command(resolved, "rev-parse", "--show-toplevel")
+    if git_check.returncode == 0:
+        return
+    if auto_init_git_worktree:
+        init_result = _run_git_command(
+            resolved,
+            "init",
+            "--quiet",
+            "--initial-branch=main",
+        )
+        if init_result.returncode != 0:
+            msg = f"Failed to initialize a Git worktree in '{resolved}'."
+            raise WorkingDirectoryValidationError(msg)
+        git_check = _run_git_command(resolved, "rev-parse", "--show-toplevel")
+        if git_check.returncode == 0:
+            return
+    msg = (
+        f"Working directory '{resolved}' must be a Git worktree root or a "
+        "descendant inside a Git worktree."
+    )
+    raise WorkingDirectoryValidationError(msg)
+
+
+def validate_working_directory(
+    candidate: str | Path,
+    *,
+    runtime_root: Path,
+    home_directory: Path | None = None,
+    auto_init_git_worktree: bool = False,
+) -> Path:
+    """Validate a requested working directory for external agent execution."""
+    candidate_path = Path(candidate).expanduser()
+    resolved = candidate_path.resolve(strict=not auto_init_git_worktree)
+    runtime_root_resolved = runtime_root.expanduser().resolve()
+    home_resolved = (
+        home_directory.expanduser().resolve()
+        if home_directory is not None
+        else Path.home().resolve()
+    )
+
+    _assert_safe_working_directory(
+        resolved,
+        runtime_root_resolved=runtime_root_resolved,
+        home_resolved=home_resolved,
+    )
+    _ensure_directory_exists(
+        resolved,
+        auto_init_git_worktree=auto_init_git_worktree,
+    )
+    _ensure_git_worktree(
+        resolved,
+        auto_init_git_worktree=auto_init_git_worktree,
+    )
 
     return resolved

--- a/src/orcheo/external_agents/paths.py
+++ b/src/orcheo/external_agents/paths.py
@@ -111,7 +111,11 @@ def _ensure_directory_exists(resolved: Path, *, auto_init_git_worktree: bool) ->
     if not auto_init_git_worktree:
         msg = f"Working directory '{resolved}' does not exist."
         raise WorkingDirectoryValidationError(msg)
-    resolved.mkdir(parents=True, exist_ok=True)
+    try:
+        resolved.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        msg = f"Unable to create working directory '{resolved}': {exc}"
+        raise WorkingDirectoryValidationError(msg) from exc
 
 
 def _ensure_git_worktree(resolved: Path, *, auto_init_git_worktree: bool) -> None:

--- a/src/orcheo/external_agents/runtime.py
+++ b/src/orcheo/external_agents/runtime.py
@@ -123,9 +123,18 @@ class ExternalAgentRuntimeManager:
             return True
         return reference_now - last_reference >= self.maintenance_interval
 
-    def validate_working_directory(self, candidate: str | Path) -> Path:
+    def validate_working_directory(
+        self,
+        candidate: str | Path,
+        *,
+        auto_init_git_worktree: bool = False,
+    ) -> Path:
         """Validate a requested execution directory against runtime safety rules."""
-        return validate_working_directory(candidate, runtime_root=self.runtime_root)
+        return validate_working_directory(
+            candidate,
+            runtime_root=self.runtime_root,
+            auto_init_git_worktree=auto_init_git_worktree,
+        )
 
     def inspect_runtime(
         self,

--- a/src/orcheo/nodes/external_agent.py
+++ b/src/orcheo/nodes/external_agent.py
@@ -41,6 +41,13 @@ class ExternalAgentNode(TaskNode):
         default=None,
         description="Git worktree path the agent should run inside.",
     )
+    auto_init_git_worktree: bool = Field(
+        default=True,
+        description=(
+            "Initialize a Git worktree in the working directory when the path is "
+            "safe but not yet inside one."
+        ),
+    )
     timeout_seconds: int = Field(
         default=1800,
         ge=1,
@@ -112,7 +119,8 @@ class ExternalAgentNode(TaskNode):
             prompt = self._resolve_prompt(state)
             working_directory_input = self._resolve_working_directory_input(state)
             working_directory = manager.validate_working_directory(
-                working_directory_input
+                working_directory_input,
+                auto_init_git_worktree=self.auto_init_git_worktree,
             )
         except (ValueError, WorkingDirectoryValidationError) as exc:
             return {

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -236,6 +236,25 @@ def test_validate_working_directory_requires_git_and_rejects_runtime_root(
         validate_working_directory(plain_dir, runtime_root=runtime_root)
 
 
+def test_validate_working_directory_auto_initializes_git_repo(
+    tmp_path: Path,
+) -> None:
+    """Auto-init creates a usable Git worktree for safe non-repo directories."""
+    runtime_root = tmp_path / "agent-runtimes"
+    runtime_root.mkdir()
+    plain_dir = tmp_path / "plain"
+
+    validated = validate_working_directory(
+        plain_dir,
+        runtime_root=runtime_root,
+        auto_init_git_worktree=True,
+    )
+
+    assert validated == plain_dir.resolve()
+    git_dir = plain_dir / ".git"
+    assert git_dir.is_dir()
+
+
 def test_validate_working_directory_surfaces_missing_git(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -789,7 +808,7 @@ def test_validate_working_directory_delegates_to_paths_helper(
     expected = tmp_path / "repo"
     monkeypatch.setattr(
         "orcheo.external_agents.runtime.validate_working_directory",
-        lambda candidate, *, runtime_root: expected,
+        lambda candidate, *, runtime_root, auto_init_git_worktree: expected,
     )
 
     assert manager.validate_working_directory("repo") == expected

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -255,6 +255,34 @@ def test_validate_working_directory_auto_initializes_git_repo(
     assert git_dir.is_dir()
 
 
+def test_validate_working_directory_wraps_mkdir_errors_as_validation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-init directory creation failures are surfaced as validation errors."""
+    runtime_root = tmp_path / "agent-runtimes"
+    runtime_root.mkdir()
+    plain_dir = tmp_path / "plain"
+
+    def _raise_permission_error(self: Path, *args: object, **kwargs: object) -> None:
+        if self == plain_dir:
+            raise PermissionError("Permission denied")
+        return original_mkdir(self, *args, **kwargs)
+
+    original_mkdir = Path.mkdir
+    monkeypatch.setattr(Path, "mkdir", _raise_permission_error)
+
+    with pytest.raises(
+        WorkingDirectoryValidationError,
+        match="Unable to create working directory",
+    ):
+        validate_working_directory(
+            plain_dir,
+            runtime_root=runtime_root,
+            auto_init_git_worktree=True,
+        )
+
+
 def test_validate_working_directory_surfaces_missing_git(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import Mock
 import pytest
+import orcheo.external_agents.paths as external_agent_paths
 from orcheo.external_agents.manifest import RuntimeManifestStore, provider_lock
 from orcheo.external_agents.models import (
     AuthProbeResult,
@@ -159,6 +160,38 @@ def test_default_runtime_root_falls_back_to_home(tmp_path: Path) -> None:
     assert resolved == home_directory / ".orcheo" / "agent-runtimes"
 
 
+def test_runtime_path_helpers_return_expected_locations(tmp_path: Path) -> None:
+    """Path helpers resolve provider-specific runtime storage locations."""
+    runtime_root = external_agent_paths.ensure_runtime_root(tmp_path / "managed")
+
+    assert runtime_root == (tmp_path / "managed").resolve()
+    assert runtime_root.is_dir()
+    assert (
+        external_agent_paths.provider_root(runtime_root, "codex")
+        == runtime_root / "codex"
+    )
+    assert (
+        external_agent_paths.provider_manifest_path(runtime_root, "codex")
+        == runtime_root / "codex" / "manifest.json"
+    )
+    assert (
+        provider_environment_path(runtime_root, "codex")
+        == runtime_root / "codex" / "environment.json"
+    )
+    assert (
+        external_agent_paths.provider_lock_path(runtime_root, "codex")
+        == runtime_root / "codex" / ".lock"
+    )
+    assert (
+        external_agent_paths.provider_runtimes_dir(runtime_root, "codex")
+        == runtime_root / "codex" / "runtimes"
+    )
+    assert (
+        external_agent_paths.provider_staging_dir(runtime_root, "codex")
+        == runtime_root / "codex" / "staging"
+    )
+
+
 def test_resolved_runtime_model_dump_serializes_paths(tmp_path: Path) -> None:
     runtime = ResolvedRuntime(
         provider="codex",
@@ -281,6 +314,92 @@ def test_validate_working_directory_wraps_mkdir_errors_as_validation_error(
             runtime_root=runtime_root,
             auto_init_git_worktree=True,
         )
+
+
+def test_ensure_directory_exists_rejects_missing_directory_without_auto_init(
+    tmp_path: Path,
+) -> None:
+    """Missing working directories are rejected when auto-init is disabled."""
+    missing_dir = tmp_path / "missing"
+
+    with pytest.raises(WorkingDirectoryValidationError, match="does not exist"):
+        external_agent_paths._ensure_directory_exists(
+            missing_dir,
+            auto_init_git_worktree=False,
+        )
+
+
+def test_ensure_git_worktree_raises_when_git_init_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero git init result is surfaced as a validation error."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    calls: list[tuple[str, ...]] = []
+
+    def _fake_run_git_command(
+        directory: Path, *args: str
+    ) -> subprocess.CompletedProcess[str]:
+        assert directory == repo
+        calls.append(args)
+        if args == ("rev-parse", "--show-toplevel"):
+            return subprocess.CompletedProcess(args=list(args), returncode=1)
+        if args == ("init", "--quiet", "--initial-branch=main"):
+            return subprocess.CompletedProcess(args=list(args), returncode=2)
+        raise AssertionError(f"Unexpected git command: {args}")
+
+    monkeypatch.setattr(external_agent_paths, "_run_git_command", _fake_run_git_command)
+
+    with pytest.raises(
+        WorkingDirectoryValidationError,
+        match="Failed to initialize a Git worktree",
+    ):
+        external_agent_paths._ensure_git_worktree(repo, auto_init_git_worktree=True)
+
+    assert calls == [
+        ("rev-parse", "--show-toplevel"),
+        ("init", "--quiet", "--initial-branch=main"),
+    ]
+
+
+def test_ensure_git_worktree_raises_when_init_does_not_create_valid_worktree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directory that still fails rev-parse after init is rejected."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    results = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["rev-parse", "--show-toplevel"],
+                returncode=1,
+            ),
+            subprocess.CompletedProcess(
+                args=["init", "--quiet", "--initial-branch=main"],
+                returncode=0,
+            ),
+            subprocess.CompletedProcess(
+                args=["rev-parse", "--show-toplevel"],
+                returncode=1,
+            ),
+        ]
+    )
+
+    def _fake_run_git_command(
+        directory: Path, *args: str
+    ) -> subprocess.CompletedProcess[str]:
+        assert directory == repo
+        return next(results)
+
+    monkeypatch.setattr(external_agent_paths, "_run_git_command", _fake_run_git_command)
+
+    with pytest.raises(
+        WorkingDirectoryValidationError,
+        match="must be a Git worktree root or a descendant inside a Git worktree",
+    ):
+        external_agent_paths._ensure_git_worktree(repo, auto_init_git_worktree=True)
 
 
 def test_validate_working_directory_surfaces_missing_git(

--- a/tests/nodes/test_external_agent_node.py
+++ b/tests/nodes/test_external_agent_node.py
@@ -79,8 +79,15 @@ class FakeRuntimeManager:
         self.raise_validate_error = raise_validate_error
         self.mark_auth_called = False
         self.environment: dict[str, str] = {}
+        self.auto_init_git_worktree: bool | None = None
 
-    def validate_working_directory(self, candidate: str | Path) -> Path:
+    def validate_working_directory(
+        self,
+        candidate: str | Path,
+        *,
+        auto_init_git_worktree: bool = False,
+    ) -> Path:
+        self.auto_init_git_worktree = auto_init_git_worktree
         if self.raise_validate_error:
             raise WorkingDirectoryValidationError("invalid workspace")
         return Path(candidate)
@@ -255,6 +262,73 @@ async def test_run_invalid_configuration_when_working_directory_invalid(
 
     assert result["reason"] == "invalid_configuration"
     assert "invalid workspace" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_auto_initializes_git_worktree_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    resolution = _make_runtime_resolution(tmp_path)
+    manager = FakeRuntimeManager(
+        provider=DummyProvider(),
+        resolution=resolution,
+    )
+    node = _make_node(manager)
+    state = _make_state({"prompt": "run"})
+
+    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
+        return ProcessExecutionResult(
+            command=["dummy"],
+            stdout="ok",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0,
+        )
+
+    monkeypatch.setattr(
+        "orcheo.nodes.external_agent.execute_process",
+        fake_execute,
+    )
+
+    await node.run(state, RunnableConfig())
+
+    assert manager.auto_init_git_worktree is True
+
+
+@pytest.mark.asyncio
+async def test_run_can_disable_auto_init_git_worktree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    resolution = _make_runtime_resolution(tmp_path)
+    manager = FakeRuntimeManager(
+        provider=DummyProvider(),
+        resolution=resolution,
+    )
+    node = _make_node(manager)
+    node.auto_init_git_worktree = False
+    state = _make_state({"prompt": "run"})
+
+    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
+        return ProcessExecutionResult(
+            command=["dummy"],
+            stdout="ok",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0,
+        )
+
+    monkeypatch.setattr(
+        "orcheo.nodes.external_agent.execute_process",
+        fake_execute,
+    )
+
+    await node.run(state, RunnableConfig())
+
+    assert manager.auto_init_git_worktree is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR improves the default workspace behavior for external agent nodes and updates the built-in agent templates to use a safer, dedicated workspace path.

## What Changed

- Added `auto_init_git_worktree` to external agent nodes, enabled by default.
- Updated working directory validation so safe non-repo directories can be created and initialized as Git worktrees automatically.
- Kept existing safety checks in place so external agents still reject `/`, the worker home directory, and the managed runtime root.
- Changed the default Claude Code and Codex template `working_directory` from `/app` to `/workspace/agents`.
- Updated Docker Compose setups to mount the repository workspace at `/workspace/agents` for agent execution.
- Refreshed docs to describe the new default behavior and the new node option.
- Added/updated backend and canvas tests to cover the new template defaults and Git worktree auto-init behavior.

## Why

Previously, external agent execution required the requested working directory to already exist inside a Git worktree. This made the default template path awkward and increased setup friction. With this change, agent nodes can start in a dedicated workspace path and bootstrap a Git worktree automatically when it is safe to do so, while still allowing callers to disable that behavior if they need stricter validation.
