### PR TITLE
Bust Docker image build cache for stack image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,8 @@ jobs:
           file: deploy/stack/Dockerfile.orcheo
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
           tags: |
             ${{ needs.stack-image-metadata.outputs.stack_repo }}:${{ needs.stack-image-metadata.outputs.version }}
             ${{ needs.stack-image-metadata.outputs.stack_repo }}:latest
@@ -277,6 +279,8 @@ jobs:
           file: deploy/stack/Dockerfile.canvas
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
           tags: |
             ${{ needs.stack-image-metadata.outputs.canvas_repo }}:${{ needs.stack-image-metadata.outputs.version }}
             ${{ needs.stack-image-metadata.outputs.canvas_repo }}:latest

--- a/deploy/stack/Dockerfile.canvas
+++ b/deploy/stack/Dockerfile.canvas
@@ -3,7 +3,8 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
-# Install orcheo-canvas from npm
+# Bust Docker layer cache to ensure latest package is installed
+ARG CACHEBUST
 RUN npm init -y \
     && npm install --silent orcheo-canvas@latest
 

--- a/deploy/stack/Dockerfile.orcheo
+++ b/deploy/stack/Dockerfile.orcheo
@@ -23,6 +23,7 @@ RUN groupadd --gid 1000 orcheo \
 COPY orcheo-entrypoint.sh /usr/local/bin/orcheo-entrypoint
 RUN chmod +x /usr/local/bin/orcheo-entrypoint
 
-# Always build with --no-cache to ensure latest packages are installed
+# Bust Docker layer cache to ensure latest packages are installed
+ARG CACHEBUST
 RUN uv pip install --system --no-cache -U orcheo orcheo-backend orcheo-sdk
 ENTRYPOINT ["orcheo-entrypoint"]


### PR DESCRIPTION
## Summary

This PR updates the stack image build flow so published Docker images reliably pick up the latest `orcheo`, `orcheo-backend`, `orcheo-sdk`, and `orcheo-canvas` packages instead of reusing stale cached layers.

## Main changes

- Add a `CACHEBUST` build argument to the stack image builds in [`.github/workflows/ci.yml`](/Users/shaojiejiang/Development/orcheo/.github/workflows/ci.yml)
- Pass `CACHEBUST=${{ github.run_id }}` when building both the Orcheo and Canvas images in CI
- Add `ARG CACHEBUST` to [`deploy/stack/Dockerfile.orcheo`](/Users/shaojiejiang/Development/orcheo/deploy/stack/Dockerfile.orcheo) so the package installation layer is invalidated on each CI run
- Add `ARG CACHEBUST` to [`deploy/stack/Dockerfile.canvas`](/Users/shaojiejiang/Development/orcheo/deploy/stack/Dockerfile.canvas) so the `orcheo-canvas@latest` install layer is also invalidated

## Why

Both stack Dockerfiles install packages from registries using "latest" style dependencies. Without explicitly invalidating those layers, CI can publish images that were rebuilt from cache but still contain older package versions.

## Expected impact

- Fresh package installs during CI image publishing
- Reduced risk of shipping outdated backend or canvas packages in stack images
- No functional runtime changes beyond ensuring newer published packages are actually included
