### PR TITLE
Align Codex and Claude external-agent commands with unattended permission-bypass flags

### DIFF
--- a/src/orcheo/external_agents/providers/base.py
+++ b/src/orcheo/external_agents/providers/base.py
@@ -5,7 +5,7 @@ import os
 import re
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 from orcheo.external_agents.models import AuthProbeResult, AuthStatus, ResolvedRuntime
 
 
@@ -58,6 +58,15 @@ class ExternalAgentProvider(Protocol):
     ) -> dict[str, str]:
         """Return the environment passed to install/auth/run commands."""
 
+    def execution_audit_metadata(
+        self,
+        runtime: ResolvedRuntime,
+        *,
+        command: list[str],
+        working_directory: Path | None = None,
+    ) -> dict[str, Any] | None:
+        """Return structured audit metadata for sensitive command executions."""
+
 
 class NpmCliProvider:
     """Shared implementation for npm-distributed external agent CLIs."""
@@ -104,6 +113,17 @@ class NpmCliProvider:
         if environ is not None:
             merged.update(environ)
         return merged
+
+    def execution_audit_metadata(
+        self,
+        runtime: ResolvedRuntime,
+        *,
+        command: list[str],
+        working_directory: Path | None = None,
+    ) -> dict[str, Any] | None:
+        """Return audit metadata for sensitive executions, when applicable."""
+        del runtime, command, working_directory
+        return None
 
     def _authenticated_if_env_present(
         self,

--- a/src/orcheo/external_agents/providers/claude_code.py
+++ b/src/orcheo/external_agents/providers/claude_code.py
@@ -88,12 +88,11 @@ class ClaudeCodeProvider(NpmCliProvider):
         """Build a non-interactive Claude Code invocation."""
         command = [
             str(runtime.executable_path),
+            "--dangerously-skip-permissions",
             "--print",
             prompt,
             "--output-format",
             "text",
-            "--permission-mode",
-            "acceptEdits",
         ]
         if system_prompt:
             command.extend(["--append-system-prompt", system_prompt])

--- a/src/orcheo/external_agents/providers/codex.py
+++ b/src/orcheo/external_agents/providers/codex.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 from orcheo.external_agents.models import AuthProbeResult, ResolvedRuntime
 from orcheo.external_agents.providers.base import NpmCliProvider
+
+
+CODEX_CONTAINER_BYPASS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox",)
 
 
 class CodexProvider(NpmCliProvider):
@@ -90,13 +94,41 @@ class CodexProvider(NpmCliProvider):
             combined_prompt = (
                 f"System instructions:\n{system_prompt.strip()}\n\nTask:\n{prompt}"
             )
+        # These bypass flags are only for managed container workers where the
+        # container and validated worktree provide the security boundary.
         return [
             str(runtime.executable_path),
             "exec",
-            "--dangerously-bypass-approvals-and-sandbox",
+            *CODEX_CONTAINER_BYPASS_FLAGS,
             "--skip-git-repo-check",
             combined_prompt,
         ]
+
+    def execution_audit_metadata(
+        self,
+        runtime: ResolvedRuntime,
+        *,
+        command: list[str],
+        working_directory: Path | None = None,
+    ) -> dict[str, Any] | None:
+        """Return structured audit metadata when container bypass flags are used."""
+        used_bypass_flags = [
+            flag for flag in CODEX_CONTAINER_BYPASS_FLAGS if flag in command
+        ]
+        if not used_bypass_flags:
+            return None  # pragma: no cover
+        return {
+            "event": "external_agent_bypass_flags_used",
+            "provider": self.name,
+            "runtime_version": runtime.version,
+            "command_path": str(runtime.executable_path),
+            "working_directory": (
+                str(working_directory) if working_directory is not None else None
+            ),
+            "bypass_flags": used_bypass_flags,
+            "security_boundary": "container_isolation",
+            "security_boundary_detail": "validated_worktree_inside_managed_container",
+        }
 
     def render_login_instructions(self, runtime: ResolvedRuntime) -> list[str]:
         """Render manual Codex login commands for setup-needed failures."""

--- a/src/orcheo/external_agents/providers/codex.py
+++ b/src/orcheo/external_agents/providers/codex.py
@@ -93,10 +93,8 @@ class CodexProvider(NpmCliProvider):
         return [
             str(runtime.executable_path),
             "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
-            "--full-auto",
-            "--sandbox",
-            "workspace-write",
             combined_prompt,
         ]
 

--- a/src/orcheo/nodes/external_agent.py
+++ b/src/orcheo/nodes/external_agent.py
@@ -1,6 +1,7 @@
 """Shared task node for CLI-backed external coding agents."""
 
 from __future__ import annotations
+import logging
 from collections.abc import Mapping
 from typing import Any, ClassVar
 from langchain_core.runnables import RunnableConfig
@@ -18,6 +19,9 @@ from orcheo.runtime.credentials import (
     CredentialReferenceNotFoundError,
     CredentialResolverUnavailableError,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class ExternalAgentNode(TaskNode):
@@ -205,6 +209,16 @@ class ExternalAgentNode(TaskNode):
             prompt=prompt,
             system_prompt=self.system_prompt,
         )
+        audit_metadata = provider.execution_audit_metadata(
+            runtime,
+            command=command,
+            working_directory=working_directory,
+        )
+        if audit_metadata:
+            logger.info(
+                "External agent execution requested provider bypass flags.",
+                extra={"node_name": self.name, **audit_metadata},
+            )
         result = await execute_process(
             command,
             cwd=working_directory,

--- a/tests/external_agents/test_providers_base.py
+++ b/tests/external_agents/test_providers_base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from pathlib import Path
 import pytest
-from orcheo.external_agents.models import AuthStatus
+from orcheo.external_agents.models import AuthStatus, ResolvedRuntime
 from orcheo.external_agents.providers.base import NpmCliProvider
 
 
@@ -68,6 +68,26 @@ def test_build_environment_without_overrides_uses_process_environment(
     merged = provider.build_environment()
 
     assert merged["BASE_ONLY"] == "1"
+
+
+def test_execution_audit_metadata_defaults_to_none(tmp_path: Path) -> None:
+    provider = DummyProvider()
+    runtime = ResolvedRuntime(
+        provider=provider.name,
+        version="1.2.3",
+        install_dir=tmp_path,
+        executable_path=tmp_path / "bin" / "dummy-cli",
+        package_name=provider.package_name,
+    )
+
+    assert (
+        provider.execution_audit_metadata(
+            runtime=runtime,
+            command=["dummy-cli", "run"],
+            working_directory=tmp_path,
+        )
+        is None
+    )
 
 
 def test_authenticated_if_env_var_present(tmp_path: Path) -> None:

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -598,6 +598,30 @@ def test_codex_provider_builds_expected_command_without_system_prompt() -> None:
     assert command[-1] == "fix tests"
 
 
+def test_codex_provider_reports_bypass_flag_audit_metadata() -> None:
+    provider = CodexProvider()
+    runtime = ResolvedRuntime(
+        provider="codex",
+        version="0.0.1",
+        install_dir=Path("/tmp/codex"),
+        executable_path=Path("/tmp/codex/bin/codex"),
+        package_name=provider.package_name,
+    )
+
+    command = provider.build_command(runtime, prompt="fix tests")
+    metadata = provider.execution_audit_metadata(
+        runtime,
+        command=command,
+        working_directory=Path("/tmp/worktree"),
+    )
+
+    assert metadata is not None
+    assert metadata["event"] == "external_agent_bypass_flags_used"
+    assert metadata["provider"] == "codex"
+    assert metadata["bypass_flags"] == ["--dangerously-bypass-approvals-and-sandbox"]
+    assert metadata["security_boundary"] == "container_isolation"
+
+
 def test_codex_provider_renders_login_instructions() -> None:
     provider = CodexProvider()
     runtime = ResolvedRuntime(

--- a/tests/external_agents/test_runtime.py
+++ b/tests/external_agents/test_runtime.py
@@ -558,7 +558,7 @@ async def test_runtime_manager_failed_maintenance_keeps_current_runtime(
 
 
 def test_codex_provider_builds_expected_command() -> None:
-    """Codex provider builds a non-interactive full-auto invocation."""
+    """Codex provider bypasses approvals and sandbox for unattended runs."""
     provider = CodexProvider()
     runtime = ResolvedRuntime(
         provider="codex",
@@ -574,13 +574,11 @@ def test_codex_provider_builds_expected_command() -> None:
         system_prompt="be minimal",
     )
 
-    assert command[:6] == [
+    assert command[:4] == [
         "/tmp/codex/bin/codex",
         "exec",
+        "--dangerously-bypass-approvals-and-sandbox",
         "--skip-git-repo-check",
-        "--full-auto",
-        "--sandbox",
-        "workspace-write",
     ]
     assert "System instructions:" in command[-1]
 
@@ -689,7 +687,7 @@ def test_claude_provider_uses_setup_token_login() -> None:
 
 
 def test_claude_provider_builds_expected_command() -> None:
-    """Claude provider uses print mode with appended system instructions."""
+    """Claude provider skips permission prompts for unattended runs."""
     provider = ClaudeCodeProvider()
     runtime = ResolvedRuntime(
         provider="claude_code",
@@ -707,11 +705,11 @@ def test_claude_provider_builds_expected_command() -> None:
 
     assert command[:6] == [
         "/tmp/claude/bin/claude",
+        "--dangerously-skip-permissions",
         "--print",
         "review",
         "--output-format",
         "text",
-        "--permission-mode",
     ]
     assert "--append-system-prompt" in command
 

--- a/tests/nodes/test_external_agent_node.py
+++ b/tests/nodes/test_external_agent_node.py
@@ -1,6 +1,7 @@
 """Unit tests for the external agent node implementation."""
 
 from __future__ import annotations
+import logging
 from pathlib import Path
 from typing import Any
 import pytest
@@ -28,6 +29,7 @@ class DummyProvider:
 
     def __init__(self, *, authenticated: bool = True) -> None:
         self.authenticated = authenticated
+        self.audit_metadata: dict[str, Any] | None = None
 
     def probe_auth(
         self,
@@ -62,6 +64,16 @@ class DummyProvider:
         environ: dict[str, str] | None = None,
     ) -> dict[str, str]:
         return dict(environ or {})
+
+    def execution_audit_metadata(
+        self,
+        runtime: ResolvedRuntime,
+        *,
+        command: list[str],
+        working_directory: Path | None = None,
+    ) -> dict[str, Any] | None:
+        del runtime, command, working_directory
+        return self.audit_metadata
 
 
 class FakeRuntimeManager:
@@ -470,3 +482,51 @@ async def test_run_succeeds_with_zero_exit(
 
     assert result["status"] == "succeeded"
     assert result["stdout"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_logs_bypass_flag_audit_event(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    resolution = _make_runtime_resolution(tmp_path)
+    provider = DummyProvider()
+    provider.audit_metadata = {
+        "event": "external_agent_bypass_flags_used",
+        "provider": "dummy_agent",
+        "bypass_flags": ["--dangerous"],
+        "security_boundary": "container_isolation",
+    }
+    manager = FakeRuntimeManager(provider=provider, resolution=resolution)
+    node = _make_node(manager)
+    state = _make_state({"prompt": "run"})
+
+    async def fake_execute(*args: object, **kwargs: object) -> ProcessExecutionResult:
+        return ProcessExecutionResult(
+            command=["dummy"],
+            stdout="ok",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            duration_seconds=0,
+        )
+
+    monkeypatch.setattr(
+        "orcheo.nodes.external_agent.execute_process",
+        fake_execute,
+    )
+
+    with caplog.at_level(logging.INFO, logger="orcheo.nodes.external_agent"):
+        await node.run(state, RunnableConfig())
+
+    record = next(
+        r
+        for r in caplog.records
+        if r.message == "External agent execution requested provider bypass flags."
+    )
+    assert record.event == "external_agent_bypass_flags_used"
+    assert record.provider == "dummy_agent"
+    assert record.bypass_flags == ["--dangerous"]
+    assert record.security_boundary == "container_isolation"
+    assert record.node_name == "test-node"


### PR DESCRIPTION
## Summary

This PR updates the external agent provider command construction to use the current unattended-execution flags for both Codex and Claude Code.

## Changes

- Update the Codex provider invocation to use `--dangerously-bypass-approvals-and-sandbox`
- Remove the older Codex `--full-auto` and `--sandbox workspace-write` arguments
- Update the Claude Code provider invocation to use `--dangerously-skip-permissions`
- Remove the older Claude `--permission-mode acceptEdits` arguments
- Refresh runtime tests to assert the new command layouts and descriptions

## Why

The branch changes the actual CLI arguments used for non-interactive external agent runs, so the providers match the newer permission/approval bypass behavior expected for unattended execution.

## Testing

- Updated `tests/external_agents/test_runtime.py` to validate the new Codex and Claude command construction
