### PR TITLE
Persist Celery Beat schedule data and safely initialize agent workspaces

### DIFF
--- a/deploy/stack/orcheo-entrypoint.sh
+++ b/deploy/stack/orcheo-entrypoint.sh
@@ -18,6 +18,7 @@ runtime_root="/data/agent-runtimes"
 cache_dir="${ORCHEO_CACHE_DIR:-/data/cache/orcheo}"
 plugin_dir="${ORCHEO_PLUGIN_DIR:-/data/plugins}"
 uv_cache_dir="${UV_CACHE_DIR:-/data/cache/uv}"
+workspace_root="/workspace/agents"
 
 ensure_dir() {
   dir_path="$1"
@@ -33,6 +34,15 @@ ensure_dir() {
   fi
 }
 
+same_path_target() {
+  left="$1"
+  right="$2"
+  if [ ! -e "$left" ] || [ ! -e "$right" ]; then
+    return 1
+  fi
+  [ "$(stat -c '%d:%i' "$left")" = "$(stat -c '%d:%i' "$right")" ]
+}
+
 if [ "$(id -u)" -eq 0 ]; then
   ensure_dir /data
   ensure_dir "$HOME" true
@@ -42,6 +52,13 @@ if [ "$(id -u)" -eq 0 ]; then
   ensure_dir "$cache_dir" true
   ensure_dir "$plugin_dir" true
   ensure_dir "$uv_cache_dir" true
+  ensure_dir /workspace
+
+  if [ ! -e "$workspace_root" ]; then
+    ensure_dir "$workspace_root" true
+  elif ! same_path_target "$workspace_root" /app; then
+    ensure_dir "$workspace_root" true
+  fi
 
   if [ -d /app/.venv ] || [ ! -e /app/.venv ]; then
     ensure_dir /app/.venv true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       # Use system Python from base image instead of downloading
       UV_PYTHON_PREFERENCE: system
       ORCHEO_MCP_STDIO_LOG: /dev/stderr
-      CELERY_BEAT_SCHEDULE_FILE: /app/.orcheo/celerybeat-schedule
+      CELERY_BEAT_SCHEDULE_FILE: /data/celerybeat-schedule
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

This PR updates the deployment setup to make runtime state more durable and container workspace initialization safer.

## Changes

- Move the Celery Beat schedule file from `/app/.orcheo/celerybeat-schedule` to `/data/celerybeat-schedule` so scheduler state lives in persistent storage instead of the app mount.
- Update the stack entrypoint to provision `/workspace` and `/workspace/agents` during container startup.
- Add a path-target check before creating `/workspace/agents` so the entrypoint does not unnecessarily recreate or overwrite it when it already points at `/app`.

## Impact

- Celery Beat schedules survive container/app directory resets more reliably.
- Agent workspace setup is more robust in environments where `/workspace/agents` may already exist or be mapped to the application directory.

## Testing

- Not run (not requested).
