### PR TITLE
backend: ignore unsupported ANSI escape sequences in external agent login

### DIFF
--- a/apps/backend/src/orcheo_backend/worker/external_agents.py
+++ b/apps/backend/src/orcheo_backend/worker/external_agents.py
@@ -167,6 +167,12 @@ def _set_pty_size(
 
 def _create_terminal_emulator() -> Any:
     """Return a VT100 screen emulator for capturing visible login output."""
+
+    def _safe_do_log(fsm: Any) -> None:
+        """Discard unsupported escape sequences without writing a local log file."""
+        screen = fsm.memory[0]
+        fsm.memory = [screen]
+
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -175,6 +181,9 @@ def _create_terminal_emulator() -> Any:
         )
         from pexpect import ANSI
 
+    # pexpect.ANSI wires its fallback handler to DoLog, which tries to append to
+    # a literal "./log" file when it sees an unsupported escape sequence.
+    ANSI.DoLog = _safe_do_log
     return ANSI.ANSI(LOGIN_PTY_ROWS, LOGIN_PTY_COLS, encoding="utf-8")
 
 

--- a/tests/backend/worker/test_external_agents.py
+++ b/tests/backend/worker/test_external_agents.py
@@ -227,6 +227,39 @@ def test_run_login_command_uses_visible_terminal_screen_for_rewritten_token() ->
     assert "[redacted worker auth token]" in result.output
 
 
+def test_run_login_command_ignores_unsupported_escape_sequences(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unsupported ANSI escapes should not try to write a local ./log file."""
+    from orcheo_backend.worker.external_agents import _run_login_command
+
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir()
+    readonly_dir.chmod(0o555)
+    monkeypatch.chdir(readonly_dir)
+
+    result = _run_login_command(
+        [
+            "python3",
+            "-c",
+            (
+                "import sys; "
+                "sys.stdout.write('\\x1bc'); "
+                "sys.stdout.write('Opening browser to sign in...\\n'); "
+                "sys.stdout.flush()"
+            ),
+        ],
+        env={},
+        on_output=lambda _output, _auth_url, _device_code: None,
+        timeout_seconds=10,
+    )
+
+    assert result.exit_code == 0
+    assert result.timed_out is False
+    assert "Opening browser to sign in..." in result.output
+    assert not (readonly_dir / "log").exists()
+
+
 def test_extract_visible_auth_token_rejects_masked_claude_token_block() -> None:
     """Rendered screen output should not mint fake tokens from masked lines."""
     from orcheo_backend.worker.external_agents import _extract_visible_auth_token


### PR DESCRIPTION
## Summary
- prevent the external agent login terminal emulator from trying to write a local `./log` file when `pexpect.ANSI` encounters unsupported escape sequences
- replace `ANSI.DoLog` with a safe in-memory fallback so login output can still be captured without filesystem writes
- add a regression test covering unsupported escape sequences in a read-only working directory

## Problem
Some login flows emit unsupported ANSI sequences such as `\x1bc`. In the current implementation, `pexpect.ANSI` routes those through `DoLog`, which attempts to append to a literal `./log` file. That can fail unexpectedly depending on the current working directory permissions.

## Changes
- override `ANSI.DoLog` in the terminal emulator setup with a handler that discards unsupported escape sequences without writing a file
- preserve the visible screen buffer so normal login output capture still works
- add test coverage to verify login output succeeds and no `log` file is created

## Testing
- not run; summary based on staged changes only
