### PR TITLE
Run Orcheo containers as a non-root user for external agent runtimes

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     git \
+    gosu \
     nodejs \
     npm \
     && rm -rf /var/lib/apt/lists/*
@@ -15,6 +16,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
     && chmod +x /usr/local/bin/uvx
+RUN groupadd --gid 1000 orcheo \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+COPY deploy/stack/orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
+RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
 # Copy dependency files first for better caching
 COPY pyproject.toml uv.lock README.md ./
@@ -29,6 +34,7 @@ COPY src/ src/
 
 # Set Python path
 ENV PYTHONPATH=/app/src:/app/apps/backend/src
+ENTRYPOINT ["orcheo-entrypoint"]
 
 # Default command (can be overridden in docker-compose)
 CMD ["uv", "run", "uvicorn", "orcheo_backend.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/stack/Dockerfile.orcheo
+++ b/deploy/stack/Dockerfile.orcheo
@@ -9,6 +9,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
+    gosu \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs=20.* \
     && apt-get clean \
@@ -17,6 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN printf '%s\n' '#!/bin/sh' 'exec uv tool run "$@"' > /usr/local/bin/uvx \
     && chmod +x /usr/local/bin/uvx
+RUN groupadd --gid 1000 orcheo \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/sh orcheo
+COPY orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
+RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
 # Always build with --no-cache to ensure latest packages are installed
 RUN uv pip install --system --no-cache -U orcheo orcheo-backend orcheo-sdk
+ENTRYPOINT ["orcheo-entrypoint"]

--- a/deploy/stack/docker-compose.yml
+++ b/deploy/stack/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER}:${ORCHEO_POSTGRES_PASSWORD}@postgres:5432/${ORCHEO_POSTGRES_DB}
       ORCHEO_GRAPH_STORE_BACKEND: postgres
@@ -81,6 +83,8 @@ services:
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER}:${ORCHEO_POSTGRES_PASSWORD}@postgres:5432/${ORCHEO_POSTGRES_DB}
       ORCHEO_GRAPH_STORE_BACKEND: postgres
@@ -117,6 +121,8 @@ services:
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER}:${ORCHEO_POSTGRES_PASSWORD}@postgres:5432/${ORCHEO_POSTGRES_DB}
       ORCHEO_GRAPH_STORE_BACKEND: postgres

--- a/deploy/stack/orcheo-entrypoint.sh
+++ b/deploy/stack/orcheo-entrypoint.sh
@@ -21,25 +21,30 @@ uv_cache_dir="${UV_CACHE_DIR:-/data/cache/uv}"
 
 ensure_dir() {
   dir_path="$1"
+  recursive="${2:-false}"
   if [ -z "$dir_path" ]; then
     return
   fi
   mkdir -p "$dir_path"
-  chown "$runtime_user:$runtime_group" "$dir_path"
+  if [ "$recursive" = "true" ]; then
+    chown -R "$runtime_user:$runtime_group" "$dir_path"
+  else
+    chown "$runtime_user:$runtime_group" "$dir_path"
+  fi
 }
 
 if [ "$(id -u)" -eq 0 ]; then
   ensure_dir /data
-  ensure_dir "$HOME"
-  ensure_dir "$codex_home"
-  ensure_dir "$claude_home"
-  ensure_dir "$runtime_root"
-  ensure_dir "$cache_dir"
-  ensure_dir "$plugin_dir"
-  ensure_dir "$uv_cache_dir"
+  ensure_dir "$HOME" true
+  ensure_dir "$codex_home" true
+  ensure_dir "$claude_home" true
+  ensure_dir "$runtime_root" true
+  ensure_dir "$cache_dir" true
+  ensure_dir "$plugin_dir" true
+  ensure_dir "$uv_cache_dir" true
 
   if [ -d /app/.venv ] || [ ! -e /app/.venv ]; then
-    ensure_dir /app/.venv
+    ensure_dir /app/.venv true
   fi
 
   exec gosu "$runtime_user:$runtime_group" "$@"

--- a/deploy/stack/orcheo-entrypoint.sh
+++ b/deploy/stack/orcheo-entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+runtime_user="${ORCHEO_RUNTIME_USER:-orcheo}"
+runtime_group="${ORCHEO_RUNTIME_GROUP:-orcheo}"
+home_dir="${ORCHEO_RUNTIME_HOME:-${HOME:-/data/home}}"
+
+if [ "$home_dir" = "/root" ]; then
+  home_dir="/data/home"
+fi
+
+export HOME="$home_dir"
+
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+claude_home="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+runtime_root="/data/agent-runtimes"
+cache_dir="${ORCHEO_CACHE_DIR:-/data/cache/orcheo}"
+plugin_dir="${ORCHEO_PLUGIN_DIR:-/data/plugins}"
+uv_cache_dir="${UV_CACHE_DIR:-/data/cache/uv}"
+
+ensure_dir() {
+  dir_path="$1"
+  if [ -z "$dir_path" ]; then
+    return
+  fi
+  mkdir -p "$dir_path"
+  chown "$runtime_user:$runtime_group" "$dir_path"
+}
+
+if [ "$(id -u)" -eq 0 ]; then
+  ensure_dir /data
+  ensure_dir "$HOME"
+  ensure_dir "$codex_home"
+  ensure_dir "$claude_home"
+  ensure_dir "$runtime_root"
+  ensure_dir "$cache_dir"
+  ensure_dir "$plugin_dir"
+  ensure_dir "$uv_cache_dir"
+
+  if [ -d /app/.venv ] || [ ! -e /app/.venv ]; then
+    ensure_dir /app/.venv
+  fi
+
+  exec gosu "$runtime_user:$runtime_group" "$@"
+fi
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,12 @@ services:
       - .:/app
       - orcheo_data:/data
       - backend_venv:/app/.venv
-      - uv_cache:/root/.cache/uv
+      - uv_cache:/data/cache/uv
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER:-orcheo}:${ORCHEO_POSTGRES_PASSWORD:-orcheo}@postgres:5432/${ORCHEO_POSTGRES_DB:-orcheo}
       ORCHEO_GRAPH_STORE_BACKEND: postgres
@@ -63,8 +65,8 @@ services:
       ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN: ${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       ORCHEO_CHATKIT_PUBLIC_BASE_URL: ${ORCHEO_CHATKIT_PUBLIC_BASE_URL:-https://orcheo-canvas.ai-colleagues.com}
       ORCHEO_CORS_ALLOW_ORIGINS: ${ORCHEO_CORS_ALLOW_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,https://orcheo-canvas.ai-colleagues.com,https://ai-colleagues.com,https://www.ai-colleagues.com}
-      ORCHEO_PLUGIN_DIR: /app/.orcheo/plugins
-      ORCHEO_CACHE_DIR: /app/.cache/orcheo
+      ORCHEO_PLUGIN_DIR: /data/plugins
+      ORCHEO_CACHE_DIR: /data/cache/orcheo
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
@@ -86,10 +88,12 @@ services:
       - .:/workspace/agents
       - orcheo_data:/data
       - worker_venv:/app/.venv
-      - uv_cache:/root/.cache/uv
+      - uv_cache:/data/cache/uv
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER:-orcheo}:${ORCHEO_POSTGRES_PASSWORD:-orcheo}@postgres:5432/${ORCHEO_POSTGRES_DB:-orcheo}
       ORCHEO_GRAPH_STORE_BACKEND: postgres
@@ -105,8 +109,8 @@ services:
       ORCHEO_AUTH_ISSUER: ${ORCHEO_AUTH_ISSUER:-}
       ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN: ${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       ORCHEO_CHATKIT_PUBLIC_BASE_URL: ${ORCHEO_CHATKIT_PUBLIC_BASE_URL:-https://orcheo-canvas.ai-colleagues.com}
-      ORCHEO_PLUGIN_DIR: /app/.orcheo/plugins
-      ORCHEO_CACHE_DIR: /app/.cache/orcheo
+      ORCHEO_PLUGIN_DIR: /data/plugins
+      ORCHEO_CACHE_DIR: /data/cache/orcheo
       ORCHEO_BACKEND_INTERNAL_URL: http://backend:8000
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
@@ -128,10 +132,12 @@ services:
       - .:/app
       - orcheo_data:/data
       - celery_venv:/app/.venv
-      - uv_cache:/root/.cache/uv
+      - uv_cache:/data/cache/uv
     environment:
       HOME: /data/home
       CODEX_HOME: /data/home/.codex
+      CLAUDE_CONFIG_DIR: /data/home/.claude
+      UV_CACHE_DIR: /data/cache/uv
       REDIS_URL: redis://redis:6379/0
       ORCHEO_POSTGRES_DSN: postgresql://${ORCHEO_POSTGRES_USER:-orcheo}:${ORCHEO_POSTGRES_PASSWORD:-orcheo}@postgres:5432/${ORCHEO_POSTGRES_DB:-orcheo}
       ORCHEO_GRAPH_STORE_BACKEND: postgres
@@ -147,8 +153,8 @@ services:
       ORCHEO_AUTH_ISSUER: ${ORCHEO_AUTH_ISSUER:-}
       ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN: ${ORCHEO_AUTH_BOOTSTRAP_SERVICE_TOKEN:-}
       ORCHEO_CHATKIT_PUBLIC_BASE_URL: ${ORCHEO_CHATKIT_PUBLIC_BASE_URL:-https://orcheo-canvas.ai-colleagues.com}
-      ORCHEO_PLUGIN_DIR: /app/.orcheo/plugins
-      ORCHEO_CACHE_DIR: /app/.cache/orcheo
+      ORCHEO_PLUGIN_DIR: /data/plugins
+      ORCHEO_CACHE_DIR: /data/cache/orcheo
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr

--- a/docs/external_agent_nodes.md
+++ b/docs/external_agent_nodes.md
@@ -10,6 +10,8 @@ host can safely run external coding-agent CLIs inside validated Git worktrees.
 - Worker-managed installs only; Orcheo does not install these CLIs into global
   system paths.
 - Manual provider login is still required on the worker host.
+- Claude Code unattended runs require the worker process to run as a non-root
+  user. Anthropic blocks `--dangerously-skip-permissions` under `root`/`sudo`.
 - V1 does not add new Orcheo environment variables for runtime roots,
   maintenance cadence, or provider selection.
 
@@ -22,6 +24,8 @@ Orcheo manages provider runtimes under a persistent root with strong defaults:
 - In Docker deployments, keep the worker `HOME` on persistent storage so
   provider login state such as `~/.claude*` and `$CODEX_HOME/auth.json`
   survives container restarts.
+- In Docker deployments, run backend and worker processes as a non-root user and
+  make the mounted workspace writable by that container user.
 - Install the latest published provider CLI into a versioned provider-owned
   prefix.
 - Keep one current runtime and one previous known-good runtime for rollback and
@@ -52,7 +56,7 @@ codex login
 ### Claude Code
 
 - Package: `@anthropic-ai/claude-code`
-- Runtime command: `claude --print ... --permission-mode acceptEdits`
+- Runtime command: `claude --dangerously-skip-permissions --print ...`
 - Manual login:
 
 ```bash


### PR DESCRIPTION
## Summary

This PR updates the Docker runtime setup so Orcheo backend and worker containers can execute external coding-agent CLIs in a supported, persistent, non-root environment.

## Changes

- add a shared container entrypoint that:
  - ensures runtime directories exist under `/data`
  - sets ownership for home, cache, plugin, and agent runtime paths
  - drops from `root` to the `orcheo` user via `gosu`
- update backend and stack Dockerfiles to:
  - install `gosu`
  - create the `orcheo` user/group
  - use the new entrypoint by default
- update local and stack `docker-compose` configs to:
  - move UV cache, plugin, and Orcheo cache directories onto persistent `/data` mounts
  - define `CLAUDE_CONFIG_DIR` and `UV_CACHE_DIR`
  - keep Codex/Claude login state and runtime artifacts outside ephemeral container home directories
- refresh external agent node docs to document:
  - the requirement to run Claude Code unattended flows as a non-root user
  - Docker guidance for persistent writable home directories
  - the updated Claude runtime command using `--dangerously-skip-permissions`

## Why

Claude Code blocks unattended permission skipping under `root`/`sudo`. These changes make the containerized Orcheo runtime compatible with that requirement while preserving agent state and caches across restarts.
